### PR TITLE
feat(config): add config action for rekor-ui

### DIFF
--- a/controllers/rekor/actions/ui/servrConfig.go
+++ b/controllers/rekor/actions/ui/servrConfig.go
@@ -1,0 +1,84 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/controllers/common/action"
+	"github.com/securesign/operator/controllers/common/utils/kubernetes"
+	"github.com/securesign/operator/controllers/constants"
+	"github.com/securesign/operator/controllers/rekor/actions"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	cmName = "rekor-ui-config"
+)
+
+func NewUiConfigAction() action.Action[rhtasv1alpha1.Rekor] {
+	return &serverConfig{}
+}
+
+type serverConfig struct {
+	action.BaseAction
+}
+
+func (i serverConfig) Name() string {
+	return "create UI config"
+}
+
+func (i serverConfig) CanHandle(_ context.Context, instance *rhtasv1alpha1.Rekor) bool {
+	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
+	return c.Reason == constants.Creating && instance.Status.UiConfigRef == nil && instance.Spec.RekorSearchUI.Enabled
+}
+
+func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor) *action.Result {
+	var (
+		err error
+	)
+	labels := constants.LabelsFor(actions.ServerComponentName, actions.ServerDeploymentName, instance.Name)
+
+	if err != nil {
+		return i.FailedWithStatusUpdate(ctx, err, instance)
+	}
+	
+	configData := map[string]string{
+		"endpoint-config.yaml": fmt.Sprintf("NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN: %s", instance.Status.Url),
+	}
+
+	newConfig := kubernetes.CreateImmutableConfigmap(fmt.Sprintf("rekor-ui-config-%s", instance.Namespace), instance.Namespace, labels, configData)
+
+	if err = controllerutil.SetControllerReference(instance, newConfig, i.Client.Scheme()); err != nil {
+		return i.Failed(fmt.Errorf("could not set controller reference for ConfigMap: %w", err))
+	}
+
+	_, err = i.Ensure(ctx, newConfig)
+	if err != nil {
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:    actions.ServerCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  constants.Failure,
+			Message: err.Error(),
+		})
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:    constants.Ready,
+			Status:  metav1.ConditionFalse,
+			Reason:  constants.Failure,
+			Message: err.Error(),
+		})
+		return i.FailedWithStatusUpdate(ctx, err, instance)
+	}
+
+	instance.Status.UiConfigRef = &rhtasv1alpha1.LocalObjectReference{Name: newConfig.Name}
+
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:    actions.ServerCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  constants.Creating,
+		Message: "UI config created",
+	})
+	return i.StatusUpdate(ctx, instance)
+}

--- a/controllers/rekor/rekor_controller.go
+++ b/controllers/rekor/rekor_controller.go
@@ -104,6 +104,7 @@ func (r *RekorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		ui.NewDeployAction(),
 		ui.NewCreateServiceAction(),
 		ui.NewIngressAction(),
+		ui.NewServerConfigAction(),
 
 		backfillredis.NewBackfillRedisCronJobAction(),
 


### PR DESCRIPTION
This PR adds reference to a ConfigMap with the required environment variable in order for the `rekor-search-ui` to be able to issue requests to the Rekor server.