### PR TITLE
chore(rekor-search-ui): update image sha

### DIFF
--- a/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
@@ -151,9 +151,8 @@ metadata:
             "name": "tuf-sample"
           },
           "spec": {
-            "external": {
-              "enabled": true,
-              "host": "tuf.example.com"
+            "externalAccess": {
+              "enabled": true
             },
             "keys": [
               {
@@ -183,7 +182,7 @@ metadata:
       ]
     capabilities: Basic Install
     containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:0c2da12e405de8c3553c5d1912dd83d0f3cb0857cf5727c7d335d5ba6d5991b5
-    createdAt: "2024-04-24T13:10:19Z"
+    createdAt: "2024-05-01T03:20:41Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -194,7 +193,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operators.operatorframework.io/builder: operator-sdk-v1.32.0
+    operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/securesign/secure-sign-operator
     support: Red Hat

--- a/bundle/manifests/rhtas.redhat.com_rekors.yaml
+++ b/bundle/manifests/rhtas.redhat.com_rekors.yaml
@@ -138,10 +138,12 @@ spec:
                 - retain
                 type: object
               rekorSearchUI:
+                default:
+                  enabled: true
                 description: Rekor Search UI
                 properties:
                   enabled:
-                    default: false
+                    default: true
                     description: If set to true, the Operator will deploy a Rekor
                       Search UI
                     type: boolean

--- a/bundle/manifests/rhtas.redhat.com_securesigns.yaml
+++ b/bundle/manifests/rhtas.redhat.com_securesigns.yaml
@@ -483,10 +483,12 @@ spec:
                     - retain
                     type: object
                   rekorSearchUI:
+                    default:
+                      enabled: true
                     description: Rekor Search UI
                     properties:
                       enabled:
-                        default: false
+                        default: true
                         description: If set to true, the Operator will deploy a Rekor
                           Search UI
                         type: boolean

--- a/controllers/constants/images.go
+++ b/controllers/constants/images.go
@@ -12,7 +12,7 @@ var (
 
 	RekorRedisImage    = "registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:8c12d98f96ed3daa3ea7ce03d52e8b6748c4b7ab20eee98c1d1ad031d14af00e"
 	RekorServerImage   = "registry.redhat.io/rhtas/rekor-server-rhel9@sha256:133e42c7dd44ce6d12a3cee28ead1a4eb1a99ebaaa07d67d4362eec7561ae672"
-	RekorSearchUiImage = "registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:0c8a24911435b3d8b9c137e8105192a3f513d775cc2728a87506c68785975f7b"
+	RekorSearchUiImage = "registry.redhat.io/rhtas/rekor-search-ui-rhel9sha256:047b9018425c1bacd0919b88b86af2f053bd14d6aafb63f6105221a9045d517c"
 	BackfillRedisImage = "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:46bf598e4959fd032f53ad7728ba9dc23f463b8b841d207d31def4f0d4990888"
 
 	TufImage = "registry.redhat.io/rhtas/tuf-server-rhel9@sha256:6e07be763052f724ac96739afed4b35509b95d88e3d5d86748c5b931f94639aa"

--- a/controllers/rekor/actions/initialize.go
+++ b/controllers/rekor/actions/initialize.go
@@ -42,7 +42,7 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 	}
 
 	if utils.IsEnabled(instance.Spec.RekorSearchUI.Enabled) {
-		if  !meta.IsStatusConditionTrue(instance.Status.Conditions, UICondition) {
+		if !meta.IsStatusConditionTrue(instance.Status.Conditions, UICondition) {
 			return i.Requeue()
 		}
 	}


### PR DESCRIPTION
Updates the image sha for the deployed rekor-search-ui and the bundles. Seems like more changes than necessary, but 🤷 