### PR TITLE
Db configuration

### DIFF
--- a/api/v1alpha1/rekor_types.go
+++ b/api/v1alpha1/rekor_types.go
@@ -21,6 +21,10 @@ type RekorSpec struct {
 	RekorSearchUI RekorSearchUI `json:"rekorSearchUI,omitempty"`
 	// Signer configuration
 	Signer RekorSigner `json:"signer,omitempty"`
+	// Retain the PVC after Rekor is deleted
+	RetainPVC bool `json:"retainPVC,omitempty"`
+	// Rekor PVC Size in MB or GB. Example: 5Gi
+	PvcSize string `json:"pvcSize,omitempty"`
 }
 
 type RekorSigner struct {

--- a/api/v1alpha1/trillian_types.go
+++ b/api/v1alpha1/trillian_types.go
@@ -35,6 +35,10 @@ type TrillianDB struct {
 	PvcName string `json:"pvcName,omitempty"`
 	// Secret with values to be used to connect to an existing DB or to be used with the creation of a new DB
 	DatabaseSecretRef *v1.LocalObjectReference `json:"databaseSecretRef,omitempty"`
+	// Retain the PVC after Trillian is deleted
+	RetainPVC bool `json:"retainPVC,omitempty"`
+	// Database PVC Size in MB or GB. Example: 5Gi
+	PvcSize string `json:"pvcSize,omitempty"`
 }
 
 // TrillianStatus defines the observed state of Trillian

--- a/config/crd/bases/rhtas.redhat.com_rekors.yaml
+++ b/config/crd/bases/rhtas.redhat.com_rekors.yaml
@@ -62,6 +62,9 @@ spec:
               pvcName:
                 description: Persistent volume claim name to bound with Rekor component
                 type: string
+              pvcSize:
+                description: 'Rekor PVC Size in MB or GB. Example: 5Gi'
+                type: string
               rekorSearchUI:
                 description: Rekor Search UI
                 properties:
@@ -69,6 +72,9 @@ spec:
                     description: Enable RekorSearchUI deployment
                     type: boolean
                 type: object
+              retainPVC:
+                description: Retain the PVC after Rekor is deleted
+                type: boolean
               signer:
                 description: Signer configuration
                 properties:

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -292,6 +292,9 @@ spec:
                     description: Persistent volume claim name to bound with Rekor
                       component
                     type: string
+                  pvcSize:
+                    description: 'Rekor PVC Size in MB or GB. Example: 5Gi'
+                    type: string
                   rekorSearchUI:
                     description: Rekor Search UI
                     properties:
@@ -299,6 +302,9 @@ spec:
                         description: Enable RekorSearchUI deployment
                         type: boolean
                     type: object
+                  retainPVC:
+                    description: Retain the PVC after Rekor is deleted
+                    type: boolean
                   signer:
                     description: Signer configuration
                     properties:
@@ -368,6 +374,12 @@ spec:
                         description: Persistent volume claim name to bound with Trillian
                           DB
                         type: string
+                      pvcSize:
+                        description: 'Database PVC Size in MB or GB. Example: 5Gi'
+                        type: string
+                      retainPVC:
+                        description: Retain the PVC after Trillian is deleted
+                        type: boolean
                     type: object
                 type: object
               tuf:

--- a/config/crd/bases/rhtas.redhat.com_trillians.yaml
+++ b/config/crd/bases/rhtas.redhat.com_trillians.yaml
@@ -65,6 +65,12 @@ spec:
                     description: Persistent volume claim name to bound with Trillian
                       DB
                     type: string
+                  pvcSize:
+                    description: 'Database PVC Size in MB or GB. Example: 5Gi'
+                    type: string
+                  retainPVC:
+                    description: Retain the PVC after Trillian is deleted
+                    type: boolean
                 type: object
             type: object
           status:

--- a/controllers/rekor/create.go
+++ b/controllers/rekor/create.go
@@ -81,7 +81,7 @@ func (i createAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 				instance.Spec.PvcSize = "5Gi"
 			}
 			pvc := k8sutils.CreatePVC(instance.Namespace, "rekor-server", instance.Spec.PvcSize)
-			if instance.Spec.RetainPVC != false {
+			if instance.Spec.RetainPVC == false {
 				controllerutil.SetControllerReference(instance, pvc, i.Client.Scheme())
 			}
 			if err := i.Client.Create(ctx, pvc); err != nil {

--- a/controllers/rekor/create.go
+++ b/controllers/rekor/create.go
@@ -81,7 +81,7 @@ func (i createAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 				instance.Spec.PvcSize = "5Gi"
 			}
 			pvc := k8sutils.CreatePVC(instance.Namespace, "rekor-server", instance.Spec.PvcSize)
-			if !instance.Spec.RetainPVC {
+			if instance.Spec.RetainPVC != false {
 				controllerutil.SetControllerReference(instance, pvc, i.Client.Scheme())
 			}
 			if err := i.Client.Create(ctx, pvc); err != nil {

--- a/controllers/trillian/create.go
+++ b/controllers/trillian/create.go
@@ -84,7 +84,7 @@ func (i createAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trilli
 				instance.Spec.Db.PvcSize = "5Gi"
 			}
 			pvc := k8sutils.CreatePVC(instance.Namespace, "trillian-mysql", instance.Spec.Db.PvcSize)
-			if !instance.Spec.Db.RetainPVC {
+			if instance.Spec.Db.RetainPVC != false {
 				controllerutil.SetControllerReference(instance, pvc, i.Client.Scheme())
 			}
 			if err = i.Client.Create(ctx, pvc); err != nil {

--- a/controllers/trillian/create.go
+++ b/controllers/trillian/create.go
@@ -84,7 +84,7 @@ func (i createAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trilli
 				instance.Spec.Db.PvcSize = "5Gi"
 			}
 			pvc := k8sutils.CreatePVC(instance.Namespace, "trillian-mysql", instance.Spec.Db.PvcSize)
-			if instance.Spec.Db.RetainPVC != false {
+			if instance.Spec.Db.RetainPVC == false {
 				controllerutil.SetControllerReference(instance, pvc, i.Client.Scheme())
 			}
 			if err = i.Client.Create(ctx, pvc); err != nil {


### PR DESCRIPTION
Allow for pvc to be retained or deleted when defining the deployment. Also allow for PVC size to be defined. I had to define the if statement in the way I did in case a user provided no input for the field. Open to suggestions on doing it cleaner though.

closes #112 