### PR TITLE
Handle error when ctlog unable to generate public key

### DIFF
--- a/controllers/ctlog/actions/handle_keys.go
+++ b/controllers/ctlog/actions/handle_keys.go
@@ -100,6 +100,9 @@ func (g handleKeys) Handle(ctx context.Context, instance *v1alpha1.CTlog) *actio
 			}
 		}
 		config, err = utils.GeneratePublicKey(&utils.PrivateKeyConfig{PrivateKey: private, PrivateKeyPass: password})
+		if err != nil || config == nil{
+			return g.Failed(fmt.Errorf("unable to generate public key: %w", err))
+		}
 		data = map[string][]byte{"public": config.PublicKey}
 	}
 


### PR DESCRIPTION
Solves [SECURESIGN-675](https://issues.redhat.com//browse/SECURESIGN-675)