### PR TITLE
ingress change due to ocp cert issue

### DIFF
--- a/controllers/common/utils/kubernetes/ingress.go
+++ b/controllers/common/utils/kubernetes/ingress.go
@@ -33,7 +33,7 @@ func CreateIngress(ctx context.Context, cli client.Client, svc v12.Service, conf
 			if err := cli.Get(ctx, types.NamespacedName{Namespace: "openshift-ingress-operator", Name: "default"}, ctrl); err != nil {
 				return nil, err
 			}
-			host = fmt.Sprintf("%s.%s.%s", svc.Name, svc.Namespace, ctrl.Status.Domain)
+			host = fmt.Sprintf("%s-%s.%s", svc.Name, svc.Namespace, ctrl.Status.Domain)
 		} else {
 			host = svc.Name + ".local"
 		}


### PR DESCRIPTION
Problem was occurring where certificate was valid for *.apps but would have issues with namespace.*.apps with the certificate not being valid


Successful initialization

```
cosign initialize --mirror=https://tuf-test.apps.rosa.t6yip-us2iv-48p.6hh1.p3.openshiftapps.com --root=https://tuf-test.apps.rosa.t6yip-us2iv-48p.6hh1.p3.openshiftapps.com/root.json
Root status:
 {
	"local": "/home/rcook/.sigstore/root",
	"remote": "https://tuf-test.apps.rosa.t6yip-us2iv-48p.6hh1.p3.openshiftapps.com",
	"metadata": {
		"root.json": {
			"version": 1,
			"len": 2178,
			"expiration": "30 Jul 24 19:12 UTC",
			"error": ""
		},
		"snapshot.json": {
			"version": 1,
			"len": 618,
			"expiration": "30 Jul 24 19:12 UTC",
			"error": ""
		},
		"targets.json": {
			"version": 1,
			"len": 1372,
			"expiration": "30 Jul 24 19:12 UTC",
			"error": ""
		},
		"timestamp.json": {
			"version": 1,
			"len": 619,
			"expiration": "30 Jul 24 19:12 UTC",
			"error": ""
		}
	},
	"targets": [
		"fulcio_v1.crt.pem",
		"rekor.pub",
		"ctfe.pub"
	]
}
``` 