### PR TITLE
fix: Make sure SBJ installation runs only once

### DIFF
--- a/internal/controller/securesign/actions/constants.go
+++ b/internal/controller/securesign/actions/constants.go
@@ -7,6 +7,7 @@ const (
 	RekorCondition           = "RekorAvailable"
 	TrillianCondition        = "TrillianAvailable"
 	CTlogCondition           = "CTlogAvailable"
+	SBJCondition             = "SBJCondition"
 	SegmentBackupCronJobName = "segment-backup-nightly-metrics"
 	SegmentBackupJobName     = "segment-backup-installation"
 	SegmentRBACName          = "rhtas-segment-backup-job"

--- a/internal/controller/securesign/actions/initialize_status.go
+++ b/internal/controller/securesign/actions/initialize_status.go
@@ -27,7 +27,7 @@ func (i initializeStatus) CanHandle(_ context.Context, instance *rhtasv1alpha1.S
 }
 
 func (i initializeStatus) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesign) *action.Result {
-	for _, conditionType := range []string{constants.Ready, TrillianCondition, FulcioCondition, RekorCondition, CTlogCondition, TufCondition, TSACondition} {
+	for _, conditionType := range []string{constants.Ready, TrillianCondition, FulcioCondition, RekorCondition, CTlogCondition, TufCondition, TSACondition, SBJCondition} {
 		meta.SetStatusCondition(&instance.Status.Conditions, v1.Condition{
 			Type:   conditionType,
 			Status: v1.ConditionUnknown,


### PR DESCRIPTION
Small bug fix, I noticed sometimes SBJ would run twice on re-installation, as in two jobs would run at the same time, this negates the issue 