### PR TITLE
Fix generated Fulcio root certificate requirements

### DIFF
--- a/api/v1alpha1/fulcio_types.go
+++ b/api/v1alpha1/fulcio_types.go
@@ -21,6 +21,7 @@ type FulcioSpec struct {
 
 // FulcioCert defines fields for system-generated certificate
 // +kubebuilder:validation:XValidation:rule=(has(self.caRef) || self.commonName != ""),message=commonName cannot be empty
+// +kubebuilder:validation:XValidation:rule=(has(self.caRef) || self.organizationName != ""),message=organizationName cannot be empty
 // +kubebuilder:validation:XValidation:rule=(!has(self.caRef) || has(self.privateKeyRef)),message=privateKeyRef cannot be empty
 type FulcioCert struct {
 	// Reference to CA private key

--- a/api/v1alpha1/fulcio_types_test.go
+++ b/api/v1alpha1/fulcio_types_test.go
@@ -229,7 +229,8 @@ func generateFulcioObject(name string) *Fulcio {
 				},
 			},
 			Certificate: FulcioCert{
-				CommonName: "hostname",
+				CommonName:       "hostname",
+				OrganizationName: "organization",
 			},
 		},
 	}

--- a/config/crd/bases/rhtas.redhat.com_fulcios.yaml
+++ b/config/crd/bases/rhtas.redhat.com_fulcios.yaml
@@ -115,6 +115,8 @@ spec:
                 x-kubernetes-validations:
                 - message: commonName cannot be empty
                   rule: (has(self.caRef) || self.commonName != "")
+                - message: organizationName cannot be empty
+                  rule: (has(self.caRef) || self.organizationName != "")
                 - message: privateKeyRef cannot be empty
                   rule: (!has(self.caRef) || has(self.privateKeyRef))
               config:
@@ -314,6 +316,8 @@ spec:
                 x-kubernetes-validations:
                 - message: commonName cannot be empty
                   rule: (has(self.caRef) || self.commonName != "")
+                - message: organizationName cannot be empty
+                  rule: (has(self.caRef) || self.organizationName != "")
                 - message: privateKeyRef cannot be empty
                   rule: (!has(self.caRef) || has(self.privateKeyRef))
               conditions:

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -221,6 +221,8 @@ spec:
                     x-kubernetes-validations:
                     - message: commonName cannot be empty
                       rule: (has(self.caRef) || self.commonName != "")
+                    - message: organizationName cannot be empty
+                      rule: (has(self.caRef) || self.organizationName != "")
                     - message: privateKeyRef cannot be empty
                       rule: (!has(self.caRef) || has(self.privateKeyRef))
                   config:

--- a/controllers/ctlog/actions/handle_fulcio_root.go
+++ b/controllers/ctlog/actions/handle_fulcio_root.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"slices"
 
 	"github.com/securesign/operator/api/v1alpha1"
@@ -92,7 +93,9 @@ func (g handleFulcioCert) Handle(ctx context.Context, instance *v1alpha1.CTlog) 
 				Namespace: instance.Namespace,
 			},
 		}); err != nil {
-			return g.Failed(err)
+			if !k8sErrors.IsNotFound(err) {
+				return g.Failed(err)
+			}
 		}
 		instance.Status.ServerConfigRef = nil
 	}

--- a/controllers/ctlog/actions/handle_keys.go
+++ b/controllers/ctlog/actions/handle_keys.go
@@ -3,7 +3,6 @@ package actions
 import (
 	"context"
 	"fmt"
-
 	"github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/controllers/common/action"
 	k8sutils "github.com/securesign/operator/controllers/common/utils/kubernetes"
@@ -11,6 +10,7 @@ import (
 	"github.com/securesign/operator/controllers/ctlog/utils"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -168,7 +168,9 @@ func (g handleKeys) Handle(ctx context.Context, instance *v1alpha1.CTlog) *actio
 				Namespace: instance.Namespace,
 			},
 		}); err != nil {
-			return g.Failed(err)
+			if !k8sErrors.IsNotFound(err) {
+				return g.Failed(err)
+			}
 		}
 		instance.Status.ServerConfigRef = nil
 	}

--- a/controllers/fulcio/actions/generate_cert.go
+++ b/controllers/fulcio/actions/generate_cert.go
@@ -183,7 +183,7 @@ func (g handleCert) setupCert(instance *v1alpha1.Fulcio) (*utils.FulcioCertConfi
 		}
 		config.PrivateKey = key
 	} else {
-		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/rekor/actions/server/generate_signer.go
+++ b/controllers/rekor/actions/server/generate_signer.go
@@ -190,7 +190,7 @@ func (g generateSigner) CreateRekorKey(instance *v1alpha1.Rekor) (*RekorCertConf
 		return config, nil
 	}
 
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/provided_certs_test.go
+++ b/e2e/provided_certs_test.go
@@ -355,14 +355,14 @@ func initCertificates(passwordProtected bool) ([]byte, []byte, []byte, error) {
 	}
 	//Create certificate templet
 	template := x509.Certificate{
-		SerialNumber:          big.NewInt(0),
+		SerialNumber:          big.NewInt(1),
 		Subject:               issuer,
 		SignatureAlgorithm:    x509.ECDSAWithSHA256,
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		Issuer:                issuer,
 	}
 	//Create certificate using templet


### PR DESCRIPTION
Fixing requirements on generated Fulcio root certificate by operator and use ECDSA P-384 (secp384r1) for generated keys.
https://github.com/sigstore/fulcio/blob/main/docs/certificate-specification.md