### PR TITLE
job for openshift CI

### DIFF
--- a/ci/openshift/job.yaml
+++ b/ci/openshift/job.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: trusted-artifact-signer-test-sign-verify
+  labels:
+    app.kubernetes.io/component: trusted-artifact-signer
+  annotations:
+    helm.sh/hook: test
+spec:
+  template:
+    spec:
+      containers:
+      - name: buildah
+        image: quay.io/buildah/stable
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          buildah pull alpine:latest
+          buildah tag alpine:latest ttl.sh/sigstore-test:5m
+          buildah push ttl.sh/sigstore-test:5m
+        securityContext:
+          privileged: true
+      restartPolicy: Never


### PR DESCRIPTION
This job is needed for OpenShift CI to be able to push an image before doing cosign