### PR TITLE
fix: add-missing-metadata

### DIFF
--- a/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
@@ -2,16 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    features.operators.openshift.io/disconnected: "false"
-    features.operators.openshift.io/fips-compliant: "false"
-    features.operators.openshift.io/proxy-aware: "false"
-    features.operators.openshift.io/cnf: "false"
-    features.operators.openshift.io/cni: "false"
-    features.operators.openshift.io/csi: "false"
-    features.operators.openshift.io/tls-profiles: "false"
-    features.operators.openshift.io/token-auth-aws: "false"
-    features.operators.openshift.io/token-auth-azure: "false"
-    features.operators.openshift.io/token-auth-gcp: "false"
     alm-examples: |-
       [
         {
@@ -190,9 +180,22 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-04-04T07:35:04Z"
+    containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:2d2a22420249890a64b42c663d57c4b5c6638e0597fe74b01b275ba915e53ea2
+    createdAt: "2024-04-18T08:46:25Z"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    repository: https://github.com/securesign/secure-sign-operator
+    support: Red Hat
   name: rhtas-operator.v1.0.0
   namespace: placeholder
 spec:

--- a/bundle/manifests/rhtas.redhat.com_ctlogs.yaml
+++ b/bundle/manifests/rhtas.redhat.com_ctlogs.yaml
@@ -44,6 +44,19 @@ spec:
           spec:
             description: CTlogSpec defines the desired state of CTlog component
             properties:
+              monitoring:
+                description: Enable Service monitors for ctlog
+                properties:
+                  enabled:
+                    default: false
+                    description: If true, the Operator will create monitoring resources
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: Feature cannot be disabled
+                      rule: (self || !oldSelf)
+                required:
+                - enabled
+                type: object
               privateKeyPasswordRef:
                 description: Password to decrypt private key
                 properties:

--- a/bundle/manifests/rhtas.redhat.com_securesigns.yaml
+++ b/bundle/manifests/rhtas.redhat.com_securesigns.yaml
@@ -67,6 +67,20 @@ spec:
               ctlog:
                 description: CTlogSpec defines the desired state of CTlog component
                 properties:
+                  monitoring:
+                    description: Enable Service monitors for ctlog
+                    properties:
+                      enabled:
+                        default: false
+                        description: If true, the Operator will create monitoring
+                          resources
+                        type: boolean
+                        x-kubernetes-validations:
+                        - message: Feature cannot be disabled
+                          rule: (self || !oldSelf)
+                    required:
+                    - enabled
+                    type: object
                   privateKeyPasswordRef:
                     description: Password to decrypt private key
                     properties:
@@ -621,6 +635,20 @@ spec:
                     x-kubernetes-validations:
                     - message: databaseSecretRef cannot be empty
                       rule: ((!self.create && self.databaseSecretRef != null) || self.create)
+                  monitoring:
+                    description: Enable Monitoring for Logsigner and Logserver
+                    properties:
+                      enabled:
+                        default: false
+                        description: If true, the Operator will create monitoring
+                          resources
+                        type: boolean
+                        x-kubernetes-validations:
+                        - message: Feature cannot be disabled
+                          rule: (self || !oldSelf)
+                    required:
+                    - enabled
+                    type: object
                 type: object
               tuf:
                 default:

--- a/bundle/manifests/rhtas.redhat.com_trillians.yaml
+++ b/bundle/manifests/rhtas.redhat.com_trillians.yaml
@@ -121,6 +121,19 @@ spec:
                 x-kubernetes-validations:
                 - message: databaseSecretRef cannot be empty
                   rule: ((!self.create && self.databaseSecretRef != null) || self.create)
+              monitoring:
+                description: Enable Monitoring for Logsigner and Logserver
+                properties:
+                  enabled:
+                    default: false
+                    description: If true, the Operator will create monitoring resources
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: Feature cannot be disabled
+                      rule: (self || !oldSelf)
+                required:
+                - enabled
+                type: object
             type: object
           status:
             description: TrillianStatus defines the observed state of Trillian

--- a/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
@@ -4,6 +4,19 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:2d2a22420249890a64b42c663d57c4b5c6638e0597fe74b01b275ba915e53ea2
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    repository: https://github.com/securesign/secure-sign-operator
+    support: Red Hat
   name: rhtas-operator.v0.0.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
This pr makes the changes necessary to display missing metadata in the operator marketplace 
Jira: https://issues.redhat.com/browse/SECURESIGN-801

![Screenshot from 2024-04-18 10-04-32](https://github.com/securesign/secure-sign-operator/assets/59924001/9ba7c43d-7e30-4b71-a7ca-6b834844c76e)


## Testing
Here is an CatalogSource yaml definition you can use if you want to test, with my FBC image

```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhtas-operator-japower
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  grpcPodConfig:
    securityContextConfig: legacy
  publisher: Red Hat
  image: quay.io/japower/4.15_test@sha256:1cee7ca01822206d8aa154614fde8119a2b8769f63a6a21047987b7f8e124c6c
  displayName: TAS Operator
```