### PR TITLE
fix: downgrading autogenerated rekor key to P256

### DIFF
--- a/docs/rekor-key-rotation.md
+++ b/docs/rekor-key-rotation.md
@@ -35,7 +35,7 @@ These variables are necessary for the subsequent steps to successfully rotate th
    Generate a new private key and store it in a Kubernetes secret. You can use the following commands:
 
    ```bash
-   openssl ecparam -genkey -name secp384r1 -noout -out rekor.pem
+   openssl ecparam -genkey -name prime256v1 -noout -out rekor.pem
    kubectl create secret generic rekor-signer-key --from-file=private=rekor.pem
    ```
 

--- a/internal/controller/rekor/actions/server/generate_signer.go
+++ b/internal/controller/rekor/actions/server/generate_signer.go
@@ -192,7 +192,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Rekor) *a
 func (g generateSigner) createSignerKey() ([]byte, []byte, error) {
 	var err error
 
-	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Downgrading EC param of the autogenerated rekor key. This makes it so that we are using a legit compatible signature algorithm instead of the current P385/SHA256 which leads to security issues due to ending bits not being verified properly unless a client has fallbacks and backwards compatibility.

```
"tlogs": [
    {
      "baseUrl": "https://rekor.rhtas",
      "hashAlgorithm": "SHA2_256",
      "publicKey": {
        "rawBytes": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwL+jPygzKH7x1IUVEc97LV3qnYe3aPHLucs21SC5VOioYl4cTe0ZBStjle7ITGaRDhtHNFQo9FEI0KoGwe8iLQ==",
        "keyDetails": "PKIX_ECDSA_P256_SHA_256",
        "validFor": {
          "start": "2025-06-11T14:12:39Z"
        }
      },
      "logId": {
        "keyId": "m1CTl3vJkYhrNYcKxFLIH7cq4lIPCYHIcR2HQQZCOMo="
      }
    }
  ],
```

Shows the correct keyDetails now and works. Signed + verified using the model transparency library. Will also add proper checksum validation to `tough` so that it does not matter the combination, it will assign keyDetails properly