### PR TITLE
fix: container images to include OS licensing at /licenses

### DIFF
--- a/Dockerfile.rhtas-operator.rh
+++ b/Dockerfile.rhtas-operator.rh
@@ -27,6 +27,7 @@ RUN go mod download && \
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:8b314e254e9ab9a7a08b675fcfd3ed66a2943eeda7b26395210d451569976b9b
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY LICENSE /licenses/license.txt
 USER 65532:65532
 
 LABEL description="The image for the rhtas-operator."

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -42,3 +42,4 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
+COPY LICENSE /licenses/license.txt


### PR DESCRIPTION
https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#con-image-content-requirements_openshift-sw-cert-policy-container-images