### PR TITLE
SECURESIGN-1250 | Targets are not coming up with monitoring enabled.

### DIFF
--- a/bundle/manifests/rhtas.redhat.com_rekors.yaml
+++ b/bundle/manifests/rhtas.redhat.com_rekors.yaml
@@ -150,6 +150,9 @@ spec:
                     x-kubernetes-validations:
                     - message: Feature cannot be disabled
                       rule: (self || !oldSelf)
+                  host:
+                    description: Set hostname for your Ingress/Route.
+                    type: string
                 required:
                 - enabled
                 type: object

--- a/bundle/manifests/rhtas.redhat.com_securesigns.yaml
+++ b/bundle/manifests/rhtas.redhat.com_securesigns.yaml
@@ -512,6 +512,9 @@ spec:
                         x-kubernetes-validations:
                         - message: Feature cannot be disabled
                           rule: (self || !oldSelf)
+                      host:
+                        description: Set hostname for your Ingress/Route.
+                        type: string
                     required:
                     - enabled
                     type: object

--- a/internal/clidownload/component.go
+++ b/internal/clidownload/component.go
@@ -58,7 +58,7 @@ func (c *Component) Start(ctx context.Context) error {
 
 	obj = append(obj, ns)
 	obj = append(obj, c.createDeployment(ns.Name, labels))
-	svc := kubernetes.CreateService(ns.Name, cliServerName, cliServerPortName, cliServerPort, labels)
+	svc := kubernetes.CreateService(ns.Name, cliServerName, cliServerPortName, cliServerPort, cliServerPort, labels)
 	obj = append(obj, svc)
 	ingress, err := kubernetes.CreateIngress(ctx, c.Client, *svc, rhtasv1alpha1.ExternalAccess{Host: CliHostName}, cliServerPortName, labels)
 	if err != nil {

--- a/internal/controller/common/utils/kubernetes/service.go
+++ b/internal/controller/common/utils/kubernetes/service.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func CreateService(namespace string, name string, portName string, port int, labels map[string]string) *corev1.Service {
+func CreateService(namespace string, name string, portName string, port int, targetPort int32, labels map[string]string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -26,7 +26,7 @@ func CreateService(namespace string, name string, portName string, port int, lab
 					Name:       portName,
 					Protocol:   corev1.ProtocolTCP,
 					Port:       int32(port),
-					TargetPort: intstr.FromInt(port),
+					TargetPort: intstr.FromInt32(targetPort),
 				},
 			},
 		},

--- a/internal/controller/ctlog/actions/constants.go
+++ b/internal/controller/ctlog/actions/constants.go
@@ -6,7 +6,10 @@ const (
 	RBACName           = "ctlog"
 	MonitoringRoleName = "prometheus-k8s-ctlog"
 
-	CertCondition   = "FulcioCertAvailable"
-	MetricsPortName = "metrics"
-	MetricsPort     = 6963
+	CertCondition    = "FulcioCertAvailable"
+	ServerPortName   = "http"
+	ServerPort       = 80
+	ServerTargetPort = 6962
+	MetricsPortName  = "metrics"
+	MetricsPort      = 6963
 )

--- a/internal/controller/ctlog/actions/deployment.go
+++ b/internal/controller/ctlog/actions/deployment.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"fmt"
+
 	cutils "github.com/securesign/operator/internal/controller/common/utils"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
@@ -39,17 +40,15 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 
 	labels := constants.LabelsFor(ComponentName, DeploymentName, instance.Name)
 
-	dp, err := utils.CreateDeployment(instance, DeploymentName, RBACName, labels)
+	dp, err := utils.CreateDeployment(instance, DeploymentName, RBACName, labels, ServerTargetPort, MetricsPort)
 	if err != nil {
-		if err != nil {
-			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-				Type:    constants.Ready,
-				Status:  metav1.ConditionFalse,
-				Reason:  constants.Failure,
-				Message: err.Error(),
-			})
-			return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could create server Deployment: %w", err), instance)
-		}
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:    constants.Ready,
+			Status:  metav1.ConditionFalse,
+			Reason:  constants.Failure,
+			Message: err.Error(),
+		})
+		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could create server Deployment: %w", err), instance)
 	}
 	err = cutils.SetTrustedCA(&dp.Spec.Template, cutils.TrustedCAAnnotationToReference(instance.Annotations))
 	if err != nil {

--- a/internal/controller/ctlog/actions/monitoring.go
+++ b/internal/controller/ctlog/actions/monitoring.go
@@ -100,7 +100,7 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CT
 		[]monitoringv1.Endpoint{
 			{
 				Interval: monitoringv1.Duration("30s"),
-				Port:     ComponentName,
+				Port:     MetricsPortName,
 				Scheme:   "http",
 			},
 		},

--- a/internal/controller/ctlog/actions/service.go
+++ b/internal/controller/ctlog/actions/service.go
@@ -40,13 +40,15 @@ func (i serviceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog
 
 	labels := constants.LabelsFor(ComponentName, ComponentName, instance.Name)
 
-	svc := kubernetes.CreateService(instance.Namespace, ComponentName, MetricsPortName, MetricsPort, labels)
-	svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
-		Name:       "80-tcp",
-		Protocol:   corev1.ProtocolTCP,
-		Port:       80,
-		TargetPort: intstr.FromInt32(6962),
-	})
+	svc := kubernetes.CreateService(instance.Namespace, ComponentName, ServerPortName, ServerPort, ServerTargetPort, labels)
+	if instance.Spec.Monitoring.Enabled {
+		svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+			Name:       MetricsPortName,
+			Protocol:   corev1.ProtocolTCP,
+			Port:       MetricsPort,
+			TargetPort: intstr.FromInt32(MetricsPort),
+		})
+	}
 	if err = controllerutil.SetControllerReference(instance, svc, i.Client.Scheme()); err != nil {
 		return i.Failed(fmt.Errorf("could not set controller reference for Service: %w", err))
 	}

