### PR TITLE
chore: bump operator version to 1.3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
           }
           EOF
           #TODO: versions needs to be maintained - try to eliminate
-          cat <<< $(jq  'select(.schema == "olm.channel" and .name == "stable").entries += [{"name":"rhtas-operator.v1.2.0", "replaces": "rhtas-operator.v1.1.2"}]' v4.14/graph.json) > v4.14/graph.json
+          cat <<< $(jq  'select(.schema == "olm.channel" and .name == "stable").entries += [{"name":"rhtas-operator.v1.3.0", "replaces": "rhtas-operator.v1.2.0"}]' v4.14/graph.json) > v4.14/graph.json
           cat v4.14/graph.json
           ${{ env.OPM }} alpha render-template basic v4.14/graph.json > v4.14/catalog/rhtas-operator/catalog.json
           ${{ env.OPM }} validate v4.14/catalog/rhtas-operator

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
           }
           EOF
           #TODO: versions needs to be maintained - try to eliminate
-          cat <<< $(jq  'select(.schema == "olm.channel" and .name == "stable").entries += [{"name":"rhtas-operator.v1.3.0", "replaces": "rhtas-operator.v1.2.0"}]' v4.14/graph.json) > v4.14/graph.json
+          cat <<< $(jq  'select(.schema == "olm.channel" and .name == "stable").entries += [{"name":"rhtas-operator.v1.3.0", "replaces": "${{ vars.LATEST_OLM_CHANNEL }}"}]' v4.14/graph.json) > v4.14/graph.json
           cat v4.14/graph.json
           ${{ env.OPM }} alpha render-template basic v4.14/graph.json > v4.14/catalog/rhtas-operator/catalog.json
           ${{ env.OPM }} validate v4.14/catalog/rhtas-operator

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.2.0
+VERSION ?= 1.3.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -14,7 +14,7 @@ LABEL operators.openshift.io/valid-subscription="Red Hat Trusted Artifact Signer
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://www.redhat.com"
 LABEL distribution-scope="public"
-LABEL version="1.2.0"
+LABEL version="1.3.0"
 
 LABEL description="The bundle image for the rhtas-operator, containing manifests, metadata and testing scorecard."
 LABEL io.k8s.description="The bundle image for the rhtas-operator, containing manifests, metadata and testing scorecard."

--- a/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
@@ -297,7 +297,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:0332d8e99dca5eb443a0de6800817d286057498374faa7a9d59b592efb453a3a
-    createdAt: "2025-04-15T19:15:42Z"
+    createdAt: "2025-05-06T10:29:24Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -313,7 +313,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/securesign/secure-sign-operator
     support: Red Hat
-  name: rhtas-operator.v1.2.0
+  name: rhtas-operator.v1.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -640,7 +640,7 @@ spec:
                 - name: RELATED_IMAGE_TRILLIAN_DB
                   value: registry.redhat.io/rhtas/trillian-database-rhel9@sha256:1921a746556119f6e0d6a41dfb528555e38eda4ff046ebb889e7f8a66c13cd03
                 - name: RELATED_IMAGE_TRILLIAN_NETCAT
-                  value: registry.redhat.io/openshift4/ose-tools-rhel9@sha256:ceffda1d467e7ae6fd4ea29c82307d6785f85ce564f8ddb0ce02fe8daa8d24fb
+                  value: registry.redhat.io/openshift4/ose-tools-rhel9@sha256:62f19013939f81cd3fb2cfaa47b826952a0b0bb1b1325cd38f01441604188bd6
                 - name: RELATED_IMAGE_TRILLIAN_CREATE_TREE
                   value: registry.redhat.io/rhtas/createtree-rhel9@sha256:56518f269821a2ef6f6e7158933694c25eda132cbf5db0c3e81aa274c22fa3f4
                 - name: RELATED_IMAGE_FULCIO_SERVER
@@ -648,23 +648,23 @@ spec:
                 - name: RELATED_IMAGE_REKOR_REDIS
                   value: registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:2f8e0dace36fe0631ade827d21bf48c25e502a02b0e8d20d26804cf75880ec02
                 - name: RELATED_IMAGE_REKOR_SERVER
