### PR TITLE
ci: add configuration for generated release notes

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - red-hat-konflux[bot]
+      - openshift-merge-bot[bot]
+      - RHTAS-build-bot
+  categories:
+    - title: Fixes
+      labels:
+        - bug
+    - title: Features
+      labels:
+        - enhancement
+    - title: Other
+      labels:
+        - "*"


### PR DESCRIPTION
I am adding an configuration to filter changes from autogenerated release notes.

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes