### PR TITLE
[Securesign 835] | Create Tree Error Looping indefinetley.

### DIFF
--- a/controllers/ctlog/ctlog_hot_update_test.go
+++ b/controllers/ctlog/ctlog_hot_update_test.go
@@ -73,7 +73,7 @@ var _ = Describe("CTlog update test", func() {
 
 			Eventually(func() error {
 				return k8sClient.Delete(context.TODO(), found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 3*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -192,7 +192,7 @@ var _ = Describe("CTlog update test", func() {
 				updated := &appsv1.Deployment{}
 				k8sClient.Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, updated)
 				return equality.Semantic.DeepDerivative(deployment.Spec.Template.Spec.Volumes, updated.Spec.Template.Spec.Volumes)
-			}, 2*time.Minute, time.Second).Should(BeFalse())
+			}, 3*time.Minute, time.Second).Should(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
This pr is a WIP as I believe this is the solution and I  also need to update tests still.

Where the error itself originates is within the trillian repo [here](https://github.com/securesign/trillian/blob/303a8bdbe307e5dbc703221cc782395ee72ee986/client/admin.go#L49) there isnt anything wrong on the trillian end but rather ours, that snippet of code will run forever without a specified deadline.
I have added some deadline flags to ctlog and rekor with a default set for 5 minutes.