-                  value: registry.redhat.io/rhtas/rekor-server-rhel9@sha256:79906e4d0d0e07c3bbc0d3589a9c4ae90d7fe53a29dea12682f4b610d08cb657
+                  value: registry.redhat.io/rhtas/rekor-server-rhel9@sha256:d2b2c382f0351e8c46922fc11aa4bc73ce63a77559981c6130faf922c8611dd8
                 - name: RELATED_IMAGE_REKOR_SEARCH_UI
-                  value: registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:571c48ecb2658ce70199c06dc483ea48a16e032a764a6830388ad845f508d981
+                  value: registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:8ca88a1bdbf69700795cedb4ffac83b6b186f9e091a9da54b1826021c686e6ec
                 - name: RELATED_IMAGE_BACKFILL_REDIS
-                  value: registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:563dbc131ace1e9b2565fb7c4414ed583c045d3f269b536a00592c48c843b3ca
+                  value: registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:c748eed487228737c0543438a54252829644c26604742371650166c5361f88a6
                 - name: RELATED_IMAGE_TUF
-                  value: registry.redhat.io/rhtas/tuffer-rhel9@sha256:775b261b8f258b369213246f2da5c91218678acb5e3b8bb4670b143f487767af
+                  value: registry.redhat.io/rhtas/tuffer-rhel9@sha256:6884b1997a98a0c6b83543a64d849408a658e45021f2050b267c6de184edce72
                 - name: RELATED_IMAGE_CTLOG
                   value: registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:166c74603a075a57df7c47cc78ffdc5a1b7523744d66b2532e6451ac756fe65b
                 - name: RELATED_IMAGE_HTTP_SERVER
-                  value: registry.redhat.io/ubi9/httpd-24@sha256:366cc5bc3b96069fecaa0abeb9d3510c507e69a20de1d205d881da8ae8561ab4
+                  value: registry.redhat.io/ubi9/httpd-24@sha256:2b6b324b10d142e8618ad2818edbb7793376f0def0d49603772b8fb64a53439d
                 - name: RELATED_IMAGE_SEGMENT_REPORTING
                   value: registry.redhat.io/rhtas/segment-reporting-rhel9@sha256:67dd8978930084aaf02d9c4ad212888dca235af136b25b2b94b6be4c3b934c74
                 - name: RELATED_IMAGE_TIMESTAMP_AUTHORITY
                   value: registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:912e7ce4632bf51731c2d9402c7c2f6dba1f7d539e907a2d9a2362478bd91716
                 - name: RELATED_IMAGE_CLIENT_SERVER
-                  value: registry.redhat.io/rhtas/client-server-rhel9@sha256:00b0fa3bb01eed3139ae3984cd53ad76ef8ec51224f46dbb9e58b54cc4797eb0
+                  value: registry.redhat.io/rhtas/client-server-rhel9@sha256:e9a175b14891e7bdd724cdd7d98129bcc8bc3f87435020292ede514534ae23a0
                 image: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:0332d8e99dca5eb443a0de6800817d286057498374faa7a9d59b592efb453a3a
                 livenessProbe:
                   httpGet:
@@ -778,7 +778,7 @@ spec:
     name: trillian-log-server
   - image: registry.redhat.io/rhtas/trillian-database-rhel9@sha256:1921a746556119f6e0d6a41dfb528555e38eda4ff046ebb889e7f8a66c13cd03
     name: trillian-db
-  - image: registry.redhat.io/openshift4/ose-tools-rhel9@sha256:ceffda1d467e7ae6fd4ea29c82307d6785f85ce564f8ddb0ce02fe8daa8d24fb
+  - image: registry.redhat.io/openshift4/ose-tools-rhel9@sha256:62f19013939f81cd3fb2cfaa47b826952a0b0bb1b1325cd38f01441604188bd6
     name: trillian-netcat
   - image: registry.redhat.io/rhtas/createtree-rhel9@sha256:56518f269821a2ef6f6e7158933694c25eda132cbf5db0c3e81aa274c22fa3f4
     name: trillian-create-tree
@@ -786,22 +786,22 @@ spec:
     name: fulcio-server
   - image: registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:2f8e0dace36fe0631ade827d21bf48c25e502a02b0e8d20d26804cf75880ec02
     name: rekor-redis
