### PR TITLE
test: Adding redirect URI for model signing

### DIFF
--- a/ci/keycloak/resources/base/tas-client.yaml
+++ b/ci/keycloak/resources/base/tas-client.yaml
@@ -50,6 +50,7 @@ spec:
     standardFlowEnabled: true
     redirectUris:
     - "*"
+    - "urn:ietf:wg:oauth:2.0:oob"
   realmSelector:
     matchLabels:
       app: sso


### PR DESCRIPTION
For model signing and verifying, the libraries currently require this redirect URI. Makes it easier for OOTB testing and such.