### PR TITLE
doc(ctlog): update treeID in key rotation patch

### DIFF
--- a/docs/ctlog-key-rotation.md
+++ b/docs/ctlog-key-rotation.md
@@ -159,6 +159,11 @@ read -r -d '' SECURESIGN_PATCH <<EOF
     },
     {
         "op": "replace",
+        "path": "/spec/ctlog/treeID",
+        "value": $NEW_TREE_ID
+    },
+    {
+        "op": "replace",
         "path": "/spec/ctlog/privateKeyRef",
         "value": {"name": "ctlog-config", "key": "private"}
     },


### PR DESCRIPTION
related to [SECURESIGN-662](https://issues.redhat.com//browse/SECURESIGN-662)