### PR TITLE
chore: limit controller-runtime dep version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,15 @@
         "k8s.io/client-go"
       ],
       "allowedVersions": "<0.33.0"
+    },
+    {
+      "matchDatasources": [
+        "go"
+      ],
+      "matchPackageNames": [
+        "sigs.k8s.io/controller-runtime"
+      ],
+      "allowedVersions": "<0.21.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Limit controller-runtime dependency version in renovate.json