### PR TITLE
add podman option for image build and oc for apply

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           config: ./ci/config.yaml
 
       - name: Build and Deploy operator container
-        run: make docker-build docker-push deploy
+        run: make image-build image-push deploy
 
       - name: deploy router crd
         run: kubectl apply -f hack/router-crd.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           config: ./ci/config.yaml
 
       - name: Build and Deploy operator container
-        run: make image-build image-push deploy
+        run: make CTR_CMD=docker image-build image-push deploy
 
       - name: deploy router crd
         run: kubectl apply -f hack/router-crd.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY client/ client/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# was called. For example, if we call make image-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager main.go

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ kubectl apply -f config/samples/
 2. Build and push your image to the location specified by `IMG`:
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/operator:tag
+make image-build image-push IMG=<some-registry>/operator:tag
 ```
 
 3. Deploy the controller to the cluster with the image specified by `IMG`:

--- a/hack/up.sh
+++ b/hack/up.sh
@@ -1,6 +1,6 @@
 kind delete cluster
 
-make docker-build && make docker-push 
+make image-build && make image-push
 
 # spin up kind cluster
 cat <<EOF | kind create cluster --image kindest/node:v1.28.0 --config=-


### PR DESCRIPTION
- Makefile: Add option to use `podman` or `docker` (CTR_CMD)
- Makefile: Add option to use `oc` or `kubectl` (KS_CMD)
- `make docker-build` -> `make image-build`
- `make docker-push` -> `make image-push` 
- Add target for `make image-build-platform` -> convenience for those devs working on MacOS who are testing in OCP - this defaults to `PLATFORM=linux/amd64` (I'm open to leaving this out of this PR if others don't think it's useful enough) 

/cc @bouskaJ 
/cc @cooktheryan 