### PR TITLE
Namespace deletion check in Reconcile function

### DIFF
--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/securesign/operator/internal/controller/common/action"
 	v1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,15 +72,21 @@ func (r *CTlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	rlog.V(1).Info("Reconciling CTlog", "request", req)
 
 	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return reconcile.Result{}, nil
-		}
-		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
+
+	// Fetch the namespace
+	var namespace v12.Namespace
+	if err := r.Get(ctx, types.NamespacedName{Name: req.Namespace}, &namespace); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check if the namespace is marked for deletion
+	if !namespace.DeletionTimestamp.IsZero() {
+		rlog.Info("namespace is marked for deletion, stopping reconciliation", "namespace", req.Namespace)
+		return ctrl.Result{}, nil
+	}
+
 	target := instance.DeepCopy()
 	acs := []action.Action[*rhtasv1alpha1.CTlog]{
 		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.CTlog](func(_ *rhtasv1alpha1.CTlog) []string {

--- a/internal/controller/ctlog/ctlog_hot_update_test.go
+++ b/internal/controller/ctlog/ctlog_hot_update_test.go
@@ -148,13 +148,14 @@ var _ = Describe("CTlog update test", func() {
 			Expect(k8sClient.Create(ctx, fulcioCa)).To(Succeed())
 
 			By("CA has changed in status field")
-			Eventually(func(g Gomega) []v1alpha1.SecretKeySelector {
+			Eventually(func(g Gomega) {
 				found := &v1alpha1.CTlog{}
 				g.Expect(k8sClient.Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return found.Status.RootCertificates
-			}).Should(HaveExactElements(WithTransform(func(ks v1alpha1.SecretKeySelector) string {
-				return ks.Name
-			}, Equal("test2"))))
+				g.Expect(found.Status.RootCertificates).
+					Should(HaveExactElements(WithTransform(func(ks v1alpha1.SecretKeySelector) string {
+						return ks.Name
+					}, Equal("test2"))))
+			}).Should(Succeed())
 
 			By("CTL deployment is updated")
 			Eventually(func() bool {

--- a/internal/controller/fulcio/fulcio_controller.go
+++ b/internal/controller/fulcio/fulcio_controller.go
@@ -19,6 +19,7 @@ package fulcio
 import (
 	"context"
 	"errors"
+	"k8s.io/apimachinery/pkg/types"
 
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
 	"github.com/securesign/operator/internal/controller/annotations"
@@ -32,7 +33,6 @@ import (
 	"github.com/securesign/operator/internal/controller/common/action"
 
 	v1 "k8s.io/api/apps/v1"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,14 +77,19 @@ func (r *FulcioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	log.V(1).Info("Reconciling Fulcio", "request", req)
 
 	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
-		if k8sErrors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return reconcile.Result{}, nil
-		}
-		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Fetch the namespace
+	var namespace v12.Namespace
+	if err := r.Get(ctx, types.NamespacedName{Name: req.Namespace}, &namespace); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check if the namespace is marked for deletion
+	if !namespace.DeletionTimestamp.IsZero() {
+		log.Info("namespace is marked for deletion, stopping reconciliation", "namespace", req.Namespace)
+		return ctrl.Result{}, nil
 	}
 
 	target := instance.DeepCopy()

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -18,6 +18,7 @@ package trillian
 
 import (
 	"context"
+	"k8s.io/apimachinery/pkg/types"
 
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
 	"github.com/securesign/operator/internal/controller/annotations"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	v1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,15 +69,21 @@ func (r *TrillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	log.V(1).Info("Reconciling Trillian", "request", req)
 
 	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
-		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return reconcile.Result{}, nil
-		}
-		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
+
+	// Fetch the namespace
+	var namespace v12.Namespace
+	if err := r.Get(ctx, types.NamespacedName{Name: req.Namespace}, &namespace); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check if the namespace is marked for deletion
+	if !namespace.DeletionTimestamp.IsZero() {
+		log.Info("namespace is marked for deletion, stopping reconciliation", "namespace", req.Namespace)
+		return ctrl.Result{}, nil
+	}
+
 	target := instance.DeepCopy()
 	actions := []action.Action[*rhtasv1alpha1.Trillian]{
 		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Trillian](func(_ *rhtasv1alpha1.Trillian) []string {

--- a/test/e2e/support/archive.go
+++ b/test/e2e/support/archive.go
@@ -10,7 +10,7 @@ import (
 
 type logTarget struct {
 	reader io.Reader
-	size int64
+	size   int64
 }
 
 func createArchive(file *os.File, logs map[string]logTarget) error {
@@ -36,12 +36,12 @@ func createArchive(file *os.File, logs map[string]logTarget) error {
 
 		// Write the header to the tar file
 		if err := tarWriter.WriteHeader(tarHeader); err != nil {
-			return fmt.Errorf("tar write header: %w",err)
+			return fmt.Errorf("tar write header: %w", err)
 		}
 
 		// Copy the logTarget data to the tar file
 		if _, err := io.Copy(tarWriter, log.reader); err != nil {
-			return fmt.Errorf("tar write content: %w",err)
+			return fmt.Errorf("tar write content: %w", err)
 		}
 	}
 	return nil

--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -82,16 +82,16 @@ func DumpNamespace(ctx context.Context, cli client.Client, ns string) {
 
 	toDump := map[string]client.ObjectList{
 		"securesign.yaml": &v1alpha1.SecuresignList{},
-		"fulcio.yaml": &v1alpha1.FulcioList{},
-		"rekor.yaml": &v1alpha1.RekorList{},
-		"tuf.yaml": &v1alpha1.TufList{},
-		"ctlog.yaml": &v1alpha1.CTlogList{},
-		"trillian.yaml": &v1alpha1.TrillianList{},
-		"pod.yaml": &v1.PodList{},
-		"configmap.yaml": &v1.ConfigMapList{},
+		"fulcio.yaml":     &v1alpha1.FulcioList{},
+		"rekor.yaml":      &v1alpha1.RekorList{},
+		"tuf.yaml":        &v1alpha1.TufList{},
+		"ctlog.yaml":      &v1alpha1.CTlogList{},
+		"trillian.yaml":   &v1alpha1.TrillianList{},
+		"pod.yaml":        &v1.PodList{},
+		"configmap.yaml":  &v1.ConfigMapList{},
 		"deployment.yaml": &v12.DeploymentList{},
-		"job.yaml": &v13.JobList{},
-		"cronjob.yaml": &v13.CronJobList{},
+		"job.yaml":        &v13.JobList{},
+		"cronjob.yaml":    &v13.CronJobList{},
 	}
 
 	core.GinkgoWriter.Println("----------------------- Dumping namespace " + ns + " -----------------------")
@@ -100,7 +100,7 @@ func DumpNamespace(ctx context.Context, cli client.Client, ns string) {
 		if dump, err := dumpK8sObjects(ctx, cli, obj, ns); err == nil {
 			k8s[key] = logTarget{
 				reader: strings.NewReader(dump),
-				size: int64(len(dump)),
+				size:   int64(len(dump)),
 			}
 		} else {
 			log.Println(fmt.Errorf("dump failed for %s: %w", key, err))
@@ -114,7 +114,7 @@ func DumpNamespace(ctx context.Context, cli client.Client, ns string) {
 		log.Fatalf("Failed to create %s file: %v", fileName, err)
 	}
 
-	if err := createArchive(outFile, k8s) ; err != nil {
+	if err := createArchive(outFile, k8s); err != nil {
 		log.Fatalf("Failed to create %s: %v", fileName, err)
 	}
 }


### PR DESCRIPTION
This pull request introduces a check in the reconcile function to determine if the namespace is marked for deletion. If the namespace is in the process of being terminated, the reconciliation will cease. This enhancement prevents the operator from attempting to create or update objects within a terminating namespace, thereby avoiding error messages such as:
```
unable to create new content in namespace test-b22323db-f1c2-4d5b-b4ba-f5bdd4aa257a because it is being terminated
```