### PR TITLE
feat(fips): build manager for strict fips runtime

### DIFF
--- a/Dockerfile.rhtas-operator.rh
+++ b/Dockerfile.rhtas-operator.rh
@@ -21,8 +21,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN go mod download && \
-    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=readonly -a -o manager cmd/main.go
+RUN CGO_ENABLED=1 GOFLAGS="-tags=strictfipsruntime,openssl" GOEXPERIMENT="strictfipsruntime" GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=readonly -a -o manager cmd/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:4c8830d349732ed8066544e1cbcf878ad64f39aa4364f13cf4a69954b0ccbda5
 WORKDIR /


### PR DESCRIPTION
Modify manager's Red Hat's dockerfile to build binary which runs on an Operating System in FIPS mode. 

Tool to verify resulted operator https://github.com/openshift/check-payload