### PR TITLE
fix: excluded bot account in .github/release.yaml

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -2,8 +2,8 @@ changelog:
   exclude:
     authors:
       - dependabot
-      - red-hat-konflux[bot]
-      - openshift-merge-bot[bot]
+      - red-hat-konflux
+      - openshift-merge-bot
       - RHTAS-build-bot
   categories:
     - title: Fixes


### PR DESCRIPTION
Fixes red-hat-konflux and openshift-merge-bot accounts names. 

Output of autogenerated changelog which correctly excluded konflux bot PRs
```
<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
### Fixes
* [SECURESIGN-1529] Keep url status up-to-date by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/787
* [SECURESIGN-1891] Fix configuration of attestation storage so Rekor can actually store attestations by @bkabrda in https://github.com/securesign/secure-sign-operator/pull/852
* fix: Add missing flag for RELATED_IMAGE_TRILLIAN_CREATE_TREE by @osmman in https://github.com/securesign/secure-sign-operator/pull/926
* fix: mount kubernetes api server certificate to /var/run/fulcio/ca.crt by @osmman in https://github.com/securesign/secure-sign-operator/pull/932
* fix: build bundle image from scratch by @osmman in https://github.com/securesign/secure-sign-operator/pull/936
* fix: mandatory labels for bundle image by @osmman in https://github.com/securesign/secure-sign-operator/pull/941
* fix: panic error when TSA configuration is nil in Securesign resource by @osmman in https://github.com/securesign/secure-sign-operator/pull/930
* fix: container images to include OS licensing at /licenses by @osmman in https://github.com/securesign/secure-sign-operator/pull/958
### Features
* refactor: extract labels from constants package by @osmman in https://github.com/securesign/secure-sign-operator/pull/733
* feat: log-type annotation to configure logging type by @osmman in https://github.com/securesign/secure-sign-operator/pull/769
* PoC rework ensure by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/740
* [SECURESIGN-1393] Migrate to the new ensure logic by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/792
* [SECURESIGN-1393] Migrate to the new ensure logic by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/793
* [SECURESIGN-1393] Rework ingress ensure by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/796
* Migrate RBAC to new ensure method by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/797
* [SECURESIGN-1393] Migrate pvc by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/798
* SECURESIGN-1716 | Update Backfill redis flags  by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/802
* [SECURESIGN-1393] Migrate svc by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/799
* [SECURESIGN-1393] migrate ConfigMap by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/803
* [SECURESIGN-1393] Migrate secret by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/809
* [SECURESIGN-1393] Migrate ingress by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/810
* [SECURESIGN-1393] Migrate ctlog and fulcio deployment by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/816
* [SECURESIGN-1393] Migrate rekor by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/819
* [SECURESIGN-1393] Migrate cli_server by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/826
* [SECURESIGN-1393] Migrate monitors by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/825
* [SECURESIGN-1393] Migrate tsa by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/824
* Migrate trillian by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/820
* feat: use RELATED_IMAGES_ environment variables to configure operand's images by @osmman in https://github.com/securesign/secure-sign-operator/pull/812
* feat: Default TLS encryption on Trillian services by @osmman in https://github.com/securesign/secure-sign-operator/pull/871
* Migrate Failures to Error function by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/849
* feat: enable operator disconnected feature by @osmman in https://github.com/securesign/secure-sign-operator/pull/956
### Other
* chore(deps): update konflux references (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/722
* chore: bump version of operator to 1.2.0 by @osmman in https://github.com/securesign/secure-sign-operator/pull/726
* chore(deps): update golang docker tag to v1.23 (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/553
* chore: opm version to 1.40.0 by @osmman in https://github.com/securesign/secure-sign-operator/pull/737
* chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to 5d2ff6e (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/738
* Add TSA to upgrade test by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/741
* ci: modify Konflux pipelines by @osmman in https://github.com/securesign/secure-sign-operator/pull/745
* chore(deps): update konflux references (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/734
* chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker digest (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/739
* chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to 2739018 (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/756
* chore(deps): update konflux references (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/760
* chore(deps): update konflux references (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/766
* doc: create documentation for annotation package by @osmman in https://github.com/securesign/secure-sign-operator/pull/768
* chore(deps): update konflux references (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/772
* [SECURESIGN-1401] Implement Fulcio cert rotation scenario by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/665
* Update Konflux pipelines to use refrences by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/774
* github-action: Store OCI image as artifact by @osmman in https://github.com/securesign/secure-sign-operator/pull/521
* chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to 388e92e (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/783
* chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker digest (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/784
* chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to 03692dc (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/800
* chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker digest (main) by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/801
* Update golang.org/x/crypto and golang.org/x/net packages by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/813
* ci: add cache for Cargo by @osmman in https://github.com/securesign/secure-sign-operator/pull/818
* chore: update golang to v1.22 by @osmman in https://github.com/securesign/secure-sign-operator/pull/732
* Add sigstore-e2e test execution by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/832
* Migrate segment jobs and securesign resources by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/838
* Add script to restore ownerReferences by @petrpinkas in https://github.com/securesign/secure-sign-operator/pull/833
* Update registry.access.redhat.com/ubi9/ubi-minimal Docker digest by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/846
* chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker digest by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/855
* chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to 9b78b58 by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/845
* chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to 63949c9 by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/863
* ci: fix GH Action linter and remove warning messages by @osmman in https://github.com/securesign/secure-sign-operator/pull/872
* Fix env vars in e2e test by @bouskaJ in https://github.com/securesign/secure-sign-operator/pull/850
* ci: fix FBC replaces version of operator by @osmman in https://github.com/securesign/secure-sign-operator/pull/892
* fix(deps): update module github.com/google/go-containerregistry to v0.20.3 by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/886
* fix(deps): update module github.com/sigstore/sigstore to v1.8.15 by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/887
* bump: github runner ubuntu-24.04 by @osmman in https://github.com/securesign/secure-sign-operator/pull/896
* fix(deps): update golang.org/x/exp digest to dead583 by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/881
* fix(deps): update k8s.io/utils digest to 24370be by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/882
* :robot: [RHTAS-build-bot] [main] Update Operator Bundle Controller Image by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/895
* chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker digest by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/864
* :robot: [RHTAS-build-bot] [main] Update Operator Bundle Controller Image by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/897
* Update Channel Labels for 1.2.0 by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/901
* Fix Replace images in ci by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/903
* chore(deps): update brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 docker digest to 44fd8f8 by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/910
* chore(deps): update registry.access.redhat.com/ubi9/ubi-minimal docker digest by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/912
* fix(deps): update github.com/openshift/api digest to b7d0481c9094 by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/880
* feat(retrievePodLogs): fetch logs from pods and add to zip  by @kdacosta0 in https://github.com/securesign/secure-sign-operator/pull/878
* chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to d086e9b by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/911
* :robot: [RHTAS-build-bot] [main] Update Operator Bundle Controller Image by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/902
* test: use grc mirror to pull httpd image by @osmman in https://github.com/securesign/secure-sign-operator/pull/929
* test: remove unmaintained actions-rs/toolchain step from github workflow by @osmman in https://github.com/securesign/secure-sign-operator/pull/931
* :robot: [RHTAS-build-bot] [main] Update Operator Bundle Controller Image by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/927
* :robot: [RHTAS-build-bot] [main] Update Component images by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/913
* :robot: [RHTAS-build-bot] [main] Update Component images by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/942
* :robot: [RHTAS-build-bot] [main] Update Component images by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/945
* :robot: [RHTAS-build-bot] [main] Update Operator Bundle Controller Image by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/939
* chore: update go module version and controller tools by @osmman in https://github.com/securesign/secure-sign-operator/pull/948
* :robot: [RHTAS-build-bot] [main] Update Component images by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/947
* :robot: [RHTAS-build-bot] [main] Update Component images by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/954
* :robot: [RHTAS-build-bot] [main] Update Component images by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/966
* Update registry.access.redhat.com/ubi9/ubi-minimal Docker digest by @red-hat-konflux in https://github.com/securesign/secure-sign-operator/pull/962
* :robot: [RHTAS-build-bot] [main] Update Component images by @JasonPowr in https://github.com/securesign/secure-sign-operator/pull/970
* ci: add configuration for generated release notes by @osmman in https://github.com/securesign/secure-sign-operator/pull/977

## New Contributors
* @petrpinkas made their first contribution in https://github.com/securesign/secure-sign-operator/pull/833
* @bkabrda made their first contribution in https://github.com/securesign/secure-sign-operator/pull/852
* @kdacosta0 made their first contribution in https://github.com/securesign/secure-sign-operator/pull/878

**Full Changelog**: https://github.com/securesign/secure-sign-operator/compare/v1.1.0...v0.0.0
```