### PR TITLE
SECURESIGN-1461: check if Trillian's secret with db connection already exists

### DIFF
--- a/internal/controller/trillian/actions/db/handle_secret.go
+++ b/internal/controller/trillian/actions/db/handle_secret.go
@@ -2,8 +2,14 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
+
+	"github.com/securesign/operator/internal/controller/common/utils/kubernetes"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierros "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/securesign/operator/internal/controller/common/utils"
 
@@ -20,9 +26,18 @@ import (
 )
 
 const (
-	port = 3306
-	host = "trillian-mysql"
+	port                   = 3306
+	host                   = "trillian-mysql"
+	dbConnectionResource   = "trillian-db-connection"
+	dbConnectionSecretName = "trillian-db-connection-"
+
+	annotationDatabase = constants.LabelNamespace + "/mysql-database"
+	annotationUser     = constants.LabelNamespace + "/mysql-user"
+	annotationPort     = constants.LabelNamespace + "/mysql-port"
+	annotationHost     = constants.LabelNamespace + "/mysql-host"
 )
+
+var ErrMissingDBConfiguration = errors.New("expecting external DB configuration")
 
 func NewHandleSecretAction() action.Action[*rhtasv1alpha1.Trillian] {
 	return &handleSecretAction{}
@@ -36,27 +51,94 @@ func (i handleSecretAction) Name() string {
 	return "create db secret"
 }
 
-func (i handleSecretAction) CanHandle(ctx context.Context, instance *rhtasv1alpha1.Trillian) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return c.Reason == constants.Creating && instance.Status.Db.DatabaseSecretRef == nil
+func (i handleSecretAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Trillian) bool {
+	switch {
+	case instance.Status.Db.DatabaseSecretRef == nil:
+		return true
+	case !equality.Semantic.DeepDerivative(instance.Spec.Db.DatabaseSecretRef, instance.Status.Db.DatabaseSecretRef):
+		return true
+	default:
+		return !meta.IsStatusConditionTrue(instance.GetConditions(), trillian.DbCondition)
+	}
 }
 
 func (i handleSecretAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian) *action.Result {
+	// external database
 	if !utils.OptionalBool(instance.Spec.Db.Create) {
-		if instance.Spec.Db.DatabaseSecretRef != nil {
-			instance.Status.Db.DatabaseSecretRef = instance.Spec.Db.DatabaseSecretRef
-			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: trillian.DbCondition,
-				Status: metav1.ConditionTrue, Reason: constants.Ready, Message: "Working with external DB"})
-		} else {
-			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: trillian.DbCondition,
-				Status: metav1.ConditionFalse, Reason: constants.Failure, Message: "Expecting external DB configuration"})
+		if instance.Spec.Db.DatabaseSecretRef == nil {
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:    trillian.DbCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  constants.Failure,
+				Message: ErrMissingDBConfiguration.Error(),
+			})
+			return i.FailedWithStatusUpdate(ctx, ErrMissingDBConfiguration, instance)
 		}
-		return i.StatusUpdate(ctx, instance)
+
+		if !equality.Semantic.DeepEqual(instance.Spec.Db.DatabaseSecretRef, instance.Status.Db.DatabaseSecretRef) {
+			instance.Status.Db.DatabaseSecretRef = instance.Spec.Db.DatabaseSecretRef
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:    trillian.DbCondition,
+				Status:  metav1.ConditionTrue,
+				Reason:  constants.Ready,
+				Message: "Working with external DB",
+			})
+			return i.StatusUpdate(ctx, instance)
+		}
+		return i.Continue()
 	}
+
+	// managed database
 	var (
 		err error
 	)
