### PR TITLE
Defining fbc ReleasePlans

### DIFF
--- a/release-plans/rhtas-fbc-v4-11-registry-redhat-io.yaml
+++ b/release-plans/rhtas-fbc-v4-11-registry-redhat-io.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+  name: rhtas-fbc-v4-11-registry-redhat-io
+  namespace: rhtas-tenant 
+spec:
+  application: rhtas-fbc-v4-11
+  target: rhtap-releng-tenant

--- a/release-plans/rhtas-fbc-v4-12-registry-redhat-io.yaml
+++ b/release-plans/rhtas-fbc-v4-12-registry-redhat-io.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+  name: rhtas-fbc-v4-12-registry-redhat-io
+  namespace: rhtas-tenant 
+spec:
+  application: rhtas-fbc-v4-12
+  target: rhtap-releng-tenant

--- a/release-plans/rhtas-fbc-v4-13-registry-redhat-io.yaml
+++ b/release-plans/rhtas-fbc-v4-13-registry-redhat-io.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+  name: rhtas-fbc-v4-13-registry-redhat-io
+  namespace: rhtas-tenant 
+spec:
+  application: rhtas-fbc-v4-13
+  target: rhtap-releng-tenant

--- a/release-plans/rhtas-fbc-v4-14-registry-redhat-io.yaml
+++ b/release-plans/rhtas-fbc-v4-14-registry-redhat-io.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+  name: rhtas-fbc-v4-14-registry-redhat-io
+  namespace: rhtas-tenant 
+spec:
+  application: rhtas-fbc-v4-14
+  target: rhtap-releng-tenant

--- a/release-plans/rhtas-fbc-v4-15-registry-redhat-io.yaml
+++ b/release-plans/rhtas-fbc-v4-15-registry-redhat-io.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+  name: rhtas-fbc-v4-15-registry-redhat-io
+  namespace: rhtas-tenant 
+spec:
+  application: rhtas-fbc-v4-15
+  target: rhtap-releng-tenant

--- a/release-plans/rhtas-fbc-v4-16-registry-redhat-io.yaml
+++ b/release-plans/rhtas-fbc-v4-16-registry-redhat-io.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleasePlan
+metadata:
+  labels:
+    release.appstudio.openshift.io/auto-release: 'false'
+  name: rhtas-fbc-v4-16-registry-redhat-io
+  namespace: rhtas-tenant 
+spec:
+  application: rhtas-fbc-v4-16
+  target: rhtap-releng-tenant


### PR DESCRIPTION
Defining the yaml we use for the ReleasePlans.
THe will be applied on the Konflux cluster after merging.