### PR TITLE
fix: replace gopkg.in/yaml.v2 by sigs.k8s.io/yaml

### DIFF
--- a/api/v1alpha1/fulcio_types.go
+++ b/api/v1alpha1/fulcio_types.go
@@ -58,7 +58,7 @@ type FulcioCert struct {
 type FulcioConfig struct {
 	// OIDC Configuration
 	// +optional
-	OIDCIssuers []OIDCIssuer `json:"OIDCIssuers,omitempty"`
+	OIDCIssuers []OIDCIssuer `json:"OIDCIssuers,omitempty" yaml:"oidc-issuers,omitempty"`
 
 	// A meta issuer has a templated URL of the form:
 	//   https://oidc.eks.*.amazonaws.com/id/*
@@ -68,7 +68,7 @@ type FulcioConfig struct {
 	// * https://oidc.eks.us-west-2.amazonaws.com/id/B02C93B6A2D30341AD01E1B6D48164CB
 	// * https://container.googleapis.com/v1/projects/mattmoor-credit/locations/us-west1-b/clusters/tenant-cluster
 	// +optional
-	MetaIssuers []OIDCIssuer `json:"MetaIssuers,omitempty"`
+	MetaIssuers []OIDCIssuer `json:"MetaIssuers,omitempty" yaml:"meta-issuers,omitempty"`
 }
 
 type OIDCIssuer struct {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	golang.org/x/net v0.39.0
 	google.golang.org/protobuf v1.36.6
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.4
 	k8s.io/apiextensions-apiserver v0.32.4
 	k8s.io/apimachinery v0.32.4

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,6 @@ gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSP
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/controller/fulcio/actions/server_config.go
+++ b/internal/controller/fulcio/actions/server_config.go
@@ -15,8 +15,8 @@ import (
 	"github.com/securesign/operator/internal/controller/constants"
 	"github.com/securesign/operator/internal/controller/labels"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 
-	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/tsa/actions/ntpMonitoring.go
+++ b/internal/controller/tsa/actions/ntpMonitoring.go
@@ -14,13 +14,13 @@ import (
 	"github.com/securesign/operator/internal/controller/constants"
 	"github.com/securesign/operator/internal/controller/labels"
 	tsaUtils "github.com/securesign/operator/internal/controller/tsa/utils"
-	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels2 "k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 const (

--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/yaml"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -32,7 +33,6 @@ import (
 	olmAlpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/securesign/operator/api/v1alpha1"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
-	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/test/e2e/update/fulcio_test.go
+++ b/test/e2e/update/fulcio_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	tufAction "github.com/securesign/operator/internal/controller/tuf/constants"
-	"gopkg.in/yaml.v2"
 
 	"github.com/securesign/operator/test/e2e/support/tas"
 
@@ -26,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	runtimeCli "sigs.k8s.io/controller-runtime/pkg/client"
+	yaml "sigs.k8s.io/yaml/goyaml.v2"
 )
 
 var _ = Describe("Fulcio update", Ordered, func() {


### PR DESCRIPTION
## Summary by Sourcery

Replace gopkg.in/yaml.v2 with sigs.k8s.io/yaml library across the project

Enhancements:
- Remove gopkg.in/yaml.v2 dependency from go.mod

Chores:
- Update import statements to use sigs.k8s.io/yaml instead of gopkg.in/yaml.v2