### PR TITLE
SECURESIGN-842 | Operator's metrics are not consumed by OCP monitor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,12 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
           kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
 
+      - name: Install prometheus
+        run: |
+          LATEST=$(curl -s https://api.github.com/repos/prometheus-operator/prometheus-operator/releases/latest | jq -cr .tag_name)
+          curl -sL https://github.com/prometheus-operator/prometheus-operator/releases/download/${LATEST}/bundle.yaml | kubectl create -f -
+          kubectl wait --for=condition=Ready pods -l  app.kubernetes.io/name=prometheus-operator -n default
+
       - name: Deploy operator container
         env:
           OPENSHIFT: false
@@ -246,6 +252,11 @@ jobs:
         run: |
           kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
           kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
+
+          #install Prometheus
+          LATEST=$(curl -s https://api.github.com/repos/prometheus-operator/prometheus-operator/releases/latest | jq -cr .tag_name)
+          curl -sL https://github.com/prometheus-operator/prometheus-operator/releases/download/${LATEST}/bundle.yaml | kubectl create -f -
+          kubectl wait --for=condition=Ready pods -l  app.kubernetes.io/name=prometheus-operator -n default
 
           #install OLM
           kubectl create -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.25.0/crds.yaml

--- a/bundle/manifests/rhtas-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/rhtas-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: operator-controller-manager
+  name: rhtas-controller-manager-metrics-service
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+  selector:
+    control-plane: operator-controller-manage
+status:
+  loadBalancer: {}

--- a/bundle/manifests/rhtas-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/rhtas-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/created-by: rhtas-operator
+    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: servicemonitor
+    app.kubernetes.io/part-of: rhtas-operator
+    control-plane: operator-controller-manager
+  name: rhtas-operator-controller-manager-metrics-monitor
+spec:
+  endpoints:
+  - path: /metrics
+    port: metrics
+  selector:
+    matchLabels:
+      control-plane: operator-controller-manager

--- a/bundle/manifests/rhtas-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/rhtas-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: operator-controller-manager
+  name: rhtas-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+  selector:
+    control-plane: operator-controller-manager
+status:
+  loadBalancer: {}

--- a/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
@@ -854,7 +854,7 @@ spec:
             spec:
               containers:
               - args:
-                - --leader-elect
+                - --metrics-bind-address=0.0.0.0:8080
                 command:
                 - /manager
                 env:
@@ -868,6 +868,9 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 8080
+                  name: metrics
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
@@ -854,6 +854,7 @@ spec:
             spec:
               containers:
               - args:
+                - --leader-elect
                 - --metrics-bind-address=0.0.0.0:8080
                 command:
                 - /manager

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,10 +25,14 @@ resources:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patches:
   - path: manager_openshift_patch.yaml
+    target:
+      kind: Deployment
+      name: operator-controller-manager
+  - path: manager_metrics_patch.yaml
     target:
       kind: Deployment
       name: operator-controller-manager

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,0 +1,16 @@
+# This patch exposes metrics endpoint in plain HTTP 8080 port
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  operator-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--metrics-bind-address=0.0.0.0:8080"
+        ports:
+        - containerPort: 8080
+          name: metrics

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -10,6 +10,7 @@ spec:
       containers:
       - name: manager
         args:
+        - "--leader-elect"
         - "--metrics-bind-address=0.0.0.0:8080"
         ports:
         - containerPort: 8080

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- metrics_service.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/manager/metrics_service.yaml
+++ b/config/manager/metrics_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: operator-controller-manager
+  name: operator-controller-manager-metrics-service
+spec:
+  ports:
+    - name: metrics
+      port: 8080
+      targetPort: metrics
+  selector:
+      control-plane: operator-controller-manager

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -16,11 +16,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: https
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
+      port: metrics
   selector:
     matchLabels:
       control-plane: operator-controller-manager


### PR DESCRIPTION
# Testing 
To test this, you just need to build and deploy the operator, you should see a new target being created under `Observe -> Targets` called `rhtas-operator-controller-manager-metrics-monitor`, you should then be able to query the metrics of the operator.