+	if instance.Spec.Db.DatabaseSecretRef != nil {
+		// skip if spec and status is equal
+		if equality.Semantic.DeepEqual(instance.Spec.Db.DatabaseSecretRef, instance.Status.Db.DatabaseSecretRef) {
+			return i.Continue()
+		}
+
+		// update database connection by spec
+		instance.Status.Db.DatabaseSecretRef = instance.Spec.Db.DatabaseSecretRef
+		return i.StatusUpdate(ctx, instance)
+	}
+
+	// skip if status exists
+	if instance.Status.Db.DatabaseSecretRef != nil {
+		return i.Continue()
+	}
+
 	dbLabels := constants.LabelsFor(trillian.DbComponentName, trillian.DbDeploymentName, instance.Name)
+	dbLabels[constants.LabelResource] = dbConnectionResource
+
+	partialSecrets, err := kubernetes.ListSecrets(ctx, i.Client, instance.Namespace, labels.SelectorFromSet(dbLabels).String())
+	if err != nil {
+		return i.Failed(fmt.Errorf("can't load secrets: %w", err))
+	}
+
+	for _, partialSecret := range partialSecrets.Items {
+		// use first db-connection and remove all other
+		if instance.Status.Db.DatabaseSecretRef == nil &&
+			equality.Semantic.DeepDerivative(i.secretAnnotations(), partialSecret.GetAnnotations()) {
+			instance.Status.Db.DatabaseSecretRef = &rhtasv1alpha1.LocalObjectReference{
+				Name: partialSecret.Name,
+			}
+			continue
+		}
+
+		// delete unused secrets with db-connection
+		err = i.Client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Name:      partialSecret.GetName(),
+			Namespace: partialSecret.GetNamespace(),
+		}})
+		if err != nil && !apierros.IsNotFound(err) {
+			i.Logger.Error(err, "can't delete secret")
+		}
+	}
+
+	if instance.Status.Db.DatabaseSecretRef != nil {
+		return i.StatusUpdate(ctx, instance)
+	}
 
 	dbSecret := i.createDbSecret(instance.Namespace, dbLabels)
 	if err = controllerutil.SetControllerReference(instance, dbSecret, i.Client.Scheme()); err != nil {
@@ -93,9 +175,10 @@ func (i handleSecretAction) createDbSecret(namespace string, labels map[string]s
 	mysqlPass = common.GeneratePassword(12)
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "rhtas",
+			GenerateName: dbConnectionSecretName,
 			Namespace:    namespace,
 			Labels:       labels,
+			Annotations:  i.secretAnnotations(),
 		},
 		Type: "Opaque",
 		Data: map[string][]byte{
@@ -106,5 +189,14 @@ func (i handleSecretAction) createDbSecret(namespace string, labels map[string]s
 			"mysql-port":          []byte(strconv.Itoa(port)),
 			"mysql-host":          []byte(host),
 		},
+	}
+}
+
+func (i handleSecretAction) secretAnnotations() map[string]string {
+	return map[string]string{
+		annotationDatabase: "trillian",
+		annotationUser:     "mysql",
+		annotationPort:     strconv.Itoa(port),
+		annotationHost:     host,
 	}
 }

