### PR TITLE
fix: recreate ctlog config when spec has changed

### DIFF
--- a/internal/controller/ctlog/actions/handle_fulcio_root.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root.go
@@ -59,9 +59,10 @@ func (g handleFulcioCert) Handle(ctx context.Context, instance *v1alpha1.CTlog) 
 
 	if meta.FindStatusCondition(instance.Status.Conditions, constants.Ready).Reason != constants.Creating {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:   constants.Ready,
-			Status: metav1.ConditionFalse,
-			Reason: constants.Creating,
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Creating,
+			ObservedGeneration: instance.Generation,
 		},
 		)
 		return g.StatusUpdate(ctx, instance)

--- a/internal/controller/ctlog/actions/initialize.go
+++ b/internal/controller/ctlog/actions/initialize.go
@@ -45,17 +45,19 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CT
 	if !ok {
 		i.Logger.Info("Waiting for deployment")
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Initialize,
-			Message: "Waiting for deployment to be ready",
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Initialize,
+			Message:            "Waiting for deployment to be ready",
+			ObservedGeneration: instance.Generation,
 		})
 		return i.StatusUpdate(ctx, instance)
 	}
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:   constants.Ready,
-		Status: metav1.ConditionTrue,
-		Reason: constants.Ready,
+		Type:               constants.Ready,
+		Status:             metav1.ConditionTrue,
+		Reason:             constants.Ready,
+		ObservedGeneration: instance.Generation,
 	})
 	return i.StatusUpdate(ctx, instance)
 }

--- a/internal/controller/ctlog/actions/monitoring.go
+++ b/internal/controller/ctlog/actions/monitoring.go
@@ -58,10 +58,11 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CT
 
 	if _, err = i.Ensure(ctx, role); err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.Generation,
 		})
 		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could not create monitoring role: %w", err), instance)
 	}
@@ -85,10 +86,11 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CT
 
 	if _, err = i.Ensure(ctx, roleBinding); err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.Generation,
 		})
 		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could not create monitoring RoleBinding: %w", err), instance)
 	}
@@ -113,10 +115,11 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CT
 
 	if _, err = i.Ensure(ctx, serviceMonitor); err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.Generation,
 		})
 		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
 	}

--- a/internal/controller/ctlog/actions/rbac.go
+++ b/internal/controller/ctlog/actions/rbac.go
@@ -53,10 +53,11 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *
 	_, err = i.Ensure(ctx, sa)
 	if err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.Generation,
 		})
 		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could not create SA: %w", err), instance)
 	}
@@ -79,10 +80,11 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *
 	_, err = i.Ensure(ctx, role)
 	if err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.Generation,
 		})
 		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could not create Role: %w", err), instance)
 	}
@@ -101,10 +103,11 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *
 	_, err = i.Ensure(ctx, rb)
 	if err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.Generation,
 		})
 		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could not create RoleBinding: %w", err), instance)
 	}

--- a/internal/controller/ctlog/actions/resolve_tree.go
+++ b/internal/controller/ctlog/actions/resolve_tree.go
@@ -86,10 +86,11 @@ func (i resolveTreeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.C
 			Message: err.Error(),
 		})
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.Generation,
 		})
 		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could not create trillian tree: %v", err), instance)
 	}

--- a/internal/controller/ctlog/actions/service.go
+++ b/internal/controller/ctlog/actions/service.go
@@ -54,17 +54,23 @@ func (i serviceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog
 	}
 	if updated, err = i.Ensure(ctx, svc); err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    constants.Ready,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.Generation,
 		})
 		return i.FailedWithStatusUpdate(ctx, fmt.Errorf("could not create service: %w", err), instance)
 	}
 
 	if updated {
-		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.Ready,
-			Status: metav1.ConditionFalse, Reason: constants.Creating, Message: "Service created"})
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               constants.Ready,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Creating,
+			Message:            "Service created",
+			ObservedGeneration: instance.Generation,
+		})
 		return i.StatusUpdate(ctx, instance)
 	} else {
 		return i.Continue()


### PR DESCRIPTION
related to [SECURESIGN-1227](https://issues.redhat.com//browse/SECURESIGN-1227)

CT log server config has not been updated when spec has changed. Because that configuration depends mostly on all fields in spec I solved that problem by comparing latest observed generation for Ready phase. `serverConfig` action will be executed on Ready phase when ObservedGeneration is different than Generation of resource.

