### PR TITLE
fix-sbj-cluster-role

### DIFF
--- a/controllers/securesign/actions/segment_backup_cronjob.go
+++ b/controllers/securesign/actions/segment_backup_cronjob.go
@@ -74,13 +74,13 @@ func (i segmentBackupCronJob) Handle(ctx context.Context, instance *rhtasv1alpha
 	role := kubernetes.CreateClusterRole(instance.Namespace, SegmentRBACName, labels, []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
-			Resources: []string{"configmaps", "secrets"},
+			Resources: []string{"secrets"},
 			Verbs:     []string{"get", "list"},
 		},
 		{
 			APIGroups: []string{""},
 			Resources: []string{"configmaps"},
-			Verbs:     []string{"update"},
+			Verbs:     []string{"update", "get", "list", "patch"},
 		},
 		{
 			APIGroups: []string{"route.openshift.io"},

--- a/controllers/securesign/actions/segment_backup_job.go
+++ b/controllers/securesign/actions/segment_backup_job.go
@@ -65,13 +65,13 @@ func (i segmentBackupJob) Handle(ctx context.Context, instance *rhtasv1alpha1.Se
 	role := kubernetes.CreateClusterRole(instance.Namespace, SegmentRBACName, labels, []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
-			Resources: []string{"configmaps", "secrets"},
+			Resources: []string{"secrets"},
 			Verbs:     []string{"get", "list"},
 		},
 		{
 			APIGroups: []string{""},
 			Resources: []string{"configmaps"},
-			Verbs:     []string{"update"},
+			Verbs:     []string{"update", "get", "list", "patch"},
 		},
 		{
 			APIGroups: []string{"route.openshift.io"},


### PR DESCRIPTION
For some reason the cluster wasn't applying the "get" to the configmaps resource properly separating them seems to work, I was also seeing errors related to patch thats why I added it