-  - image: registry.redhat.io/rhtas/rekor-server-rhel9@sha256:79906e4d0d0e07c3bbc0d3589a9c4ae90d7fe53a29dea12682f4b610d08cb657
+  - image: registry.redhat.io/rhtas/rekor-server-rhel9@sha256:d2b2c382f0351e8c46922fc11aa4bc73ce63a77559981c6130faf922c8611dd8
     name: rekor-server
-  - image: registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:571c48ecb2658ce70199c06dc483ea48a16e032a764a6830388ad845f508d981
+  - image: registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:8ca88a1bdbf69700795cedb4ffac83b6b186f9e091a9da54b1826021c686e6ec
     name: rekor-search-ui
-  - image: registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:563dbc131ace1e9b2565fb7c4414ed583c045d3f269b536a00592c48c843b3ca
+  - image: registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:c748eed487228737c0543438a54252829644c26604742371650166c5361f88a6
     name: backfill-redis
-  - image: registry.redhat.io/rhtas/tuffer-rhel9@sha256:775b261b8f258b369213246f2da5c91218678acb5e3b8bb4670b143f487767af
+  - image: registry.redhat.io/rhtas/tuffer-rhel9@sha256:6884b1997a98a0c6b83543a64d849408a658e45021f2050b267c6de184edce72
     name: tuf
   - image: registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:166c74603a075a57df7c47cc78ffdc5a1b7523744d66b2532e6451ac756fe65b
     name: ctlog
-  - image: registry.redhat.io/ubi9/httpd-24@sha256:366cc5bc3b96069fecaa0abeb9d3510c507e69a20de1d205d881da8ae8561ab4
+  - image: registry.redhat.io/ubi9/httpd-24@sha256:2b6b324b10d142e8618ad2818edbb7793376f0def0d49603772b8fb64a53439d
     name: http-server
   - image: registry.redhat.io/rhtas/segment-reporting-rhel9@sha256:67dd8978930084aaf02d9c4ad212888dca235af136b25b2b94b6be4c3b934c74
     name: segment-reporting
   - image: registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:912e7ce4632bf51731c2d9402c7c2f6dba1f7d539e907a2d9a2362478bd91716
     name: timestamp-authority
-  - image: registry.redhat.io/rhtas/client-server-rhel9@sha256:00b0fa3bb01eed3139ae3984cd53ad76ef8ec51224f46dbb9e58b54cc4797eb0
+  - image: registry.redhat.io/rhtas/client-server-rhel9@sha256:e9a175b14891e7bdd724cdd7d98129bcc8bc3f87435020292ede514534ae23a0
     name: client-server
-  version: 1.2.0
+  version: 1.3.0

--- a/bundle/manifests/rhtas-related-images_v1_configmap.yaml
+++ b/bundle/manifests/rhtas-related-images_v1_configmap.yaml
@@ -1,21 +1,21 @@
 apiVersion: v1
 data:
-  RELATED_IMAGE_BACKFILL_REDIS: registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:563dbc131ace1e9b2565fb7c4414ed583c045d3f269b536a00592c48c843b3ca
-  RELATED_IMAGE_CLIENT_SERVER: registry.redhat.io/rhtas/client-server-rhel9@sha256:00b0fa3bb01eed3139ae3984cd53ad76ef8ec51224f46dbb9e58b54cc4797eb0
+  RELATED_IMAGE_BACKFILL_REDIS: registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:c748eed487228737c0543438a54252829644c26604742371650166c5361f88a6
+  RELATED_IMAGE_CLIENT_SERVER: registry.redhat.io/rhtas/client-server-rhel9@sha256:e9a175b14891e7bdd724cdd7d98129bcc8bc3f87435020292ede514534ae23a0
   RELATED_IMAGE_CTLOG: registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:166c74603a075a57df7c47cc78ffdc5a1b7523744d66b2532e6451ac756fe65b
   RELATED_IMAGE_FULCIO_SERVER: registry.redhat.io/rhtas/fulcio-rhel9@sha256:9ccb7764f3812c71a1a802c39c722360a35b9e98239ac4b1761f5dfae1e1c0ac
