### PR TITLE
Add annotation to pause resource reconciliation

### DIFF
--- a/controllers/annotations/annotations.go
+++ b/controllers/annotations/annotations.go
@@ -1,0 +1,6 @@
+package annotations
+
+const (
+	// PausedReconciliation Annotation used to pause resource reconciliation
+	PausedReconciliation = "rhtas.redhat.com/pause-reconciliation"
+)

--- a/controllers/common/action/base_action.go
+++ b/controllers/common/action/base_action.go
@@ -3,7 +3,9 @@ package action
 import (
 	"context"
 	"errors"
+	"github.com/securesign/operator/controllers/annotations"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -112,6 +114,14 @@ func (action *BaseAction) Ensure(ctx context.Context, obj client2.Object) (bool,
 			return true, nil
 		}
 		return false, err
+	}
+
+	annoStr, find := currentObj.GetAnnotations()[annotations.PausedReconciliation]
+	if find {
+		annoBool, _ := strconv.ParseBool(annoStr)
+		if annoBool {
+			return false, nil
+		}
 	}
 
 	currentSpec := reflect.ValueOf(currentObj).Elem().FieldByName("Spec")

--- a/controllers/fulcio/fulcio_controller.go
+++ b/controllers/fulcio/fulcio_controller.go
@@ -19,6 +19,8 @@ package fulcio
 import (
 	"context"
 	"errors"
+	olpredicate "github.com/operator-framework/operator-lib/predicate"
+	"github.com/securesign/operator/controllers/annotations"
 
 	"github.com/securesign/operator/controllers/fulcio/actions"
 	v12 "k8s.io/api/core/v1"
@@ -115,7 +117,14 @@ func (r *FulcioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *FulcioReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Filter out with the pause annotation.
+	pause, err := olpredicate.NewPause(annotations.PausedReconciliation)
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(pause).
 		For(&rhtasv1alpha1.Fulcio{}).
 		Owns(&v1.Deployment{}).
 		Owns(&v12.Service{}).

--- a/controllers/rekor/rekor_controller.go
+++ b/controllers/rekor/rekor_controller.go
@@ -18,6 +18,8 @@ package rekor
 
 import (
 	"context"
+	olpredicate "github.com/operator-framework/operator-lib/predicate"
+	"github.com/securesign/operator/controllers/annotations"
 
 	actions2 "github.com/securesign/operator/controllers/rekor/actions"
 	backfillredis "github.com/securesign/operator/controllers/rekor/actions/backfillRedis"
@@ -144,7 +146,14 @@ func (r *RekorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RekorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Filter out with the pause annotation.
+	pause, err := olpredicate.NewPause(annotations.PausedReconciliation)
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(pause).
 		For(&rhtasv1alpha1.Rekor{}).
 		Owns(&v12.Deployment{}).
 		Owns(&v13.Service{}).

--- a/controllers/securesign/securesign_controller.go
+++ b/controllers/securesign/securesign_controller.go
@@ -18,8 +18,9 @@ package securesign
 
 import (
 	"context"
-
+	"github.com/operator-framework/operator-lib/predicate"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/controllers/annotations"
 	"github.com/securesign/operator/controllers/common/action"
 	"github.com/securesign/operator/controllers/constants"
 	"github.com/securesign/operator/controllers/securesign/actions"
@@ -141,7 +142,14 @@ func (r *SecuresignReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SecuresignReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Filter out with the pause annotation.
+	pause, err := predicate.NewPause(annotations.PausedReconciliation)
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(pause).
 		For(&rhtasv1alpha1.Securesign{}).
 		Owns(&rhtasv1alpha1.Fulcio{}).
 		Owns(&rhtasv1alpha1.Rekor{}).

--- a/controllers/trillian/trillian_controller.go
+++ b/controllers/trillian/trillian_controller.go
@@ -18,6 +18,8 @@ package trillian
 
 import (
 	"context"
+	olpredicate "github.com/operator-framework/operator-lib/predicate"
+	"github.com/securesign/operator/controllers/annotations"
 
 	"github.com/securesign/operator/controllers/common/action"
 	actions2 "github.com/securesign/operator/controllers/trillian/actions"
@@ -119,7 +121,14 @@ func (r *TrillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TrillianReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Filter out with the pause annotation.
+	pause, err := olpredicate.NewPause(annotations.PausedReconciliation)
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithEventFilter(pause).
 		For(&rhtasv1alpha1.Trillian{}).
 		Owns(&v1.Deployment{}).
 		Owns(&v12.Service{}).

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/securesign/operator
 go 1.21
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/go-logr/logr v1.4.1
 	github.com/google/certificate-transparency-go v1.1.7
@@ -12,6 +13,7 @@ require (
 	github.com/onsi/gomega v1.29.0
 	github.com/openshift/api v0.0.0-20231118005202-0f638a8a4705
 	github.com/operator-framework/api v0.22.0
+	github.com/operator-framework/operator-lib v0.12.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.70.0
 	github.com/sigstore/fulcio v1.4.4
 	github.com/sigstore/sigstore v1.8.1
@@ -26,7 +28,6 @@ require (
 )
 
 require (
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/openshift/api v0.0.0-20231118005202-0f638a8a4705 h1:GwpCt0VhL9GjVGJhd
 github.com/openshift/api v0.0.0-20231118005202-0f638a8a4705/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/operator-framework/api v0.22.0 h1:UZSn+iaQih4rCReezOnWTTJkMyawwV5iLnIItaOzytY=
 github.com/operator-framework/api v0.22.0/go.mod h1:p/7YDbr+n4fmESfZ47yLAV1SvkfE6NU2aX8KhcfI0GA=
+github.com/operator-framework/operator-lib v0.12.0 h1:OzpMU5N7mvFgg/uje8FUUeD24Ahq64R6TdN25uswCYA=
+github.com/operator-framework/operator-lib v0.12.0/go.mod h1:ClpLUI7hctEF7F5DBe/kg041dq/4NLR7XC5tArY7bG4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Add a new `rhtas.redhat.com/pause-reconciliation` annotation to pause resource reconciliation. Annotation can be used on any Securesign's custom resource and resources which are owned by them like Deploymen, Service, Ingress

Example custom resource with a paused reconciliation condition
```
kind: Tuf
metadata:
  annotations:
    rhtas.redhat.com/pause-reconciliation: "true"
```