### PR TITLE
fix: panic error when TSA configuration is nil in Securesign resource

### DIFF
--- a/internal/controller/securesign/actions/update_status.go
+++ b/internal/controller/securesign/actions/update_status.go
@@ -60,6 +60,7 @@ func sortByStatus(conditions []v1.Condition) []string {
 			constants.Initialize: 1,
 			constants.Creating:   2,
 			constants.Ready:      3,
+			constants.NotDefined: 4,
 		}
 
 		return order[iCondition.Reason] < order[jCondition.Reason]


### PR DESCRIPTION
Fixing regression which caused panic error when TSA configuration is nil in Securesign resource.

Error message in operator log:
```
E0318 11:22:04.856291       1 runtime.go:79] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 594 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x18d2f60, 0x2bd8c70})
	/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000585340?})
	/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x18d2f60?, 0x2bd8c70?})
	/usr/lib/golang/src/runtime/panic.go:785 +0x132
github.com/securesign/operator/internal/controller/securesign/actions.tsaAction.Handle.func1(0xc0025eeb40?)
	/workspace/internal/controller/securesign/actions/ensure_tsa.go:56 +0x1b
github.com/securesign/operator/internal/controller/common/utils/kubernetes.CreateOrUpdate[...].func2.1()
	/workspace/internal/controller/common/utils/kubernetes/common.go:155 +0x1ba
sigs.k8s.io/controller-runtime/pkg/controller/controllerutil.mutate(0x1dfc540?, {{0xc00221c030?, 0x0?}, {0xc003392eb6?, 0x1e162d8?}}, {0x1e2f050, 0xc0025eeb40})
	/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/controller/controllerutil/controllerutil.go:426 +0x49
sigs.k8s.io/controller-runtime/pkg/controller/controllerutil.CreateOrUpdate({0x1e162d8, 0xc003581740}, {0x1e22620, 0xc000259440}, {0x1e2f050, 0xc0025eeb40}, 0xc001c1f478)
	/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/controller/controllerutil/controllerutil.go:282 +0x128
github.com/securesign/operator/internal/controller/common/utils/kubernetes.CreateOrUpdate[...].func2()
	/workspace/internal/controller/common/utils/kubernetes/common.go:146 +0x85
k8s.io/client-go/util/retry.OnError.func1()
	/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.29.2/util/retry/util.go:51 +0x30
k8s.io/apimachinery/pkg/util/wait.runConditionWithCrashProtection(0xc001c1f588?)
	/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/wait.go:145 +0x3e
k8s.io/apimachinery/pkg/util/wait.ExponentialBackoff({0x989680, 0x3ff0000000000000, 0x3fb999999999999a, 0x5, 0x0}, 0xc001c1f598)
	/cachi2/output/deps/gomod/pkg/mod/k8s.io/apimachinery@v0.29.2/pkg/util/wait/backoff.go:461 +0x5a
k8s.io/client-go/util/retry.OnError({0x989680, 0x3ff0000000000000, 0x3fb999999999999a, 0x5, 0x0}, 0x7f2262f15088?, 0x50?)
	/cachi2/output/deps/gomod/pkg/mod/k8s.io/client-go@v0.29.2/util/retry/util.go:50 +0x96
github.com/securesign/operator/internal/controller/common/utils/kubernetes.CreateOrUpdate[...]({0x1e162d8?, 0xc003581740?}, {0x1e22620?, 0xc000259440?}, 0x0?, {0xc001c1f8c0?, 0xc001e89440?, 0x0?})
	/workspace/internal/controller/common/utils/kubernetes/common.go:142 +0x119
github.com/securesign/operator/internal/controller/securesign/actions.tsaAction.Handle({{{0x1e22620, 0xc000259440}, {0x0, 0x0}, {{0x1e19fc8, 0xc001e89600}, 0x0}}}, {0x1e162d8, 0xc003581740}, 0xc002290f08)
	/workspace/internal/controller/securesign/actions/ensure_tsa.go:50 +0x59c
github.com/securesign/operator/internal/controller/securesign.(*SecuresignReconciler).Reconcile(0xc0002a2be8, {0x1e162d8, 0xc003581740}, {{{0xc0023ae480?, 0x0?}, {0xc0023ac496?, 0xc001c1fd10?}}})
	/workspace/internal/controller/securesign/securesign_controller.go:154 +0xec9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1e19fc8?, {0x1e162d8?, 0xc003581740?}, {{{0xc0023ae480?, 0xb?}, {0xc0023ac496?, 0x0?}}})
	/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119 +0xa5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0000fc140, {0x1e16310, 0xc0002d6e60}, {0x1960f00, 0xc0023bc360})
	/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:316 +0x39c
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0000fc140, {0x1e16310, 0xc0002d6e60})
	/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:266 +0x19d
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:227 +0x73
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 90
	/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:223 +0x50c
```

Reproducer:
```
apiVersion: rhtas.redhat.com/v1alpha1
kind: Securesign
metadata:
  labels:
    app.kubernetes.io/name: securesign-sample
    app.kubernetes.io/instance: securesign-sample
    app.kubernetes.io/part-of: trusted-artifact-signer
  annotations:
    rhtas.redhat.com/metrics: "true"
  name: securesign-sample
spec:
  rekor:
    externalAccess:
      enabled: true
    monitoring:
      enabled: true
  trillian:
    database:
      create: true
  fulcio:
    externalAccess:
      enabled: true
    config:
      OIDCIssuers:
        - ClientID: "trusted-artifact-signer"
          IssuerURL: "https://your-oidc-issuer-url"
          Issuer: "https://your-oidc-issuer-url"
          Type: "email"
    certificate:
      organizationName: Red Hat
      organizationEmail: jdoe@redhat.com
      commonName: fulcio.hostname
    monitoring:
      enabled: true
  tuf:
    externalAccess:
      enabled: true
    keys:
      - name: rekor.pub
      - name: ctfe.pub
      - name: fulcio_v1.crt.pem
    rootKeySecretRef:
      name: tuf-root-keys
    pvc:
      accessModes:
        - ReadWriteOnce
      retain: true
      size: 100Mi
  ctlog:

```