### PR TITLE
add podman option for image build and oc for apply

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           config: ./ci/config.yaml
 
       - name: Build and Deploy operator container
-        run: make docker-build docker-push deploy
+        run: make image-build image-push deploy
 
       - name: deploy router crd
         run: kubectl apply -f hack/router-crd.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY client/ client/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# was called. For example, if we call make image-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Allows for running with podman or docker
+CTR_CMD :=$(or $(shell which podman 2>/dev/null), $(shell which docker 2>/dev/null))
+KS_CMD :=$(or $(shell which oc 2>/dev/null), $(shell which kubectl 2>/dev/null))
+
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
@@ -119,16 +123,21 @@ build: manifests generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-# If you wish built the manager image targeting other platforms you can use the --platform flag.
-# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
-# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-.PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build . -t ${IMG}
+.PHONY: image-build
+image-build: test ## Build container image with the manager.
+	${CTR_CMD} build . -t ${IMG}
 
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+# OpenShift nodes are often linux/amd64 architecture. If running on MacOS it is likely linux/arm64.
+# If you wish to build the manager for OpenShift linux/amd64 nodes but are building from MacOS,
+# you can use the --platform flag. (i.e. ${CTR_CMD} build --platform linux/amd64 ).
+PLATFORM ?= linux/amd64
+.PHONY: image-build-amd64
+image-build-amd64: test ## Build container image with the manager.
+	${CTR_CMD} build --platform=${PLATFORM} . -t ${IMG}
+
+.PHONY: image-push
+image-push: ## Push container image with the manager.
+	${CTR_CMD} push ${IMG}
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
@@ -155,20 +164,20 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | ${KS_CMD} apply -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/crd | ${KS_CMD} delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | ${KS_CMD} apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/default | ${KS_CMD} delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Build Dependencies
 
@@ -233,11 +242,11 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	${CTR_CMD} build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
+	$(MAKE) image-push IMG=$(BUNDLE_IMG)
 
 .PHONY: opm
 OPM = ./bin/opm
@@ -273,9 +282,9 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool ${CTR_CMD} --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
-	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+	$(MAKE) image-push IMG=$(CATALOG_IMG)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ kubectl apply -f config/samples/
 2. Build and push your image to the location specified by `IMG`:
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/operator:tag
+make image-build image-push IMG=<some-registry>/operator:tag
 ```
 
 3. Deploy the controller to the cluster with the image specified by `IMG`:

--- a/hack/up.sh
+++ b/hack/up.sh
@@ -1,6 +1,6 @@
 kind delete cluster
 
-make docker-build && make docker-push 
+make image-build && make image-push
 
 # spin up kind cluster
 cat <<EOF | kind create cluster --image kindest/node:v1.28.0 --config=-


### PR DESCRIPTION
- Makefile: Add option to use `podman` or `docker` (CTR_CMD)
- Makefile: Add option to use `oc` or `kubectl` (KS_CMD)
- `make docker-build` -> `make image-build`
- `make docker-push` -> `make image-push` 
- Add target for `make image-build-amd64` -> convenience for those devs working on MacOS who are testing in OCP (I'm open to leaving this out of this PR if others don't think it's useful enough) 

/cc @bouskaJ 
/cc @cooktheryan 