--- a/internal/controller/ctlog/ctlog_controller_test.go
+++ b/internal/controller/ctlog/ctlog_controller_test.go
@@ -123,7 +123,7 @@ var _ = Describe("CTlog controller", func() {
 			}).Should(Equal(constants.Pending))
 
 			By("Creating trillian service")
-			Expect(k8sClient.Create(ctx, kubernetes.CreateService(Namespace, trillian.LogserverDeploymentName, trillian.ServerPortName, trillian.ServerPort, constants.LabelsForComponent(trillian.LogServerComponentName, instance.Name)))).To(Succeed())
+			Expect(k8sClient.Create(ctx, kubernetes.CreateService(Namespace, trillian.LogserverDeploymentName, trillian.ServerPortName, trillian.ServerPort, trillian.ServerPort, constants.LabelsForComponent(trillian.LogServerComponentName, instance.Name)))).To(Succeed())
 			Eventually(func(g Gomega) string {
 				found := &v1alpha1.CTlog{}
 				g.Expect(k8sClient.Get(ctx, typeNamespaceName, found)).Should(Succeed())
@@ -163,8 +163,7 @@ var _ = Describe("CTlog controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{Name: actions.ComponentName, Namespace: Namespace}, service)
 			}).Should(Succeed())
-			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(6963)))
-			Expect(service.Spec.Ports[1].Port).Should(Equal(int32(80)))
+			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(80)))
 
 			By("Move to Ready phase")
 			// Workaround to succeed condition for Ready phase

--- a/internal/controller/ctlog/ctlog_hot_update_test.go
+++ b/internal/controller/ctlog/ctlog_hot_update_test.go
@@ -111,7 +111,7 @@ var _ = Describe("CTlog update test", func() {
 			}).Should(Succeed())
 
 			By("Creating trillian service")
