### PR TITLE
SECURESIGN-1362 | Trillian failing to start after upgrade

### DIFF
--- a/internal/controller/annotations/annotations.go
+++ b/internal/controller/annotations/annotations.go
@@ -12,10 +12,17 @@ const (
 
 	// TreeId Annotation inform that resource is associated with specific Merkle Tree
 	TreeId = "rhtas.redhat.com/treeId"
+
+	// TLS annotation
+	TLS = "service.beta.openshift.io/serving-cert-secret-name"
 )
 
 var inheritable = []string{
 	TrustedCA,
+}
+
+var managed = []string{
+	TLS,
 }
 
 func FilterInheritable(annotations map[string]string) map[string]string {
@@ -23,6 +30,18 @@ func FilterInheritable(annotations map[string]string) map[string]string {
 	for key, value := range annotations {
 		for _, ia := range inheritable {
 			if key == ia {
+				result[key] = value
+			}
+		}
+	}
+	return result
+}
+
+func FilterManaged(annotations map[string]string) map[string]string {
+	result := make(map[string]string, 0)
+	for key, value := range annotations {
+		for _, ma := range managed {
+			if key == ma {
 				result[key] = value
 			}
 		}

--- a/internal/controller/trillian/actions/db/svc.go
+++ b/internal/controller/trillian/actions/db/svc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/securesign/operator/internal/controller/annotations"
 	"github.com/securesign/operator/internal/controller/common/utils"
 
 	"github.com/securesign/operator/internal/controller/common/action"
@@ -49,7 +50,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 		if mysql.Annotations == nil {
 			mysql.Annotations = make(map[string]string)
 		}
-		mysql.Annotations["service.beta.openshift.io/serving-cert-secret-name"] = instance.Name + "-trillian-db-tls"
+		mysql.Annotations[annotations.TLS] = instance.Name + "-trillian-db-tls"
 	}
 
 	if err = controllerutil.SetControllerReference(instance, mysql, i.Client.Scheme()); err != nil {

--- a/test/e2e/byodb_test.go
+++ b/test/e2e/byodb_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/controller/annotations"
 	"github.com/securesign/operator/internal/controller/common/utils"
 	"github.com/securesign/operator/internal/controller/common/utils/kubernetes"
 	"github.com/securesign/operator/internal/controller/constants"
@@ -178,7 +179,7 @@ func createDB(ctx context.Context, cli runtimeCli.Client, ns string, secretRef s
 		if mysql.Annotations == nil {
 			mysql.Annotations = make(map[string]string)
 		}
-		mysql.Annotations["service.beta.openshift.io/serving-cert-secret-name"] = "my-trillian-db-tls-secret"
+		mysql.Annotations[annotations.TLS] = "my-trillian-db-tls-secret"
 	}
 	err := cli.Create(ctx, mysql)
 	if err != nil {


### PR DESCRIPTION
The main cause for trillian not starting after upgrade was because the existing service was missing the 'service.beta.openshift.io/serving-cert-secret-name' annotation meaning the secrets for TLS communication were not being created.

