### PR TITLE
Triggering builds to promote images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY client/ client/
-
+#
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.display-name="RHTAS operator bundle container image for Red Hat Tru
 LABEL io.openshift.tags="rhtas-operator-bundle, rhtas-operator, Red Hat Trusted Artifact Signer."
 LABEL summary="Operator Bundle for the rhtas-operator."
 LABEL com.redhat.component="sigstore-operator-bundle"
-
+#
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"
 LABEL features.operators.openshift.io/disconnected="false"


### PR DESCRIPTION
If I am right marking EC as optional will allow us to promote images for testing, because seemingly what has happend is the EC is running against builds from friday even though there have been extra builds and succeessful pushes since then. 