### PR TITLE
fix(ctlog): cleanup only linked server configs

### DIFF
--- a/internal/controller/ctlog/actions/constants.go
+++ b/internal/controller/ctlog/actions/constants.go
@@ -8,7 +8,13 @@ const (
 	RBACName           = "ctlog"
 	MonitoringRoleName = "prometheus-k8s-ctlog"
 
-	CertCondition    = "FulcioCertAvailable"
+	CertCondition = "FulcioCertAvailable"
+
+	ConfigCondition    = "ServerConfigAvailable"
+	TrillianTreeReason = "TrillianTree"
+	SignerKeyReason    = "SignerKey"
+	FulcioReason       = "FulcioCertificate"
+
 	ServerPortName   = "http"
 	ServerPort       = 80
 	ServerTargetPort = 6962

--- a/internal/controller/ctlog/actions/handle_fulcio_root.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root.go
@@ -96,9 +96,12 @@ func (g handleFulcioCert) Handle(ctx context.Context, instance *v1alpha1.CTlog) 
 	}
 
 	// invalidate server config
-	if instance.Status.ServerConfigRef != nil {
-		instance.Status.ServerConfigRef = nil
-	}
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:    ConfigCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  FulcioReason,
+		Message: "Fulcio certificate changed",
+	})
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 		Type:   CertCondition,

--- a/internal/controller/ctlog/actions/handle_fulcio_root_test.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root_test.go
@@ -336,13 +336,14 @@ func TestCert_Handle(t *testing.T) {
 			want: want{
 				result: testAction.StatusUpdate(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
-					g.Expect(status.ServerConfigRef).Should(BeNil())
-
 					g.Expect(status.RootCertificates).Should(HaveLen(1))
 					g.Expect(status.RootCertificates[0].Key).Should(Equal("key"))
 					g.Expect(status.RootCertificates[0].Name).Should(Equal("my-secret"))
 
 					g.Expect(meta.IsStatusConditionTrue(status.Conditions, CertCondition)).To(BeTrue())
+
+					// Config condition should be invalidated
+					g.Expect(meta.IsStatusConditionFalse(status.Conditions, ConfigCondition)).Should(BeTrue())
 				},
 			},
 		},

--- a/internal/controller/ctlog/actions/handle_keys.go
+++ b/internal/controller/ctlog/actions/handle_keys.go
@@ -94,9 +94,12 @@ func (g handleKeys) Handle(ctx context.Context, instance *v1alpha1.CTlog) *actio
 	instance.Status = *newKeyStatus
 
 	// invalidate server config
-	if instance.Status.ServerConfigRef != nil {
-		instance.Status.ServerConfigRef = nil
-	}
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:    ConfigCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  SignerKeyReason,
+		Message: "New signer key",
+	})
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 		Type:               constants.Ready,

--- a/internal/controller/ctlog/actions/resolve_tree.go
+++ b/internal/controller/ctlog/actions/resolve_tree.go
@@ -58,6 +58,13 @@ func (i resolveTreeAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.
 func (i resolveTreeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *action.Result {
 	if instance.Spec.TreeID != nil && *instance.Spec.TreeID != int64(0) {
 		instance.Status.TreeID = instance.Spec.TreeID
+		// invalidate server config
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:    ConfigCondition,
+			Status:  metav1.ConditionFalse,
+			Reason:  TrillianTreeReason,
+			Message: "Trillian tree changed",
+		})
 		return i.StatusUpdate(ctx, instance)
 	}
 	var err error
@@ -96,6 +103,14 @@ func (i resolveTreeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.C
 	}
 	i.Recorder.Eventf(instance, v1.EventTypeNormal, "TrillianTreeCreated", "New Trillian tree created: %d", tree.TreeId)
 	instance.Status.TreeID = &tree.TreeId
+
+	// invalidate server config
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:    ConfigCondition,
+		Status:  metav1.ConditionFalse,
+		Reason:  TrillianTreeReason,
+		Message: "Trillian tree changed",
+	})
 
 	return i.StatusUpdate(ctx, instance)
 }

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -91,7 +91,7 @@ func (r *CTlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	target := instance.DeepCopy()
 	acs := []action.Action[*rhtasv1alpha1.CTlog]{
 		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.CTlog](func(_ *rhtasv1alpha1.CTlog) []string {
-			return []string{actions.CertCondition}
+			return []string{actions.CertCondition, actions.ConfigCondition}
 		}),
 		transitions.NewToCreatePhaseAction[*rhtasv1alpha1.CTlog](),
 


### PR DESCRIPTION
### Fix handling of cleanup of ServerConfig secrets and invalidation mechanism

**Handling of Deleted Generated Secrets:**
In cases where generated secrets were being deleted due to duplicate events during the operator's reconciliation process, I have adjusted order of execution. Now, any secrets that have the expected resource labels will be removed after successful creation of new one.

**ServerConfig Invalidation Mechanism:**
I have modified the mechanism that invalidates the current server configuration in response to external actions, such as the creation of a Trillian tree, issuance of Fulcio certificates, or the generation of signer keys. When any of these external actions result in a change of data, the ServerConfigAvaliable status is now correctly set to `false`. This triggers the necessary reconciliation to maintain the correct state of the server configuration.