-			Expect(k8sClient.Create(ctx, kubernetes.CreateService(Namespace, trillian.LogserverDeploymentName, trillian.ServerPortName, trillian.ServerPort, constants.LabelsForComponent(trillian.LogServerComponentName, instance.Name)))).To(Succeed())
+			Expect(k8sClient.Create(ctx, kubernetes.CreateService(Namespace, trillian.LogserverDeploymentName, trillian.ServerPortName, trillian.ServerPort, trillian.ServerPort, constants.LabelsForComponent(trillian.LogServerComponentName, instance.Name)))).To(Succeed())
 
 			By("Creating fulcio root cert")
 			fulcioCa := kubernetes.CreateSecret("test", Namespace,

--- a/internal/controller/fulcio/actions/constants.go
+++ b/internal/controller/fulcio/actions/constants.go
@@ -9,6 +9,11 @@ const (
 
 	CertCondition = "FulcioCertAvailable"
 
-	PortName = "metrics"
-	Port     = 2112
+	ServerPortName   = "http"
+	ServerPort       = 80
+	TargetServerPort = 5555
+	GRPCPortName     = "grpc"
+	GRPCPort         = 5554
+	MetricsPortName  = "metrics"
+	MetricsPort      = 2112
 )

--- a/internal/controller/fulcio/actions/ingress.go
+++ b/internal/controller/fulcio/actions/ingress.go
@@ -43,7 +43,7 @@ func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulci
 		return i.Failed(fmt.Errorf("could not find service for ingress: %w", err))
 	}
 
-	ingress, err := kubernetes.CreateIngress(ctx, i.Client, *svc, instance.Spec.ExternalAccess, "80-tcp", labels)
+	ingress, err := kubernetes.CreateIngress(ctx, i.Client, *svc, instance.Spec.ExternalAccess, ServerPortName, labels)
 	if err != nil {
 		return i.Failed(fmt.Errorf("could not create ingress object: %w", err))
 	}

--- a/internal/controller/fulcio/actions/monitoring.go
+++ b/internal/controller/fulcio/actions/monitoring.go
@@ -100,7 +100,7 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fu
 		[]monitoringv1.Endpoint{
 			{
 				Interval: monitoringv1.Duration("30s"),
-				Port:     "fulcio-server",
+				Port:     MetricsPortName,
 				Scheme:   "http",
 			},
 		},

--- a/internal/controller/fulcio/fulcio_controller_test.go
+++ b/internal/controller/fulcio/fulcio_controller_test.go
@@ -209,9 +209,8 @@ var _ = Describe("Fulcio controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, service)
 			}).Should(Succeed())
-			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(2112)))
+			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(80)))
 			Expect(service.Spec.Ports[1].Port).Should(Equal(int32(5554)))
-			Expect(service.Spec.Ports[2].Port).Should(Equal(int32(80)))
 
 			By("Checking if Ingress was successfully created in the reconciliation")
 			ingress := &v1.Ingress{}
@@ -220,7 +219,7 @@ var _ = Describe("Fulcio controller", func() {
 			}).Should(Succeed())
 			Expect(ingress.Spec.Rules[0].Host).Should(Equal("fulcio.localhost"))
 			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name).Should(Equal(service.Name))
-			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).Should(Equal("80-tcp"))
+			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).Should(Equal(actions.ServerPortName))
 
 			By("Checking if controller will return deployment to desired state")
 			deployment = &appsv1.Deployment{}

--- a/internal/controller/fulcio/utils/fulcio_deployment.go
+++ b/internal/controller/fulcio/utils/fulcio_deployment.go
@@ -29,6 +29,24 @@ func CreateDeployment(instance *v1alpha1.Fulcio, deploymentName string, sa strin
 		return nil, errors.New("CA secret is not specified")
 	}
 
