### PR TITLE
fix: Set the common name of the Fulcio cert automatically 

### DIFF
--- a/api/v1alpha1/fulcio_types.go
+++ b/api/v1alpha1/fulcio_types.go
@@ -24,7 +24,6 @@ type FulcioSpec struct {
 }
 
 // FulcioCert defines fields for system-generated certificate
-// +kubebuilder:validation:XValidation:rule=(has(self.caRef) || self.commonName != ""),message=commonName cannot be empty
 // +kubebuilder:validation:XValidation:rule=(has(self.caRef) || self.organizationName != ""),message=organizationName cannot be empty
 // +kubebuilder:validation:XValidation:rule=(!has(self.caRef) || has(self.privateKeyRef)),message=privateKeyRef cannot be empty
 type FulcioCert struct {
@@ -40,6 +39,8 @@ type FulcioCert struct {
 	CARef *SecretKeySelector `json:"caRef,omitempty"`
 
 	//+optional
+	// CommonName specifies the common name for the Fulcio certificate.
+	// If not provided, the common name will default to the host name.
 	CommonName string `json:"commonName,omitempty"`
 	//+optional
 	OrganizationName string `json:"organizationName,omitempty"`

--- a/api/v1alpha1/fulcio_types_test.go
+++ b/api/v1alpha1/fulcio_types_test.go
@@ -105,15 +105,6 @@ var _ = Describe("Fulcio", func() {
 		})
 
 		Context("is validated", func() {
-			It("commonName", func() {
-				invalidObject := generateFulcioObject("commonname-invalid")
-				invalidObject.Spec.Certificate.CommonName = ""
-
-				Expect(apierrors.IsInvalid(k8sClient.Create(context.Background(), invalidObject))).To(BeTrue())
-				Expect(k8sClient.Create(context.Background(), invalidObject)).
-					To(MatchError(ContainSubstring("commonName cannot be empty")))
-			})
-
 			It("private key", func() {
 				invalidObject := generateFulcioObject("private-key-invalid")
 				invalidObject.Spec.Certificate.CARef = &SecretKeySelector{

--- a/bundle/manifests/rhtas.redhat.com_fulcios.yaml
+++ b/bundle/manifests/rhtas.redhat.com_fulcios.yaml
@@ -70,6 +70,9 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   commonName:
+                    description: |-
+                      CommonName specifies the common name for the Fulcio certificate.
+                      If not provided, the common name will default to the host name.
                     type: string
                   organizationEmail:
                     type: string
@@ -113,8 +116,6 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
                 x-kubernetes-validations:
-                - message: commonName cannot be empty
-                  rule: (has(self.caRef) || self.commonName != "")
                 - message: organizationName cannot be empty
                   rule: (has(self.caRef) || self.organizationName != "")
                 - message: privateKeyRef cannot be empty
@@ -292,6 +293,9 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   commonName:
+                    description: |-
+                      CommonName specifies the common name for the Fulcio certificate.
+                      If not provided, the common name will default to the host name.
                     type: string
                   organizationEmail:
                     type: string
@@ -335,8 +339,6 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
                 x-kubernetes-validations:
-                - message: commonName cannot be empty
-                  rule: (has(self.caRef) || self.commonName != "")
                 - message: organizationName cannot be empty
                   rule: (has(self.caRef) || self.organizationName != "")
                 - message: privateKeyRef cannot be empty

--- a/bundle/manifests/rhtas.redhat.com_securesigns.yaml
+++ b/bundle/manifests/rhtas.redhat.com_securesigns.yaml
@@ -190,6 +190,9 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       commonName:
+                        description: |-
+                          CommonName specifies the common name for the Fulcio certificate.
+                          If not provided, the common name will default to the host name.
                         type: string
                       organizationEmail:
                         type: string
@@ -233,8 +236,6 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                     x-kubernetes-validations:
-                    - message: commonName cannot be empty
-                      rule: (has(self.caRef) || self.commonName != "")
                     - message: organizationName cannot be empty
                       rule: (has(self.caRef) || self.organizationName != "")
                     - message: privateKeyRef cannot be empty

--- a/config/crd/bases/rhtas.redhat.com_fulcios.yaml
+++ b/config/crd/bases/rhtas.redhat.com_fulcios.yaml
@@ -70,6 +70,9 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   commonName:
+                    description: |-
+                      CommonName specifies the common name for the Fulcio certificate.
+                      If not provided, the common name will default to the host name.
                     type: string
                   organizationEmail:
                     type: string
@@ -113,8 +116,6 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
                 x-kubernetes-validations:
-                - message: commonName cannot be empty
-                  rule: (has(self.caRef) || self.commonName != "")
                 - message: organizationName cannot be empty
                   rule: (has(self.caRef) || self.organizationName != "")
                 - message: privateKeyRef cannot be empty
@@ -292,6 +293,9 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   commonName:
+                    description: |-
+                      CommonName specifies the common name for the Fulcio certificate.
+                      If not provided, the common name will default to the host name.
                     type: string
                   organizationEmail:
                     type: string
@@ -335,8 +339,6 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
                 x-kubernetes-validations:
-                - message: commonName cannot be empty
-                  rule: (has(self.caRef) || self.commonName != "")
                 - message: organizationName cannot be empty
                   rule: (has(self.caRef) || self.organizationName != "")
                 - message: privateKeyRef cannot be empty

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -190,6 +190,9 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       commonName:
+                        description: |-
+                          CommonName specifies the common name for the Fulcio certificate.
+                          If not provided, the common name will default to the host name.
                         type: string
                       organizationEmail:
                         type: string
@@ -233,8 +236,6 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                     x-kubernetes-validations:
-                    - message: commonName cannot be empty
-                      rule: (has(self.caRef) || self.commonName != "")
                     - message: organizationName cannot be empty
                       rule: (has(self.caRef) || self.organizationName != "")
                     - message: privateKeyRef cannot be empty

--- a/controllers/fulcio/actions/generate_cert.go
+++ b/controllers/fulcio/actions/generate_cert.go
@@ -77,7 +77,7 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 	}
 	maps.Copy(secretLabels, labels)
 
-	cert, err := g.setupCert(instance)
+	cert, err := g.setupCert(ctx, instance)
 	if err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:    CertCondition,
@@ -164,7 +164,7 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 	return g.StatusUpdate(ctx, instance)
 }
 
-func (g handleCert) setupCert(instance *v1alpha1.Fulcio) (*utils.FulcioCertConfig, error) {
+func (g handleCert) setupCert(ctx context.Context, instance *v1alpha1.Fulcio) (*utils.FulcioCertConfig, error) {
 	config := &utils.FulcioCertConfig{}
 
 	if ref := instance.Spec.Certificate.PrivateKeyPasswordRef; ref != nil {
@@ -208,7 +208,7 @@ func (g handleCert) setupCert(instance *v1alpha1.Fulcio) (*utils.FulcioCertConfi
 		}
 		config.RootCert = key
 	} else {
-		rootCert, err := utils.CreateFulcioCA(config, instance)
+		rootCert, err := utils.CreateFulcioCA(ctx, g.Client, config, instance, DeploymentName)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SECURESIGN-851

If commonName is empty in the CRD definition, One will be calculated based on the ns and name of service 