### PR TITLE
refactor: remove prometheus-operator dependency

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,7 +33,6 @@ import (
 	consolev1 "github.com/openshift/api/console/v1"
 	v1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/securesign/operator/internal/clidownload"
 	"github.com/securesign/operator/internal/controller/common/utils"
 	"github.com/securesign/operator/internal/controller/constants"
@@ -72,7 +71,6 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(rhtasv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(v1.AddToScheme(scheme))

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/openshift/api v0.0.0-20250411135543-10a8fa583797
 	github.com/operator-framework/api v0.30.0
 	github.com/operator-framework/operator-lib v0.17.0
-	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.81.0
 	github.com/robfig/cron/v3 v3.0.1
 	golang.org/x/net v0.39.0
 	google.golang.org/protobuf v1.36.6

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.81.0 h1:mSii7z+TihzdeULnGjLnNikgtDbeViY/wW8s3430rhE=
-github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.81.0/go.mod h1:YfnEQzw7tUQa0Sjiz8V6QFc6JUGE+i5wybsjc3EOKn8=
 github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
 github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/internal/controller/common/utils/kubernetes/ensure/ensure_test.go
+++ b/internal/controller/common/utils/kubernetes/ensure/ensure_test.go
@@ -2,16 +2,14 @@ package ensure
 
 import (
 	"context"
+	"testing"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	"testing"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/controller/annotations"
 	"github.com/securesign/operator/internal/controller/common/utils/kubernetes"
@@ -365,7 +363,6 @@ func Test_Ensure(t *testing.T) {
 func fakeClientBuilder() *fake.ClientBuilder {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(rhtasv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(v1.AddToScheme(scheme))

--- a/internal/controller/common/utils/kubernetes/service_moniter_test.go
+++ b/internal/controller/common/utils/kubernetes/service_moniter_test.go
@@ -1,0 +1,141 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestCreateServiceMonitor(t *testing.T) {
+	type args struct {
+		namespace string
+		name      string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *unstructured.Unstructured
+	}{
+		{
+			name: "simple",
+			args: args{
+				"default",
+				"simple",
+			},
+			want: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "monitoring.coreos.com/v1",
+					"kind":       "ServiceMonitor",
+					"metadata": map[string]interface{}{
+						"name":      "simple",
+						"namespace": "default",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CreateServiceMonitor(tt.args.namespace, tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateServiceMonitor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureServiceMonitorSpec(t *testing.T) {
+	type args struct {
+		selectorLabels map[string]string
+		endpoints      []serviceMonitorEndpoint
+	}
+	tests := []struct {
+		name string
+		args args
+		want func(gomega.Gomega, *unstructured.Unstructured)
+	}{
+		{
+			name: "empty",
+			args: args{},
+			want: func(g gomega.Gomega, u *unstructured.Unstructured) {
+				endpoints, found, err := unstructured.NestedSlice(u.Object, "spec", "endpoints")
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(found).Should(gomega.BeTrue())
+				g.Expect(endpoints).Should(gomega.BeEmpty())
+
+				selector, found, err := unstructured.NestedStringMap(u.Object, "spec", "selector", "matchLabels")
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(found).Should(gomega.BeTrue())
+				g.Expect(selector).Should(gomega.BeEmpty())
+				g.Expect(selector).Should(gomega.BeEmpty())
+			},
+		},
+		{
+			name: "single endpoint",
+			args: args{
+				endpoints: []serviceMonitorEndpoint{
+					ServiceMonitorEndpoint("http"),
+				},
+				selectorLabels: map[string]string{
+					"label": "value",
+				},
+			},
+			want: func(g gomega.Gomega, u *unstructured.Unstructured) {
+				endpoints, found, err := unstructured.NestedSlice(u.Object, "spec", "endpoints")
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(found).Should(gomega.BeTrue())
+				g.Expect(endpoints).ShouldNot(gomega.BeEmpty())
+				g.Expect(endpoints).To(gomega.HaveLen(1))
+				g.Expect(endpoints[0]).To(gomega.HaveKeyWithValue("port", "http"))
+
+				selector, found, err := unstructured.NestedStringMap(u.Object, "spec", "selector", "matchLabels")
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(found).Should(gomega.BeTrue())
+				g.Expect(selector).ShouldNot(gomega.BeEmpty())
+				g.Expect(selector).Should(gomega.HaveKeyWithValue("label", "value"))
+			},
+		},
+		{
+			name: "multiple endpoints",
+			args: args{
+				endpoints: []serviceMonitorEndpoint{
+					ServiceMonitorEndpoint("http"),
+					ServiceMonitorEndpoint("https"),
+					ServiceMonitorEndpoint("grpc"),
+				},
+				selectorLabels: map[string]string{
+					"label":  "value",
+					"label2": "value2",
+				},
+			},
+			want: func(g gomega.Gomega, u *unstructured.Unstructured) {
+				endpoints, found, err := unstructured.NestedSlice(u.Object, "spec", "endpoints")
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(found).Should(gomega.BeTrue())
+				g.Expect(endpoints).ShouldNot(gomega.BeEmpty())
+				g.Expect(endpoints).To(gomega.HaveLen(3))
+				g.Expect(endpoints[0]).To(gomega.HaveKeyWithValue("port", "http"))
+				g.Expect(endpoints[1]).To(gomega.HaveKeyWithValue("port", "https"))
+				g.Expect(endpoints[2]).To(gomega.HaveKeyWithValue("port", "grpc"))
+
+				selector, found, err := unstructured.NestedStringMap(u.Object, "spec", "selector", "matchLabels")
+				g.Expect(err).ShouldNot(gomega.HaveOccurred())
+				g.Expect(found).Should(gomega.BeTrue())
+				g.Expect(selector).ShouldNot(gomega.BeEmpty())
+				g.Expect(selector).Should(gomega.HaveKeyWithValue("label", "value"))
+				g.Expect(selector).Should(gomega.HaveKeyWithValue("label2", "value2"))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			sm := CreateServiceMonitor("default", "monitor")
+			got := EnsureServiceMonitorSpec(tt.args.selectorLabels, tt.args.endpoints...)
+			err := got(sm)
+			g.Expect(err).ShouldNot(gomega.HaveOccurred())
+			tt.want(g, sm)
+		})
+	}
+}

--- a/internal/controller/ctlog/actions/monitoring.go
+++ b/internal/controller/ctlog/actions/monitoring.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"slices"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/controller/common/action"
 	"github.com/securesign/operator/internal/controller/common/utils/kubernetes"
@@ -16,6 +15,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -84,20 +84,13 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CT
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeploymentName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*monitoringv1.ServiceMonitor](instance, i.Client),
-		ensure.Labels[*monitoringv1.ServiceMonitor](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(labels.ForComponent(ComponentName, instance.Name),
-			monitoringv1.Endpoint{
-				Interval: monitoringv1.Duration("30s"),
-				Port:     MetricsPortName,
-				Scheme:   "http",
-			}),
+	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
+		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
+		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
+		kubernetes.EnsureServiceMonitorSpec(
+			labels.ForComponent(ComponentName, instance.Name),
+			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
+		),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
 	}

--- a/internal/controller/fulcio/actions/monitoring.go
+++ b/internal/controller/fulcio/actions/monitoring.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"slices"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/controller/common/action"
 	"github.com/securesign/operator/internal/controller/common/utils/kubernetes"
@@ -16,6 +15,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -84,20 +84,13 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fu
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeploymentName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*monitoringv1.ServiceMonitor](instance, i.Client),
-		ensure.Labels[*monitoringv1.ServiceMonitor](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(labels.ForComponent(ComponentName, instance.Name),
-			monitoringv1.Endpoint{
-				Interval: monitoringv1.Duration("30s"),
-				Port:     MetricsPortName,
-				Scheme:   "http",
-			}),
+	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
+		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
+		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
+		kubernetes.EnsureServiceMonitorSpec(
+			labels.ForComponent(ComponentName, instance.Name),
+			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
+		),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
 	}

--- a/internal/controller/rekor/actions/server/monitoring.go
+++ b/internal/controller/rekor/actions/server/monitoring.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"slices"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/controller/common/action"
 	"github.com/securesign/operator/internal/controller/common/utils/kubernetes"
@@ -17,6 +16,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -97,20 +97,13 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.ServerDeploymentName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*monitoringv1.ServiceMonitor](instance, i.Client),
-		ensure.Labels[*monitoringv1.ServiceMonitor](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(labels.ForComponent(actions.ServerComponentName, instance.Name),
-			monitoringv1.Endpoint{
-				Interval: monitoringv1.Duration("30s"),
-				Port:     actions.MetricsPortName,
-				Scheme:   "http",
-			}),
+	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.ServerDeploymentName),
+		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
+		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
+		kubernetes.EnsureServiceMonitorSpec(
+			labels.ForComponent(actions.ServerComponentName, instance.Name),
+			kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
+		),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance, metav1.Condition{
 			Type:    actions.ServerCondition,

--- a/internal/controller/trillian/actions/logserver/monitoring.go
+++ b/internal/controller/trillian/actions/logserver/monitoring.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"slices"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/controller/common/action"
 	"github.com/securesign/operator/internal/controller/common/utils/kubernetes"
@@ -17,6 +16,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -84,20 +84,13 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tr
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.LogServerComponentName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*monitoringv1.ServiceMonitor](instance, i.Client),
-		ensure.Labels[*monitoringv1.ServiceMonitor](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(labels.ForComponent(actions.LogServerComponentName, instance.Name),
-			monitoringv1.Endpoint{
-				Interval: monitoringv1.Duration("30s"),
-				Port:     actions.MetricsPortName,
-				Scheme:   "http",
-			}),
+	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.LogServerComponentName),
+		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
+		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
+		kubernetes.EnsureServiceMonitorSpec(
+			labels.ForComponent(actions.LogServerComponentName, instance.Name),
+			kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
+		),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance,
 			metav1.Condition{

--- a/internal/controller/tsa/actions/monitoring.go
+++ b/internal/controller/tsa/actions/monitoring.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"slices"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/controller/common/action"
 	"github.com/securesign/operator/internal/controller/common/utils/kubernetes"
@@ -16,6 +15,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -82,20 +82,13 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Ti
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &monitoringv1.ServiceMonitor{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      DeploymentName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*monitoringv1.ServiceMonitor](instance, i.Client),
-		ensure.Labels[*monitoringv1.ServiceMonitor](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(labels.ForComponent(ComponentName, instance.Name),
-			monitoringv1.Endpoint{
-				Interval: monitoringv1.Duration("30s"),
-				Port:     MetricsPortName,
-				Scheme:   "http",
-			}),
+	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
+		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
+		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
+		kubernetes.EnsureServiceMonitorSpec(
+			labels.ForComponent(ComponentName, instance.Name),
+			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
+		),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
 	}

--- a/internal/testing/action/support.go
+++ b/internal/testing/action/support.go
@@ -4,7 +4,6 @@ import (
 	"github.com/go-logr/logr"
 	consolev1 "github.com/openshift/api/console/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/apis"
 	"github.com/securesign/operator/internal/controller/common/action"
@@ -21,7 +20,6 @@ import (
 func FakeClientBuilder() *fake.ClientBuilder {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(v1.AddToScheme(scheme))

--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 
 	routev1 "github.com/openshift/api/route/v1"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v12 "k8s.io/api/apps/v1"
 	v13 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,7 +52,6 @@ func IsCIEnvironment() bool {
 func CreateClient() (runtimeCli.Client, error) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(rhtasv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(olmAlpha.AddToScheme(scheme))


### PR DESCRIPTION
Change to use unstructured api to operate with SecureMonitor resources.