### PR TITLE
fix(rekor): create new secret only for generated signer key

### DIFF
--- a/internal/controller/common/utils/kubernetes/deployment.go
+++ b/internal/controller/common/utils/kubernetes/deployment.go
@@ -7,6 +7,7 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -14,7 +15,12 @@ var (
 	ErrDeploymentNotReady        = errors.New("deployment not ready")
 	ErrDeploymentNotObserved     = errors.New("not observed")
 	ErrDeploymentNotAvailable    = errors.New("not available")
+	ErrDeploymentNotFound        = errors.New("not found")
 	ErrNewReplicaSetNotAvailable = errors.New("new ReplicaSet not available")
+)
+
+var (
+	log = ctrl.Log.WithName("deployment")
 )
 
 func DeploymentIsRunning(ctx context.Context, cli client.Client, namespace string, labels map[string]string) (bool, error) {
@@ -24,14 +30,25 @@ func DeploymentIsRunning(ctx context.Context, cli client.Client, namespace strin
 	if err = cli.List(ctx, list, client.InNamespace(namespace), client.MatchingLabels(labels)); err != nil {
 		return false, err
 	}
+
+	if len(list.Items) == 0 {
+		return false, fmt.Errorf("%w: %w: with labels %v", ErrDeploymentNotReady, ErrDeploymentNotFound, labels)
+	}
+
 	for _, d := range list.Items {
+		log.V(2).WithValues(
+			"namespace", d.Namespace, "name",
+			d.Name, "generation", d.Generation,
+			"observed", d.Status.ObservedGeneration,
+			"conditions", d.Status.Conditions,
+		).Info("state")
 
 		if d.Generation != d.Status.ObservedGeneration {
 			return false, fmt.Errorf("%w(%s): %w: generation %d", ErrDeploymentNotReady, d.Name, ErrDeploymentNotObserved, d.Generation)
 		}
 
 		c := getDeploymentCondition(d.Status, v1.DeploymentAvailable)
-		if c == nil || c.Status == corev1.ConditionFalse {
+		if c == nil || c.Status != corev1.ConditionTrue {
 			return false, fmt.Errorf("%w(%s): %w", ErrDeploymentNotReady, d.Name, ErrDeploymentNotAvailable)
 		}
 

--- a/internal/controller/rekor/actions/server/generate_signer_test.go
+++ b/internal/controller/rekor/actions/server/generate_signer_test.go
@@ -1,0 +1,429 @@
+package server
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	"github.com/securesign/operator/internal/controller/common/action"
+	"github.com/securesign/operator/internal/controller/rekor/actions"
+
+	"reflect"
+	"testing"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/controller/constants"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGenerateSigner_CanHandle(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       []metav1.Condition
+		canHandle    bool
+		signer       rhtasv1alpha1.RekorSigner
+		statusSigner rhtasv1alpha1.RekorSigner
+	}{
+		{
+			name: "spec.signer.keyRef is not nil and status.signer.keyRef is nil",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: true,
+			signer: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+			},
+		},
+		{
+			name: "spec.signer.keyRef is nil and status.signer.keyRef is not nil",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: false,
+			statusSigner: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+			},
+		},
+		{
+			name: "spec.signer.keyRef is nil and status.signer.keyRef is nil",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: true,
+		},
+		{
+			name: "spec.signer.keyRef != status.signer.keyRef",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: true,
+			signer: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new_secret"}, Key: "private"},
+			},
+			statusSigner: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "old_secret"}, Key: "private"},
+			},
+		},
+		{
+			name: "spec.signer.keyRef == status.signer.keyRef",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: false,
+			signer: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+			},
+			statusSigner: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+			},
+		},
+		{
+			name: "spec.signer.passwordRef == status.signer.passwordRef",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: false,
+			signer: rhtasv1alpha1.RekorSigner{
+				KeyRef:      &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+				PasswordRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "password"},
+			},
+			statusSigner: rhtasv1alpha1.RekorSigner{
+				KeyRef:      &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+				PasswordRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "password"},
+			},
+		},
+		{
+			name: "spec.signer.passwordRef != status.signer.passwordRef",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: true, signer: rhtasv1alpha1.RekorSigner{
+				KeyRef:      &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new_secret"}, Key: "private"},
+				PasswordRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new_secret"}, Key: "password"},
+			},
+			statusSigner: rhtasv1alpha1.RekorSigner{
+				KeyRef:      &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "old_secret"}, Key: "private"},
+				PasswordRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "old_secret"}, Key: "password"},
+			},
+		},
+		{
+			name: "spec.signer.kms != status.signer.kms",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: true,
+			signer: rhtasv1alpha1.RekorSigner{
+				KMS: "azurekeyvault://mykeyvaultname.vault.azure.net/keys/mykeyname",
+			},
+			statusSigner: rhtasv1alpha1.RekorSigner{
+				KMS: "awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1",
+			},
+		},
+		{
+			name: "spec.signer.kms == status.signer.kms",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: false,
+			signer: rhtasv1alpha1.RekorSigner{
+				KMS: "awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1",
+			},
+			statusSigner: rhtasv1alpha1.RekorSigner{
+				KMS: "awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1",
+			},
+		},
+		{
+			name:      "no phase condition",
+			status:    []metav1.Condition{},
+			canHandle: true,
+		},
+		{
+			name: "ConditionFalse",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionFalse,
+					Reason: constants.Pending,
+				},
+			},
+			canHandle: true,
+		},
+		{
+			name: "ConditionTrue",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionTrue,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: false,
+			signer: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+			},
+			statusSigner: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+			},
+		},
+		{
+			name: "ConditionUnknown",
+			status: []metav1.Condition{
+				{
+					Type:   actions.SignerCondition,
+					Status: metav1.ConditionUnknown,
+					Reason: constants.Ready,
+				},
+			},
+			canHandle: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := testAction.FakeClientBuilder().Build()
+			a := testAction.PrepareAction(c, NewGenerateSignerAction())
+			instance := rhtasv1alpha1.Rekor{
+				Spec: rhtasv1alpha1.RekorSpec{
+					Signer: tt.signer,
+				},
+				Status: rhtasv1alpha1.RekorStatus{
+					Signer: tt.statusSigner,
+				},
+			}
+			for _, status := range tt.status {
+				meta.SetStatusCondition(&instance.Status.Conditions, status)
+			}
+
+			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
+			}
+		})
+	}
+}
+
+func TestGenerateSigner_Handle(t *testing.T) {
+	g := NewWithT(t)
+	type env struct {
+		spec   rhtasv1alpha1.RekorSigner
+		status rhtasv1alpha1.RekorSigner
+	}
+	type want struct {
+		result *action.Result
+		verify func(Gomega, *rhtasv1alpha1.Rekor)
+	}
+	tests := []struct {
+		name string
+		env  env
+		want want
+	}{
+		{
+			name: "use spec.signer.keyRef",
+			env: env{
+				spec: rhtasv1alpha1.RekorSigner{
+					KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+				},
+				status: rhtasv1alpha1.RekorSigner{},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
+					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Signer.KeyRef.Name).Should(Equal("secret"))
+					g.Expect(instance.Status.Signer.KeyRef.Key).Should(Equal("private"))
+
+					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).Should(BeTrue())
+					g.Expect(meta.IsStatusConditionFalse(instance.Status.Conditions, actions.ServerCondition)).Should(BeTrue())
+				},
+			},
+		},
+		{
+			name: "generate signer key",
+			env: env{
+				spec:   rhtasv1alpha1.RekorSigner{},
+				status: rhtasv1alpha1.RekorSigner{},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
+					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Signer.KeyRef.Name).Should(ContainSubstring("rekor-signer-rekor-"))
+
+					g.Expect(instance.Status.Signer.PasswordRef).Should(BeNil())
+
+					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).Should(BeTrue())
+					g.Expect(meta.IsStatusConditionFalse(instance.Status.Conditions, actions.ServerCondition)).Should(BeTrue())
+				},
+			},
+		},
+		{
+			name: "replace status.signer.keyRef from spec",
+			env: env{
+				spec: rhtasv1alpha1.RekorSigner{
+					KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new_secret"}, Key: "private"},
+				},
+				status: rhtasv1alpha1.RekorSigner{
+					KeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "old_secret"}, Key: "private"},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
+					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Signer.KeyRef.Name).Should(Equal("new_secret"))
+
+					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).Should(BeTrue())
+					g.Expect(meta.IsStatusConditionFalse(instance.Status.Conditions, actions.ServerCondition)).Should(BeTrue())
+				},
+			},
+		},
+		{
+			name: "use spec.signer.KMS",
+			env: env{
+				spec: rhtasv1alpha1.RekorSigner{
+					KMS: "awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1",
+				},
+				status: rhtasv1alpha1.RekorSigner{},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
+					g.Expect(instance.Status.Signer.KMS).ShouldNot(BeNil())
+					g.Expect(instance.Status.Signer.KMS).Should(Equal("awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1"))
+
+					g.Expect(instance.Status.Signer.KeyRef).Should(BeNil())
+					g.Expect(instance.Status.Signer.PasswordRef).Should(BeNil())
+
+					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).Should(BeTrue())
+					g.Expect(meta.IsStatusConditionFalse(instance.Status.Conditions, actions.ServerCondition)).Should(BeTrue())
+				},
+			},
+		},
+		{
+			name: "replace status.signer.KMS from spec",
+			env: env{
+				spec: rhtasv1alpha1.RekorSigner{
+					KMS: "new-kms",
+				},
+				status: rhtasv1alpha1.RekorSigner{
+					KMS: "old-kms",
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
+					g.Expect(instance.Status.Signer.KMS).ShouldNot(BeNil())
+					g.Expect(instance.Status.Signer.KMS).Should(Equal("new-kms"))
+
+					g.Expect(instance.Status.Signer.KeyRef).Should(BeNil())
+					g.Expect(instance.Status.Signer.PasswordRef).Should(BeNil())
+
+					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).Should(BeTrue())
+					g.Expect(meta.IsStatusConditionFalse(instance.Status.Conditions, actions.ServerCondition)).Should(BeTrue())
+				},
+			},
+		},
+		{
+			name: "spec with encrypted private key",
+			env: env{
+				spec: rhtasv1alpha1.RekorSigner{
+					KeyRef:      &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+					PasswordRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "password"},
+				},
+				status: rhtasv1alpha1.RekorSigner{},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
+					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Signer.KeyRef.Name).Should(Equal("secret"))
+					g.Expect(instance.Status.Signer.KeyRef.Key).Should(Equal("private"))
+
+					g.Expect(instance.Status.Signer.PasswordRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Signer.PasswordRef.Name).Should(Equal("secret"))
+					g.Expect(instance.Status.Signer.PasswordRef.Key).Should(Equal("password"))
+
+					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).Should(BeTrue())
+					g.Expect(meta.IsStatusConditionFalse(instance.Status.Conditions, actions.ServerCondition)).Should(BeTrue())
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			instance := &rhtasv1alpha1.Rekor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rekor",
+					Namespace: "default",
+				},
+				Spec: rhtasv1alpha1.RekorSpec{
+					Signer: tt.env.spec,
+				},
+				Status: rhtasv1alpha1.RekorStatus{
+					Signer: tt.env.status,
+				},
+			}
+
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:   constants.Ready,
+				Reason: constants.Pending,
+			})
+
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:   actions.SignerCondition,
+				Status: metav1.ConditionFalse,
+				Reason: constants.Pending,
+			})
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				Build()
+
+			a := testAction.PrepareAction(c, NewGenerateSignerAction())
+
+			if got := a.Handle(ctx, instance); !reflect.DeepEqual(got, tt.want.result) {
+				t.Errorf("CanHandle() = %v, want %v", got, tt.want.result)
+			}
+			if tt.want.verify != nil {
+				tt.want.verify(g, instance)
+			}
+		})
+	}
+}

--- a/test/e2e/config_update_test.go
+++ b/test/e2e/config_update_test.go
@@ -312,7 +312,7 @@ var _ = Describe("Securesign hot update", Ordered, func() {
 			Eventually(func() string {
 				rekor := tas.GetRekor(ctx, cli, namespace.Name, securesign.Name)()
 				return meta.FindStatusCondition(rekor.Status.Conditions, constants.Ready).Reason
-			}).Should(Equal(constants.Pending))
+			}).Should(Equal(constants.Initialize))
 
 			Expect(cli.Create(ctx, support.InitRekorSecret(namespace.Name, "my-rekor-secret"))).To(Succeed())
 


### PR DESCRIPTION
It fixes:
1. create new immutable secret only for generated signer key
2. identify changes in spec.signer.kms and apply them
3. ignore privateKey if kms is not empty 
4. simplify generation function signer key, because it will newer generate key by password