### PR TITLE
fix: build bundle image from scratch

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:d086e9b85efa3818f9429c2959c9acd62a6a4115c7ad6d59ae428c61d3c704fa
+FROM scratch
 
 ## Core bundle labels.
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
@@ -16,8 +16,8 @@ LABEL io.k8s.description="The bundle image for the rhtas-operator, containing ma
 LABEL io.k8s.display-name="RHTAS operator bundle container image for Red Hat Trusted Artifact Signer."
 LABEL io.openshift.tags="rhtas-operator-bundle, rhtas-operator, Red Hat Trusted Artifact Signer."
 LABEL summary="Operator Bundle for the rhtas-operator."
-LABEL com.redhat.component="sigstore-operator-bundle"
-LABEL name="sigstore-operator-bundle"
+LABEL com.redhat.component="rhtas-operator-bundle"
+LABEL name="rhtas-operator-bundle"
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"
 LABEL features.operators.openshift.io/fips-compliant="false"


### PR DESCRIPTION
change component and name labels values to rhtas-operator-bundle

Reference:
- https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md
- https://github.com/konflux-ci/olm-operator-konflux-sample/blob/main/Containerfile.gatekeeper-operator-bundle