+	containerPorts := []corev1.ContainerPort{
+		{
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: 5555,
+		},
+		{
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: 5554,
+		},
+	}
+
+	if instance.Spec.Monitoring.Enabled {
+		containerPorts = append(containerPorts, corev1.ContainerPort{
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: 2112,
+		})
+	}
+
 	args := []string{
 		"serve",
 		"--port=5555",
@@ -95,20 +113,7 @@ func CreateDeployment(instance *v1alpha1.Fulcio, deploymentName string, sa strin
 							Image: constants.FulcioServerImage,
 							Args:  args,
 							Env:   env,
-							Ports: []corev1.ContainerPort{
-								{
-									Protocol:      corev1.ProtocolTCP,
-									ContainerPort: 5555,
-								},
-								{
-									Protocol:      corev1.ProtocolTCP,
-									ContainerPort: 5554,
-								},
-								{
-									Protocol:      corev1.ProtocolTCP,
-									ContainerPort: 2112,
-								},
-							},
+							Ports: containerPorts,
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/internal/controller/rekor/actions/constants.go
+++ b/internal/controller/rekor/actions/constants.go
@@ -2,8 +2,11 @@ package actions
 
 const (
 	ServerDeploymentName       = "rekor-server"
-	ServerDeploymentPortName   = "metrics"
-	ServerDeploymentPort       = 2112
+	ServerDeploymentPortName   = "http"
+	ServerDeploymentPort       = 80
+	ServerTargetDeploymentPort = 3000
+	MetricsPortName            = "metrics"
+	MetricsPort                = 2112
 	RedisDeploymentName        = "rekor-redis"
 	RedisDeploymentPortName    = "resp"
 	RedisDeploymentPort        = 6379

--- a/internal/controller/rekor/actions/redis/svc.go
+++ b/internal/controller/rekor/actions/redis/svc.go
@@ -40,7 +40,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 	)
 
 	labels := constants.LabelsFor(actions.RedisComponentName, actions.RedisDeploymentName, instance.Name)
-	svc := k8sutils.CreateService(instance.Namespace, actions.RedisDeploymentName, actions.RedisDeploymentPortName, actions.RedisDeploymentPort, labels)
+	svc := k8sutils.CreateService(instance.Namespace, actions.RedisDeploymentName, actions.RedisDeploymentPortName, actions.RedisDeploymentPort, actions.RedisDeploymentPort, labels)
 
 	if err = controllerutil.SetControllerReference(instance, svc, i.Client.Scheme()); err != nil {
 		return i.Failed(fmt.Errorf("could not set controller reference for Redis service: %w", err))

--- a/internal/controller/rekor/actions/server/ingress.go
+++ b/internal/controller/rekor/actions/server/ingress.go
@@ -44,7 +44,7 @@ func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor
 		return i.Failed(fmt.Errorf("could not find service for ingress: %w", err))
 	}
 
-	ingress, err := kubernetes.CreateIngress(ctx, i.Client, *svc, instance.Spec.ExternalAccess, "80-tcp", labels)
+	ingress, err := kubernetes.CreateIngress(ctx, i.Client, *svc, instance.Spec.ExternalAccess, actions.ServerDeploymentPortName, labels)
 	if err != nil {
 		return i.Failed(fmt.Errorf("could not create ingress object: %w", err))
 	}

--- a/internal/controller/rekor/actions/server/monitoring.go
+++ b/internal/controller/rekor/actions/server/monitoring.go
@@ -113,7 +113,7 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 		[]monitoringv1.Endpoint{
 			{
 				Interval: monitoringv1.Duration("30s"),
-				Port:     "rekor-server",
+				Port:     actions.MetricsPortName,
 				Scheme:   "http",
 			},
 		},

--- a/internal/controller/rekor/actions/ui/svc.go
+++ b/internal/controller/rekor/actions/ui/svc.go
@@ -41,7 +41,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 	)
 
 	labels := constants.LabelsFor(actions.UIComponentName, actions.SearchUiDeploymentName, instance.Name)
-	svc := k8sutils.CreateService(instance.Namespace, actions.SearchUiDeploymentName, actions.SearchUiDeploymentPortName, actions.SearchUiDeploymentPort, labels)
+	svc := k8sutils.CreateService(instance.Namespace, actions.SearchUiDeploymentName, actions.SearchUiDeploymentPortName, actions.SearchUiDeploymentPort, actions.SearchUiDeploymentPort, labels)
 	svc.Spec.Ports[0].Port = 80
 
 	if err = controllerutil.SetControllerReference(instance, svc, i.Client.Scheme()); err != nil {

--- a/internal/controller/rekor/utils/rekor_deployment.go
+++ b/internal/controller/rekor/utils/rekor_deployment.go
@@ -71,6 +71,20 @@ func CreateRekorDeployment(instance *v1alpha1.Rekor, dpName string, sa string, l
 		},
 	}
 
+	containerPorts := []core.ContainerPort{
+		{
+			ContainerPort: 3000,
+			Name:          "rekor-server",
+		},
+	}
+
+	if instance.Spec.Monitoring.Enabled {
+		containerPorts = append(containerPorts, core.ContainerPort{
+			ContainerPort: 2112,
+			Protocol:      "TCP",
+		})
+	}
+
 	// KMS memory
 	if instance.Spec.Signer.KMS == "memory" {
 		appArgs = append(appArgs, "--rekor_server.signer=memory")
@@ -145,18 +159,9 @@ func CreateRekorDeployment(instance *v1alpha1.Rekor, dpName string, sa string, l
 					Volumes:            volumes,
 					Containers: []core.Container{
 						{
-							Name:  dpName,
-							Image: constants.RekorServerImage,
-							Ports: []core.ContainerPort{
-								{
-									ContainerPort: 3000,
-									Name:          "rekor-server",
-								},
-								{
-									ContainerPort: 2112,
-									Protocol:      "TCP",
-								},
-							},
+							Name:         dpName,
+							Image:        constants.RekorServerImage,
+							Ports:        containerPorts,
 							Env:          env,
 							Args:         appArgs,
 							VolumeMounts: volumeMounts,

--- a/internal/controller/trillian/actions/constants.go
+++ b/internal/controller/trillian/actions/constants.go
@@ -18,8 +18,8 @@ const (
 	ServerCondition = "LogServerAvailable"
 	SignerCondition = "LogSignerAvailable"
 
-	ServerPort         = 8091
-	ServerPortName     = "grpc"
-	MonitoringPort     = 8090
-	MonitoringPortName = "metrics"
+	ServerPort      = 8091
+	ServerPortName  = "grpc"
+	MetricsPort     = 8090
+	MetricsPortName = "metrics"
 )

--- a/internal/controller/trillian/actions/db/svc.go
+++ b/internal/controller/trillian/actions/db/svc.go
@@ -42,7 +42,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 	)
 
 	labels := constants.LabelsFor(actions.DbComponentName, actions.DbDeploymentName, instance.Name)
-	mysql := k8sutils.CreateService(instance.Namespace, host, host, port, labels)
+	mysql := k8sutils.CreateService(instance.Namespace, host, host, port, port, labels)
 
 	if err = controllerutil.SetControllerReference(instance, mysql, i.Client.Scheme()); err != nil {
 		return i.Failed(fmt.Errorf("could not set controller reference for DB service: %w", err))

--- a/internal/controller/trillian/actions/logserver/deployment.go
+++ b/internal/controller/trillian/actions/logserver/deployment.go
@@ -3,6 +3,7 @@ package logserver
 import (
 	"context"
 	"fmt"
+
 	"github.com/securesign/operator/internal/controller/common/utils"
 
 	"github.com/securesign/operator/internal/controller/common/action"
@@ -14,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const serverPort = 8091
@@ -43,14 +43,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trilli
 	)
 
 	labels := constants.LabelsFor(actions.LogServerComponentName, actions.LogserverDeploymentName, instance.Name)
-	server, err := trillianUtils.CreateTrillDeployment(instance, constants.TrillianServerImage,
-		actions.LogserverDeploymentName,
-		actions.RBACName,
-		labels)
-	server.Spec.Template.Spec.Containers[0].Ports = append(server.Spec.Template.Spec.Containers[0].Ports, corev1.ContainerPort{
-		Protocol:      corev1.ProtocolTCP,
-		ContainerPort: 8090,
-	})
+	server, err := trillianUtils.CreateTrillDeployment(instance, constants.TrillianServerImage, actions.LogserverDeploymentName, actions.RBACName, labels)
 	err = utils.SetTrustedCA(&server.Spec.Template, utils.TrustedCAAnnotationToReference(instance.Annotations))
 	if err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{

--- a/internal/controller/trillian/actions/logserver/monitoring.go
+++ b/internal/controller/trillian/actions/logserver/monitoring.go
@@ -112,7 +112,7 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tr
 		[]monitoringv1.Endpoint{
 			{
 				Interval: monitoringv1.Duration("30s"),
-				Port:     actions.LogServerMonitoringName,
+				Port:     actions.MetricsPortName,
 				Scheme:   "http",
 			},
 		},

--- a/internal/controller/trillian/actions/logserver/service.go
+++ b/internal/controller/trillian/actions/logserver/service.go
@@ -42,14 +42,14 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 	)
 
 	labels := constants.LabelsFor(actions.LogServerComponentName, actions.LogserverDeploymentName, instance.Name)
-	logserverService := k8sutils.CreateService(instance.Namespace, actions.LogserverDeploymentName, actions.ServerPortName, actions.ServerPort, labels)
+	logserverService := k8sutils.CreateService(instance.Namespace, actions.LogserverDeploymentName, actions.ServerPortName, actions.ServerPort, actions.ServerPort, labels)
 
 	if instance.Spec.Monitoring.Enabled {
 		logserverService.Spec.Ports = append(logserverService.Spec.Ports, corev1.ServicePort{
-			Name:       actions.LogServerMonitoringName,
+			Name:       actions.MetricsPortName,
 			Protocol:   corev1.ProtocolTCP,
-			Port:       int32(actions.MonitoringPort),
-			TargetPort: intstr.FromInt(actions.MonitoringPort),
+			Port:       int32(actions.MetricsPort),
+			TargetPort: intstr.FromInt32(actions.MetricsPort),
 		})
 	}
 

--- a/internal/controller/trillian/actions/logsigner/deployment.go
+++ b/internal/controller/trillian/actions/logsigner/deployment.go
@@ -40,10 +40,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trilli
 	)
 
 	labels := constants.LabelsFor(actions.LogSignerComponentName, actions.LogsignerDeploymentName, instance.Name)
-	signer, err := trillianUtils.CreateTrillDeployment(instance, constants.TrillianLogSignerImage,
-		actions.LogsignerDeploymentName,
-		actions.RBACName,
-		labels)
+	signer, err := trillianUtils.CreateTrillDeployment(instance, constants.TrillianLogSignerImage, actions.LogsignerDeploymentName, actions.RBACName, labels)
 	signer.Spec.Template.Spec.Containers[0].Args = append(signer.Spec.Template.Spec.Containers[0].Args, "--force_master=true")
 	err = utils.SetTrustedCA(&signer.Spec.Template, utils.TrustedCAAnnotationToReference(instance.Annotations))
 	if err != nil {

--- a/internal/controller/trillian/actions/logsigner/monitoring.go
+++ b/internal/controller/trillian/actions/logsigner/monitoring.go
@@ -112,7 +112,7 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tr
 		[]monitoringv1.Endpoint{
 			{
 				Interval: monitoringv1.Duration("30s"),
-				Port:     actions.LogSignerComponentName,
+				Port:     actions.MetricsPortName,
 				Scheme:   "http",
 			},
 		},

--- a/internal/controller/tuf/actions/servise.go
+++ b/internal/controller/tuf/actions/servise.go
@@ -38,7 +38,7 @@ func (i serviceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tuf) 
 
 	labels := constants.LabelsFor(ComponentName, DeploymentName, instance.Name)
 
-	svc := kubernetes.CreateService(instance.Namespace, DeploymentName, PortName, Port, labels)
+	svc := kubernetes.CreateService(instance.Namespace, DeploymentName, PortName, Port, Port, labels)
 	//patch the pregenerated service
 	svc.Spec.Ports[0].Port = instance.Spec.Port
 	if err = controllerutil.SetControllerReference(instance, svc, i.Client.Scheme()); err != nil {


### PR DESCRIPTION
Pr to fix the issue where service monitor targets are not coming up, caused by a change in the naming for the service ports.