### PR TITLE
test: use grc mirror to pull httpd image

### DIFF
--- a/test/e2e/custom_install/proxy.go
+++ b/test/e2e/custom_install/proxy.go
@@ -311,7 +311,7 @@ func newHTTPDPod(ns, configName, secretName string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:    "httpd",
-					Image:   "httpd:2.4.46",
+					Image:   "mirror.gcr.io/httpd:2.4.46",
 					Command: []string{"httpd", "-f", "/etc/httpd/httpd.conf", "-DFOREGROUND"},
 					Ports: []v1.ContainerPort{
 						{


### PR DESCRIPTION
Fixes instability of proxy e2e test which has been caused by DockerHub pull limit.