### PR TITLE
chore: add image preflight checks to pipelines

### DIFF
--- a/.tekton/rhtas-operator-bundle-pull-request.yaml
+++ b/.tekton/rhtas-operator-bundle-pull-request.yaml
@@ -332,6 +332,19 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+    - name: ecosystem-cert-preflight-checks
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values: ["false"]
+      runAfter:
+        - build-container
+      taskRef:
+        name: ecosystem-cert-preflight-checks
+        version: "0.1"
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/rhtas-operator-bundle-pull-request.yaml
+++ b/.tekton/rhtas-operator-bundle-pull-request.yaml
@@ -340,8 +340,14 @@ spec:
       runAfter:
         - build-container
       taskRef:
-        name: ecosystem-cert-preflight-checks
-        version: "0.1"
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
+        - name: kind
+          value: task
+        resolver: bundles
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)

--- a/.tekton/rhtas-operator-bundle-push.yaml
+++ b/.tekton/rhtas-operator-bundle-push.yaml
@@ -330,6 +330,19 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+    - name: ecosystem-cert-preflight-checks
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values: ["false"]
+      runAfter:
+        - build-container
+      taskRef:
+        name: ecosystem-cert-preflight-checks
+        version: "0.1"
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/rhtas-operator-bundle-push.yaml
+++ b/.tekton/rhtas-operator-bundle-push.yaml
@@ -338,8 +338,14 @@ spec:
       runAfter:
         - build-container
       taskRef:
-        name: ecosystem-cert-preflight-checks
-        version: "0.1"
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
+        - name: kind
+          value: task
+        resolver: bundles
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: | 
+    pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" && (".tekton/rhtas-operator-pull-request.yaml".pathChanged() || "api/***".pathChanged() || "internal/***".pathChanged() || "Dockerfile.rhtas-operator.rh".pathChanged() || "go.mod".pathChanged() || "cmd/***".pathChanged() || "go.sum".pathChanged() || "trigger-konflux-builds.txt".pathChanged() )
   creationTimestamp: null
   labels:
@@ -333,6 +333,19 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+    - name: ecosystem-cert-preflight-checks
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values: ["false"]
+      runAfter:
+        - build-container
+      taskRef:
+        name: ecosystem-cert-preflight-checks
+        version: "0.1"
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -341,8 +341,14 @@ spec:
       runAfter:
         - build-container
       taskRef:
-        name: ecosystem-cert-preflight-checks
-        version: "0.1"
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
+        - name: kind
+          value: task
+        resolver: bundles
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)

--- a/.tekton/rhtas-operator-push.yaml
+++ b/.tekton/rhtas-operator-push.yaml
@@ -339,8 +339,14 @@ spec:
       runAfter:
         - build-container
       taskRef:
-        name: ecosystem-cert-preflight-checks
-        version: "0.1"
+        params:
+        - name: name
+          value: ecosystem-cert-preflight-checks
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:8838d3e1628dbe61f4851b3640d2e3a9a3079d3ff3da955f4a3e4c2c95a013df
+        - name: kind
+          value: task
+        resolver: bundles
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)

--- a/.tekton/rhtas-operator-push.yaml
+++ b/.tekton/rhtas-operator-push.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: | 
+    pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" && target_branch == "main" && (".tekton/rhtas-operator-push.yaml".pathChanged() || "api/***".pathChanged() || "internal/***".pathChanged() || "Dockerfile.rhtas-operator.rh".pathChanged() || "go.mod".pathChanged() || "go.sum".pathChanged() || "cmd/***".pathChanged() || "trigger-konflux-builds.txt".pathChanged() )
     build.appstudio.openshift.io/build-nudge-files: "controllers/constants/*"
   creationTimestamp: null
@@ -331,6 +331,19 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+    - name: ecosystem-cert-preflight-checks
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values: ["false"]
+      runAfter:
+        - build-container
+      taskRef:
+        name: ecosystem-cert-preflight-checks
+        version: "0.1"
+      params:
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
     - name: clamav-scan
       params:
       - name: image-digest


### PR DESCRIPTION
Konflux does not have a way of introducing new tasks into our build pipelines automatically. Instead, we need to do these things manually. The image preflight checks are new as of a couple of months ago, and are now being added to all new components as they are onboarded. This commit brings the operator pipelines up to date with that addition. Apparently, it also removes a whitespace from the cel expression.