--- a/internal/controller/trillian/actions/db/handle_secret.go
+++ b/internal/controller/trillian/actions/db/handle_secret.go
@@ -17,6 +17,7 @@ import (
 	"github.com/securesign/operator/internal/controller/common/action"
 	"github.com/securesign/operator/internal/controller/constants"
 	trillian "github.com/securesign/operator/internal/controller/trillian/actions"
+	trillianUtils "github.com/securesign/operator/internal/controller/trillian/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -28,13 +29,15 @@ import (
 const (
 	port                   = 3306
 	host                   = "trillian-mysql"
+	user                   = "mysql"
+	databaseName           = "trillian"
 	dbConnectionResource   = "trillian-db-connection"
 	dbConnectionSecretName = "trillian-db-connection-"
 
-	annotationDatabase = constants.LabelNamespace + "/mysql-database"
-	annotationUser     = constants.LabelNamespace + "/mysql-user"
-	annotationPort     = constants.LabelNamespace + "/mysql-port"
-	annotationHost     = constants.LabelNamespace + "/mysql-host"
+	annotationDatabase = constants.LabelNamespace + "/" + trillianUtils.SecretDatabaseName
+	annotationUser     = constants.LabelNamespace + "/" + trillianUtils.SecretUser
+	annotationPort     = constants.LabelNamespace + "/" + trillianUtils.SecretPort
+	annotationHost     = constants.LabelNamespace + "/" + trillianUtils.SecretHost
 )
 
 var ErrMissingDBConfiguration = errors.New("expecting external DB configuration")
@@ -182,20 +185,20 @@ func (i handleSecretAction) createDbSecret(namespace string, labels map[string]s
 		},
 		Type: "Opaque",
 		Data: map[string][]byte{
-			"mysql-root-password": rootPass,
-			"mysql-password":      mysqlPass,
-			"mysql-database":      []byte("trillian"),
-			"mysql-user":          []byte("mysql"),
-			"mysql-port":          []byte(strconv.Itoa(port)),
-			"mysql-host":          []byte(host),
+			trillianUtils.SecretRootPassword: rootPass,
+			trillianUtils.SecretPassword:     mysqlPass,
+			trillianUtils.SecretDatabaseName: []byte(databaseName),
+			trillianUtils.SecretUser:         []byte(user),
+			trillianUtils.SecretPort:         []byte(strconv.Itoa(port)),
+			trillianUtils.SecretHost:         []byte(host),
 		},
 	}
 }
 
 func (i handleSecretAction) secretAnnotations() map[string]string {
 	return map[string]string{
-		annotationDatabase: "trillian",
-		annotationUser:     "mysql",
+		annotationDatabase: databaseName,
+		annotationUser:     user,
 		annotationPort:     strconv.Itoa(port),
 		annotationHost:     host,
 	}

--- a/internal/controller/trillian/actions/db/handle_secret_test.go
+++ b/internal/controller/trillian/actions/db/handle_secret_test.go
@@ -1,0 +1,673 @@
+package db
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/securesign/operator/internal/controller/common/action"
+	actions2 "github.com/securesign/operator/internal/controller/trillian/actions"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/controller/constants"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHandleSecret_CanHandle(t *testing.T) {
+	tests := []struct {
+		name      string
+		instance  rhtasv1alpha1.Trillian
+		condition metav1.ConditionStatus
+		canHandle bool
+	}{
+		{
+			name:      "no phase condition",
+			canHandle: true,
+		},
+		{
+			name:      "ConditionUnknown",
+			condition: metav1.ConditionUnknown,
+			canHandle: true,
+		},
+		{
+			name:      "ConditionTrue: status.db.databaseSecretRef == nil",
+			condition: metav1.ConditionTrue,
+			instance: rhtasv1alpha1.Trillian{
+				Status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						DatabaseSecretRef: nil,
+					},
+				},
+			},
+			canHandle: true,
+		},
+		{
+			name:      "ConditionTrue: status.db.databaseSecretRef != nil",
+			condition: metav1.ConditionTrue,
+			instance: rhtasv1alpha1.Trillian{
+				Status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{
+							Name: "connection",
+						},
+					},
+				},
+			},
+			canHandle: false,
+		},
+		{
+			name:      "ConditionTrue: status.db.databaseSecretRef != spec.db.databaseSecretRef",
+			condition: metav1.ConditionTrue,
+			instance: rhtasv1alpha1.Trillian{
+				Spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{
+							Name: "new-connection",
+						},
+					},
+				},
+				Status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{
+							Name: "connection",
+						},
+					},
+				},
+			},
+			canHandle: true,
+		},
+		{
+			name:      "ConditionTrue: status.db.databaseSecretRef == spec.db.databaseSecretRef",
+			condition: metav1.ConditionTrue,
+			instance: rhtasv1alpha1.Trillian{
+				Spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{
+							Name: "connection",
+						},
+					},
+				},
+				Status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{
+							Name: "connection",
+						},
+					},
+				},
+			},
+			canHandle: false,
+		},
+		{
+			name:      "ConditionFalse",
+			condition: metav1.ConditionFalse,
+			canHandle: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := testAction.FakeClientBuilder().Build()
+			a := testAction.PrepareAction(c, NewHandleSecretAction())
+
+			instance := tt.instance
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:   actions2.DbCondition,
+				Status: tt.condition,
+			})
+
+			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
+			}
+		})
+	}
+}
+
+func TestHandleSecret_Handle(t *testing.T) {
+	namespacedName := types.NamespacedName{Namespace: "default", Name: "trillian"}
+	type env struct {
+		spec    rhtasv1alpha1.TrillianSpec
+		status  rhtasv1alpha1.TrillianStatus
+		objects []client.Object
+	}
+	type want struct {
+		result *action.Result
+		verify func(Gomega, client.WithWatch, <-chan watch.Event)
+	}
+	tests := []struct {
+		name string
+		env  env
+		want want
+	}{
+		{
+			name: "external: missing spec.db.databaseSecretRef",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(false),
+						DatabaseSecretRef: nil,
+					},
+				},
+			},
+			want: want{
+				result: testAction.FailedWithStatusUpdate(ErrMissingDBConfiguration),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Failure))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "external: set spec.db.databaseSecretRef",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(false),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "connection"},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionTrue))
+					g.Expect(condition.Reason).Should(Equal(constants.Ready))
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("connection"))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "external: modify spec.db.databaseSecretRef",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(false),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "new-connection"},
+					},
+				},
+				status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(false),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "old-connection"},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionTrue))
+					g.Expect(condition.Reason).Should(Equal(constants.Ready))
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("new-connection"))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "external: unmodified spec.db.databaseSecretRef",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(false),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "connection"},
+					},
+				},
+				status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(false),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "connection"},
+					},
+				},
+			},
+			want: want{
+				result: testAction.Continue(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("connection"))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "managed: set spec.db.databaseSecretRef",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(true),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "connection"},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Pending))
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("connection"))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "managed: empty spec.db.databaseSecretRef",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(true),
+						DatabaseSecretRef: nil,
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Pending))
+
+					g.Expect(events).To(HaveLen(1))
+					event := <-events
+					g.Expect(event.Type).To(Equal(watch.Added))
+					secret := event.Object.(*core.Secret)
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal(secret.Name))
+				},
+			},
+		},
+		{
+			name: "managed: update spec.db.databaseSecretRef",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(true),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "new-connection"},
+					},
+				},
+				status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(true),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "old-connection"},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Pending))
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("new-connection"))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "managed: unmodified spec.db.databaseSecretRef",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(true),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "connection"},
+					},
+				},
+				status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(true),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "connection"},
+					},
+				},
+			},
+			want: want{
+				result: testAction.Continue(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Pending))
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("connection"))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "managed: unmodified generated db connection",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create: ptr.To(true),
+					},
+				},
+				status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create:            ptr.To(true),
+						DatabaseSecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "connection"},
+					},
+				},
+			},
+			want: want{
+				result: testAction.Continue(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Pending))
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("connection"))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "managed: SECURESIGN_1455: link unassigned db-connection secret",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create: ptr.To(true),
+					},
+				},
+				status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create: ptr.To(true),
+					},
+				},
+				objects: []client.Object{
+					&core.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "unlinked-connection",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.LabelAppInstance:  "trillian",
+								constants.LabelAppComponent: actions2.DbComponentName,
+								constants.LabelAppName:      actions2.DbDeploymentName,
+								constants.LabelAppPartOf:    constants.AppName,
+								constants.LabelAppManagedBy: "controller-manager",
+								constants.LabelResource:     dbConnectionResource,
+							},
+							Annotations: map[string]string{
+								annotationDatabase: "trillian",
+								annotationUser:     "mysql",
+								annotationPort:     strconv.Itoa(port),
+								annotationHost:     host,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Pending))
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("unlinked-connection"))
+
+					g.Expect(events).To(BeEmpty())
+				},
+			},
+		},
+		{
+			name: "managed: SECURESIGN_1455: delete old db-connection secret",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create: ptr.To(true),
+					},
+				},
+				status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create: ptr.To(true),
+					},
+				},
+				objects: []client.Object{
+					&core.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "old-connection-1",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.LabelAppInstance:  "trillian",
+								constants.LabelAppComponent: actions2.DbComponentName,
+								constants.LabelAppName:      actions2.DbDeploymentName,
+								constants.LabelAppPartOf:    constants.AppName,
+								constants.LabelAppManagedBy: "controller-manager",
+								constants.LabelResource:     dbConnectionResource,
+							},
+						},
+					},
+					&core.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "old-connection-2",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.LabelAppInstance:  "trillian",
+								constants.LabelAppComponent: actions2.DbComponentName,
+								constants.LabelAppName:      actions2.DbDeploymentName,
+								constants.LabelAppPartOf:    constants.AppName,
+								constants.LabelAppManagedBy: "controller-manager",
+								constants.LabelResource:     dbConnectionResource,
+							},
+							Annotations: map[string]string{
+								annotationDatabase: "old",
+								annotationUser:     "mysql",
+								annotationPort:     strconv.Itoa(port),
+								annotationHost:     "old",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Pending))
+
+					g.Expect(events).To(HaveLen(3))
+
+					var newName string
+					for event := range events {
+						switch event.Type {
+						case watch.Deleted:
+							g.Expect(event.Object.(*core.Secret).Name).To(ContainSubstring("old-connection"))
+						case watch.Added:
+							newName = event.Object.(*core.Secret).Name
+							g.Expect(newName).To(ContainSubstring(dbConnectionSecretName))
+						default:
+							g.Expect(true).Should(BeFalse(), "should not be executed")
+						}
+					}
+
+					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal(newName))
+
+				},
+			},
+		},
+		{
+			name: "managed: SECURESIGN_1455: link valid and delete old db-connection secret",
+			env: env{
+				spec: rhtasv1alpha1.TrillianSpec{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create: ptr.To(true),
+					},
+				},
+				status: rhtasv1alpha1.TrillianStatus{
+					Db: rhtasv1alpha1.TrillianDB{
+						Create: ptr.To(true),
+					},
+				},
+				objects: []client.Object{
+					&core.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "unlinked-connection",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.LabelAppInstance:  "trillian",
+								constants.LabelAppComponent: actions2.DbComponentName,
+								constants.LabelAppName:      actions2.DbDeploymentName,
+								constants.LabelAppPartOf:    constants.AppName,
+								constants.LabelAppManagedBy: "controller-manager",
+								constants.LabelResource:     dbConnectionResource,
+							},
+							Annotations: map[string]string{
+								annotationDatabase: "trillian",
+								annotationUser:     "mysql",
+								annotationPort:     strconv.Itoa(port),
+								annotationHost:     host,
+							},
+						},
+					},
+					&core.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "old-connection",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.LabelAppInstance:  "trillian",
+								constants.LabelAppComponent: actions2.DbComponentName,
+								constants.LabelAppName:      actions2.DbDeploymentName,
+								constants.LabelAppPartOf:    constants.AppName,
+								constants.LabelAppManagedBy: "controller-manager",
+								constants.LabelResource:     dbConnectionResource,
+							},
+							Annotations: map[string]string{
+								annotationDatabase: "old",
+								annotationUser:     "mysql",
+								annotationPort:     strconv.Itoa(port),
+								annotationHost:     "old",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+					instance := &rhtasv1alpha1.Trillian{}
+					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+
+					condition := meta.FindStatusCondition(instance.GetConditions(), actions2.DbCondition)
+					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+					g.Expect(condition.Reason).Should(Equal(constants.Pending))
+
+					g.Expect(events).To(HaveLen(1))
+					for event := range events {
+						switch event.Type {
+						case watch.Deleted:
+							g.Expect(event.Object.(*core.Secret).Name).To(ContainSubstring("old-connection"))
+						default:
+							g.Expect(true).Should(BeFalse(), "should not be executed")
+						}
+
+						g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
+						g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("unlinked-connection"))
+					}
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.TODO()
+			instance := &rhtasv1alpha1.Trillian{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "trillian",
+					Namespace: "default",
+				},
+				Spec:   tt.env.spec,
+				Status: tt.env.status,
+			}
+
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:   actions2.DbCondition,
+				Status: metav1.ConditionFalse,
+				Reason: constants.Pending,
+			})
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				WithObjects(tt.env.objects...).
+				Build()
+
+			watchSecrets, err := c.Watch(ctx, &core.SecretList{}, client.InNamespace(instance.Namespace))
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			a := testAction.PrepareAction(c, NewHandleSecretAction())
+
+			if got := a.Handle(ctx, instance); !reflect.DeepEqual(got, tt.want.result) {
+				t.Errorf("CanHandle() = %v, want %v", got, tt.want.result)
+			}
+
+			watchSecrets.Stop()
+			if tt.want.verify != nil {
+				tt.want.verify(g, c, watchSecrets.ResultChan())
+			}
+		})
+	}
+}

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -19,8 +19,6 @@ package trillian
 import (
 	"context"
 
-	"github.com/securesign/operator/internal/controller/common/utils"
-
 	"k8s.io/apimachinery/pkg/types"
 
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
@@ -89,11 +87,7 @@ func (r *TrillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	target := instance.DeepCopy()
 	actions := []action.Action[*rhtasv1alpha1.Trillian]{
 		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Trillian](func(t *rhtasv1alpha1.Trillian) []string {
-			components := []string{actions.ServerCondition, actions.SignerCondition}
-			if utils.IsEnabled(t.Spec.Db.Create) {
-				components = append(components, actions.DbCondition)
-			}
-			return components
+			return []string{actions.ServerCondition, actions.SignerCondition, actions.DbCondition}
 		}),
 
 		transitions.NewToCreatePhaseAction[*rhtasv1alpha1.Trillian](),

--- a/internal/controller/trillian/utils/constants.go
+++ b/internal/controller/trillian/utils/constants.go
@@ -1,0 +1,10 @@
+package trillianUtils
+
+const (
+	SecretRootPassword = "mysql-root-password"
+	SecretPassword     = "mysql-password"
+	SecretDatabaseName = "mysql-database"
+	SecretUser         = "mysql-user"
+	SecretPort         = "mysql-port"
+	SecretHost         = "mysql-host"
+)

--- a/internal/controller/trillian/utils/server-deployment.go
+++ b/internal/controller/trillian/utils/server-deployment.go
@@ -60,7 +60,7 @@ func CreateLogServerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_HOSTNAME",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-host",
+											Key: SecretHost,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -71,7 +71,7 @@ func CreateLogServerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_PORT",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-port",
+											Key: SecretPort,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -105,7 +105,7 @@ func CreateLogServerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_USER",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-user",
+											Key: SecretUser,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -116,7 +116,7 @@ func CreateLogServerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_PASSWORD",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-password",
+											Key: SecretPassword,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -127,7 +127,7 @@ func CreateLogServerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_HOSTNAME",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-host",
+											Key: SecretHost,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -138,7 +138,7 @@ func CreateLogServerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_PORT",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-port",
+											Key: SecretPort,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -149,7 +149,7 @@ func CreateLogServerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_DATABASE",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-database",
+											Key: SecretDatabaseName,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},

--- a/internal/controller/trillian/utils/signer-deployment.go
+++ b/internal/controller/trillian/utils/signer-deployment.go
@@ -60,7 +60,7 @@ func CreateLogSignerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_HOSTNAME",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-host",
+											Key: SecretHost,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -71,7 +71,7 @@ func CreateLogSignerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_PORT",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-port",
+											Key: SecretPort,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -105,7 +105,7 @@ func CreateLogSignerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_USER",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-user",
+											Key: SecretUser,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -116,7 +116,7 @@ func CreateLogSignerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_PASSWORD",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-password",
+											Key: SecretPassword,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -127,7 +127,7 @@ func CreateLogSignerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_HOSTNAME",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-host",
+											Key: SecretHost,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -138,7 +138,7 @@ func CreateLogSignerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_PORT",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-port",
+											Key: SecretPort,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},
@@ -149,7 +149,7 @@ func CreateLogSignerDeployment(ctx context.Context, client client.Client, instan
 									Name: "MYSQL_DATABASE",
 									ValueFrom: &core.EnvVarSource{
 										SecretKeyRef: &core.SecretKeySelector{
-											Key: "mysql-database",
+											Key: SecretDatabaseName,
 											LocalObjectReference: core.LocalObjectReference{
 												Name: instance.Status.Db.DatabaseSecretRef.Name,
 											},

--- a/internal/controller/trillian/utils/trillian-db.go
+++ b/internal/controller/trillian/utils/trillian-db.go
@@ -99,7 +99,7 @@ func CreateTrillDb(instance *v1alpha1.Trillian, dpName string, sa string, secCon
 							Name: "MYSQL_USER",
 							ValueFrom: &core.EnvVarSource{
 								SecretKeyRef: &core.SecretKeySelector{
-									Key: "mysql-user",
+									Key: SecretUser,
 									LocalObjectReference: core.LocalObjectReference{
 										Name: instance.Status.Db.DatabaseSecretRef.Name,
 									},
@@ -110,7 +110,7 @@ func CreateTrillDb(instance *v1alpha1.Trillian, dpName string, sa string, secCon
 							Name: "MYSQL_PASSWORD",
 							ValueFrom: &core.EnvVarSource{
 								SecretKeyRef: &core.SecretKeySelector{
-									Key: "mysql-password",
+									Key: SecretPassword,
 									LocalObjectReference: core.LocalObjectReference{
 										Name: instance.Status.Db.DatabaseSecretRef.Name,
 									},
@@ -121,7 +121,7 @@ func CreateTrillDb(instance *v1alpha1.Trillian, dpName string, sa string, secCon
 							Name: "MYSQL_ROOT_PASSWORD",
 							ValueFrom: &core.EnvVarSource{
 								SecretKeyRef: &core.SecretKeySelector{
-									Key: "mysql-root-password",
+									Key: SecretRootPassword,
 									LocalObjectReference: core.LocalObjectReference{
 										Name: instance.Status.Db.DatabaseSecretRef.Name,
 									},
@@ -132,7 +132,7 @@ func CreateTrillDb(instance *v1alpha1.Trillian, dpName string, sa string, secCon
 							Name: "MYSQL_PORT",
 							ValueFrom: &core.EnvVarSource{
 								SecretKeyRef: &core.SecretKeySelector{
-									Key: "mysql-port",
+									Key: SecretPort,
 									LocalObjectReference: core.LocalObjectReference{
 										Name: instance.Status.Db.DatabaseSecretRef.Name,
 									},
@@ -143,7 +143,7 @@ func CreateTrillDb(instance *v1alpha1.Trillian, dpName string, sa string, secCon
 							Name: "MYSQL_DATABASE",
 							ValueFrom: &core.EnvVarSource{
 								SecretKeyRef: &core.SecretKeySelector{
-									Key: "mysql-database",
+									Key: SecretDatabaseName,
 									LocalObjectReference: core.LocalObjectReference{
 										Name: instance.Status.Db.DatabaseSecretRef.Name,
 									},


### PR DESCRIPTION
fixes [SECURESIGN-1461](https://issues.redhat.com//browse/SECURESIGN-1461)
depends on https://github.com/securesign/secure-sign-operator/pull/673