### PR TITLE
add deprication warning for operator version 1.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,6 +111,26 @@ jobs:
           {
              "schema": "olm.bundle",
              "image": "$BUNDLE_IMG"
+          },
+          {
+             "schema": "olm.deprecations",
+             "package": "rhtas-operator",
+             "entries": [
+               {
+                 "reference": {
+                   "schema": "olm.bundle",
+                   "name": "rhtas-operator.v1.0.0"
+                 },
+                 "message": "rhtas-operator.v1.0.0 is deprecated. Please upgrade to v1.1.0 for continued support."
+               },
+               {
+                 "reference": {
+                   "schema": "olm.channel",
+                   "name": "stable-v1.0"
+                 },
+                 "message": "The stable-v1.0 channel is depricated. Please migrate to the stable-v1.1 channel for the latest updates."
+               }
+             ]
           }
           EOF
           #TODO: versions needs to be maintained - try to eliminate


### PR DESCRIPTION
**Updated the operator catalog with deprecation warnings:**

**Deprecation warning for `operator-v1.0.0`**: 
Added a message recommending users to upgrade to `operator-v1.1.0` for continued support.

**Deprecation warning for `stable-v1.0` channel**: 
Added a message recommending users to switch to the newer `stable-v1.1` channel.

I used this [schema](https://olm.operatorframework.io/docs/reference/file-based-catalogs/#olmdeprecations). 