### PR TITLE
fix: fix-snyk-vul

### DIFF
--- a/controllers/common/password.go
+++ b/controllers/common/password.go
@@ -2,18 +2,18 @@ package common
 
 import (
 	"bytes"
-	"math/rand"
-	"time"
+	"crypto/rand"
+	"math/big"
 )
 
 func GeneratePassword(length int) []byte {
-	rand.Seed(time.Now().UnixNano())
 	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
 		"abcdefghijklmnopqrstuvwxyz" +
 		"0123456789" + "!@#$%&*")
 	var b bytes.Buffer
 	for i := 0; i < length; i++ {
-		b.WriteRune(chars[rand.Intn(len(chars))])
+		index, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+		b.WriteRune(chars[index.Int64()])
 	}
 	return b.Bytes()
 }


### PR DESCRIPTION
Snyk.io was complaining about the use of ` math.rand.Intn` to generate the password and recommend we switch to crypto/rand.

Ref: https://app.snyk.io/org/application-services-red-hat-trusted-artifact-signer/project/7226cc76-b503-4925-b193-c8cc5459f3de