-  RELATED_IMAGE_HTTP_SERVER: registry.redhat.io/ubi9/httpd-24@sha256:366cc5bc3b96069fecaa0abeb9d3510c507e69a20de1d205d881da8ae8561ab4
+  RELATED_IMAGE_HTTP_SERVER: registry.redhat.io/ubi9/httpd-24@sha256:2b6b324b10d142e8618ad2818edbb7793376f0def0d49603772b8fb64a53439d
   RELATED_IMAGE_REKOR_REDIS: registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:2f8e0dace36fe0631ade827d21bf48c25e502a02b0e8d20d26804cf75880ec02
-  RELATED_IMAGE_REKOR_SEARCH_UI: registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:571c48ecb2658ce70199c06dc483ea48a16e032a764a6830388ad845f508d981
-  RELATED_IMAGE_REKOR_SERVER: registry.redhat.io/rhtas/rekor-server-rhel9@sha256:79906e4d0d0e07c3bbc0d3589a9c4ae90d7fe53a29dea12682f4b610d08cb657
+  RELATED_IMAGE_REKOR_SEARCH_UI: registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:8ca88a1bdbf69700795cedb4ffac83b6b186f9e091a9da54b1826021c686e6ec
+  RELATED_IMAGE_REKOR_SERVER: registry.redhat.io/rhtas/rekor-server-rhel9@sha256:d2b2c382f0351e8c46922fc11aa4bc73ce63a77559981c6130faf922c8611dd8
   RELATED_IMAGE_SEGMENT_REPORTING: registry.redhat.io/rhtas/segment-reporting-rhel9@sha256:67dd8978930084aaf02d9c4ad212888dca235af136b25b2b94b6be4c3b934c74
   RELATED_IMAGE_TIMESTAMP_AUTHORITY: registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:912e7ce4632bf51731c2d9402c7c2f6dba1f7d539e907a2d9a2362478bd91716
   RELATED_IMAGE_TRILLIAN_CREATE_TREE: registry.redhat.io/rhtas/createtree-rhel9@sha256:56518f269821a2ef6f6e7158933694c25eda132cbf5db0c3e81aa274c22fa3f4
   RELATED_IMAGE_TRILLIAN_DB: registry.redhat.io/rhtas/trillian-database-rhel9@sha256:1921a746556119f6e0d6a41dfb528555e38eda4ff046ebb889e7f8a66c13cd03
   RELATED_IMAGE_TRILLIAN_LOG_SERVER: registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:99285a83df8fd97e4fb0338feb35aa556171890154a00ec24ee7473ac8241d32
   RELATED_IMAGE_TRILLIAN_LOG_SIGNER: registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:ee9be1a0edbe52d31fcf9755ac3ec3aeb2d5e8388e47ac8c2e2d83125fd50c44
-  RELATED_IMAGE_TRILLIAN_NETCAT: registry.redhat.io/openshift4/ose-tools-rhel9@sha256:ceffda1d467e7ae6fd4ea29c82307d6785f85ce564f8ddb0ce02fe8daa8d24fb
-  RELATED_IMAGE_TUF: registry.redhat.io/rhtas/tuffer-rhel9@sha256:775b261b8f258b369213246f2da5c91218678acb5e3b8bb4670b143f487767af
+  RELATED_IMAGE_TRILLIAN_NETCAT: registry.redhat.io/openshift4/ose-tools-rhel9@sha256:62f19013939f81cd3fb2cfaa47b826952a0b0bb1b1325cd38f01441604188bd6
+  RELATED_IMAGE_TUF: registry.redhat.io/rhtas/tuffer-rhel9@sha256:6884b1997a98a0c6b83543a64d849408a658e45021f2050b267c6de184edce72
 kind: ConfigMap
 metadata:
   name: rhtas-related-images

--- a/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["Red Hat Trusted Artifact Signer"]'
     repository: https://github.com/securesign/secure-sign-operator
     support: Red Hat
-  name: rhtas-operator.v1.2.0
+  name: rhtas-operator.v1.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -112,4 +112,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/securesign/secure-sign-operator
-  version: 1.2.0
+  version: 1.3.0


### PR DESCRIPTION
## Summary by Sourcery

Bump the RHTAS (Red Hat Trusted Artifact Signer) Operator version from 1.2.0 to 1.3.0

Chores:
- Update operator version across multiple configuration files
- Update image references to new versions