### PR TITLE
[SECURESIGN-1891] Fix configuration of attestation storage so Rekor can actually store attestations

### DIFF
--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -129,7 +129,9 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 			"--enable_retrieve_api=true",
 			fmt.Sprintf("--trillian_log_server.tlog_id=%d", *instance.Status.TreeID),
 			"--enable_attestation_storage",
-			"--attestation_storage_bucket=file:///var/run/attestations",
+			// NOTE: we need to use no_tmp_dir=true with file-based storage to prevent
+			// cross-device link error - see https://github.com/google/go-cloud/issues/3314
+			"--attestation_storage_bucket=file:///var/run/attestations?no_tmp_dir=true",
 			fmt.Sprintf("--log_type=%s", cutils.GetOrDefault(instance.GetAnnotations(), annotations.LogType, string(constants.Prod))),
 		}
 


### PR DESCRIPTION
This is to prevent errors when storing attestations such like this (which lead to the attestation not being stored at all):

```
2025-02-12T08:25:38.400Z	DEBUG api/entries.go:277	error storing attestation: blob (key "sha256:63e103a30619b9bb47acc8e28c476072f785329bdb7897bb93a642be48651719") (code=Unknown): rename /tmp/sha256:63e103a30619b9bb47acc8e28c476072f785329bdb7897bb93a642be48651719.182368764cd52996.tmp /var/run/attestations/sha256:63e103a30619b9bb47acc8e28c476072f785329bdb7897bb93a642be48651719: invalid cross-device link	{"operation": {"id": "rekor-server-7f846b7fdc-xtxfz/u5fdJYde07-000449"}}
```