### PR TITLE
chore: patch-tsa-upgrade-test

### DIFF
--- a/test/e2e/byodb_test.go
+++ b/test/e2e/byodb_test.go
@@ -164,8 +164,10 @@ var _ = Describe("Securesign install with byodb", Ordered, func() {
 
 			tsa := tas.GetTSA(ctx, cli, namespace.Name, securesign.Name)()
 			Expect(tsa).ToNot(BeNil())
-			err := tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
-			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() error {
+				return tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
+			}).Should(Succeed())
 
 			oidcToken, err := support.OidcToken(ctx)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/common_install_test.go
+++ b/test/e2e/common_install_test.go
@@ -307,8 +307,10 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 
 			tsa := tas.GetTSA(ctx, cli, namespace.Name, securesign.Name)()
 			Expect(tsa).ToNot(BeNil())
-			err := tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
-			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() error {
+				return tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
+			}).Should(Succeed())
 
 			oidcToken, err := support.OidcToken(ctx)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/config_update_test.go
+++ b/test/e2e/config_update_test.go
@@ -542,8 +542,10 @@ var _ = Describe("Securesign hot update", Ordered, func() {
 
 		tsa := tas.GetTSA(ctx, cli, namespace.Name, securesign.Name)()
 		Expect(tsa).ToNot(BeNil())
-		err := tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
-		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() error {
+			return tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
+		}).Should(Succeed())
 
 		oidcToken, err := support.OidcToken(ctx)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/key_autodiscovery_test.go
+++ b/test/e2e/key_autodiscovery_test.go
@@ -235,8 +235,10 @@ var _ = Describe("Securesign key autodiscovery test", Ordered, func() {
 
 			tsa := tas.GetTSA(ctx, cli, namespace.Name, securesign.Name)()
 			Expect(tsa).ToNot(BeNil())
-			err := tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
-			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() error {
+				return tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
+			}).Should(Succeed())
 
 			oidcToken, err := support.OidcToken(ctx)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/provided_certs_test.go
+++ b/test/e2e/provided_certs_test.go
@@ -289,8 +289,10 @@ var _ = Describe("Securesign install with provided certs", Ordered, func() {
 
 			tsa := tas.GetTSA(ctx, cli, namespace.Name, securesign.Name)()
 			Expect(tsa).ToNot(BeNil())
-			err := tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
-			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() error {
+				return tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
+			}).Should(Succeed())
 
 			oidcToken, err := support.OidcToken(ctx)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/support/tas/tsa.go
+++ b/test/e2e/support/tas/tsa.go
@@ -54,14 +54,19 @@ func GetTSA(ctx context.Context, cli client.Client, ns string, name string) func
 }
 
 func GetTSACertificateChain(ctx context.Context, cli client.Client, ns string, name string, url string) error {
+	var resp *http.Response
+	var err error
 	req, err := http.NewRequestWithContext(ctx, "GET", url+"/api/v1/timestamp/certchain", nil)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to perform HTTP request: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected HTTP status: %s", resp.Status)
 	}
 
 	defer func() {
@@ -69,10 +74,6 @@ func GetTSACertificateChain(ctx context.Context, cli client.Client, ns string, n
 			fmt.Println("Error closing response body:", closeErr)
 		}
 	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected HTTP status: %s", resp.Status)
-	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -492,8 +492,10 @@ var _ = Describe("Operator upgrade", Ordered, func() {
 		tsa := tas.GetTSA(ctx, cli, namespace.Name, securesign.Name)()
 
 		gomega.Expect(tsa).ToNot(gomega.BeNil())
-		err := tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+		gomega.Eventually(func() error {
+			return tas.GetTSACertificateChain(ctx, cli, tsa.Namespace, tsa.Name, tsa.Status.Url)
+		}).Should(gomega.Succeed())
 
 		gomega.Expect(clients.Execute("cosign", "initialize", "--mirror="+rtuf.Status.Url, "--root="+rtuf.Status.Url+"/root.json")).To(gomega.Succeed())
 


### PR DESCRIPTION
Small fix the upgrade test, adds a retry to the GetTSACertificateChain() func 