### PR TITLE
chore: bump operator version to 1.2.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
           }
           EOF
           #TODO: versions needs to be maintained - try to eliminate
-          cat <<< $(jq  'select(.schema == "olm.channel" and .name == "stable").entries += [{"name":"rhtas-operator.v1.2.0", "replaces": "rhtas-operator.v1.1.2"}]' v4.14/graph.json) > v4.14/graph.json
+          cat <<< $(jq  'select(.schema == "olm.channel" and .name == "stable").entries += [{"name":"rhtas-operator.v1.2.1", "replaces": "${{ vars.LATEST_OLM_CHANNEL }}"}]' v4.14/graph.json) > v4.14/graph.json
           cat v4.14/graph.json
           ${{ env.OPM }} alpha render-template basic v4.14/graph.json > v4.14/catalog/rhtas-operator/catalog.json
           ${{ env.OPM }} validate v4.14/catalog/rhtas-operator

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.2.0
+VERSION ?= 1.2.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -14,7 +14,7 @@ LABEL operators.openshift.io/valid-subscription="Red Hat Trusted Artifact Signer
 LABEL vendor="Red Hat, Inc."
 LABEL url="https://www.redhat.com"
 LABEL distribution-scope="public"
-LABEL version="1.2.0"
+LABEL version="1.2.1"
 
 LABEL description="The bundle image for the rhtas-operator, containing manifests, metadata and testing scorecard."
 LABEL io.k8s.description="The bundle image for the rhtas-operator, containing manifests, metadata and testing scorecard."

--- a/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
@@ -297,7 +297,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:335608b84ba0a5c3f0067087e6c7735c94d957aa6e63c8e9c2212236965e3b71
-    createdAt: "2025-04-28T09:29:08Z"
+    createdAt: "2025-05-06T11:16:29Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -313,7 +313,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/securesign/secure-sign-operator
     support: Red Hat
-  name: rhtas-operator.v1.2.0
+  name: rhtas-operator.v1.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -800,4 +800,4 @@ spec:
     name: timestamp-authority
   - image: registry.redhat.io/rhtas/client-server-rhel9@sha256:e9a175b14891e7bdd724cdd7d98129bcc8bc3f87435020292ede514534ae23a0
     name: client-server
-  version: 1.2.0
+  version: 1.2.1

--- a/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["Red Hat Trusted Artifact Signer"]'
     repository: https://github.com/securesign/secure-sign-operator
     support: Red Hat
-  name: rhtas-operator.v1.2.0
+  name: rhtas-operator.v1.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Update version references in multiple configuration files and manifests