### PR TITLE
Add pprof-address option to expose pprof server

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -89,11 +90,17 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
+
+	// flags related to operator
+	var (
+		metricsAddr          string
+		probeAddr            string
+		pprofAddr            string
+		enableLeaderElection bool
+	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-address", "", "The address to expose the pprof server. Default is empty string which disables the pprof server.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -107,9 +114,12 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
-		// MetricsBindAddress:     metricsAddr,
+		Metrics: metricsserver.Options{
+			BindAddress: metricsAddr,
+		},
 		// Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
+		PprofBindAddress:       pprofAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "f81d37df.redhat.com",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily


### PR DESCRIPTION
Add `--pprof-address` option to expose the pprof server. Default is empty string which disables the pprof server.

Fixes unused value ffrom `--metrics-bind-address` option.

/cc @lance @JasonPowr 