### PR TITLE
chore: use bundle build pipeline

### DIFF
--- a/.tekton/rhtas-operator-bundle-pull-request.yaml
+++ b/.tekton/rhtas-operator-bundle-pull-request.yaml
@@ -7,9 +7,12 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ("config/***".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged()
-      || ".tekton/rhtas-operator-bundle-pull-request.yaml".pathChanged() || "bundle.Dockerfile".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+      && (".tekton/rhtas-operator-bundle-pull-request.yaml".pathChanged() || ".tekton/rhtas-operator-pull-request.yaml".pathChanged()
+      || "bundle.Dockerfile".pathChanged() || "Dockerfile.rhtas-operator.rh".pathChanged()
+      || "config/***".pathChanged() || "hack/***".pathChanged()
+      || "api/***".pathChanged() || "internal/***".pathChanged() || "cmd/***".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: operator
@@ -37,6 +40,10 @@ spec:
     value: '{"type": "generic", "path": "."}'
   - name: image-expires-after
     value: 5d
+  - name: manager-pipelinerun-selector
+    value: appstudio.openshift.io/application=operator,appstudio.openshift.io/component=rhtas-operator,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type=pull_request
+  - name: manager-registry-url
+    value: registry.redhat.io/rhtas/rhtas-rhel9-operator
   pipelineRef:
     params:
     - name: url
@@ -44,7 +51,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/docker-build-oci-ta.yaml
+      value: pipelines/bundle-build-oci-ta.yaml
     resolver: git
   taskRunTemplate:
     serviceAccountName: build-pipeline-rhtas-operator-bundle

--- a/.tekton/rhtas-operator-bundle-push.yaml
+++ b/.tekton/rhtas-operator-bundle-push.yaml
@@ -8,9 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ("config/***".pathChanged() || ".tekton/bundle-build-pipeline.yaml".pathChanged()
-      || ".tekton/rhtas-operator-bundle-push.yaml".pathChanged() || "bundle.Dockerfile".pathChanged()
-      || "trigger-konflux-builds.txt".pathChanged())
+      == "main" && (".tekton/rhtas-operator-bundle-push.yaml".pathChanged() || ".tekton/rhtas-operator-push.yaml".pathChanged()
+      || "bundle.Dockerfile".pathChanged() || "Dockerfile.rhtas-operator.rh".pathChanged()
+      || "config/***".pathChanged() || "hack/***".pathChanged()
+      || "api/***".pathChanged() || "internal/***".pathChanged() || "cmd/***".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: operator
@@ -36,6 +38,10 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '{"type": "generic", "path": "."}'
+  - name: manager-pipelinerun-selector
+    value: appstudio.openshift.io/application=operator,appstudio.openshift.io/component=rhtas-operator,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type=push
+  - name: manager-registry-url
+    value: registry.redhat.io/rhtas/rhtas-rhel9-operator
   pipelineRef:
     params:
     - name: url
@@ -43,7 +49,7 @@ spec:
     - name: revision
       value: main
     - name: pathInRepo
-      value: pipelines/docker-build-oci-ta.yaml
+      value: pipelines/bundle-build-oci-ta.yaml
     resolver: git
   taskRunTemplate:
     serviceAccountName: build-pipeline-rhtas-operator-bundle

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -9,9 +9,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && (".tekton/operator-build-pipeline.yaml".pathChanged() || ".tekton/rhtas-operator-pull-request.yaml".pathChanged()
-      || "api/***".pathChanged() || "internal/***".pathChanged() || "Dockerfile.rhtas-operator.rh".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged() || "cmd/***".pathChanged())
+      == "main" && (".tekton/rhtas-operator-bundle-pull-request.yaml".pathChanged() || ".tekton/rhtas-operator-pull-request.yaml".pathChanged()
+      || "bundle.Dockerfile".pathChanged() || "Dockerfile.rhtas-operator.rh".pathChanged()
+      || "config/***".pathChanged() || "hack/***".pathChanged()
+      || "api/***".pathChanged() || "internal/***".pathChanged() || "cmd/***".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: operator

--- a/.tekton/rhtas-operator-push.yaml
+++ b/.tekton/rhtas-operator-push.yaml
@@ -8,9 +8,11 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && (".tekton/operator-build-pipeline.yaml".pathChanged() || ".tekton/rhtas-operator-push.yaml".pathChanged()
-      || "api/***".pathChanged() || "internal/***".pathChanged() || "Dockerfile.rhtas-operator.rh".pathChanged()
-      || "go.mod".pathChanged() || "go.sum".pathChanged() || "cmd/***".pathChanged())
+      == "main" && (".tekton/rhtas-operator-bundle-push.yaml".pathChanged() || ".tekton/rhtas-operator-push.yaml".pathChanged()
+      || "bundle.Dockerfile".pathChanged() || "Dockerfile.rhtas-operator.rh".pathChanged()
+      || "config/***".pathChanged() || "hack/***".pathChanged()
+      || "api/***".pathChanged() || "internal/***".pathChanged() || "cmd/***".pathChanged()
+      || "go.mod".pathChanged() || "go.sum".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: operator


### PR DESCRIPTION
Depends on https://github.com/securesign/pipelines/pull/133

## Summary by Sourcery

Migrate to and configure the new bundle build pipeline with expanded triggers

Enhancements:
- Switch pull-request and push pipeline references from the docker-build task to the bundle-build task
- Broaden file-change triggers to include config, hack, api, internal, cmd directories and bundle.Dockerfile, Dockerfile.rhtas-operator.rh, go.mod, and go.sum
- Add manager-pipelinerun-selector and manager-registry-url parameters to bundle pipeline runs
- Update the service account name used for the bundle push pipeline