### PR TITLE
fix: changing CA common names

### DIFF
--- a/config/samples/rhtas_v1alpha1_securesign.yaml
+++ b/config/samples/rhtas_v1alpha1_securesign.yaml
@@ -60,12 +60,12 @@ spec:
         rootCA:
           organizationName: Red Hat
           organizationEmail: jdoe@redhat.com
-          commonName: tsa.hostname
+          commonName: tsa.hostname-root
         intermediateCA:
           - organizationName: Red Hat
             organizationEmail: jdoe@redhat.com
-            commonName: tsa.hostname
+            commonName: tsa.hostname-intermediate
         leafCA:
           organizationName: Red Hat
           organizationEmail: jdoe@redhat.com
-          commonName: tsa.hostname
+          commonName: tsa.hostname-leaf

--- a/config/samples/rhtas_v1alpha1_timestampauthority.yaml
+++ b/config/samples/rhtas_v1alpha1_timestampauthority.yaml
@@ -20,12 +20,12 @@ spec:
       rootCA:
         organizationName: Red Hat
         organizationEmail: jdoe@redhat.com
-        commonName: tsa.hostname
+        commonName: tsa.hostname-root
       intermediateCA:
         - organizationName: Red Hat
           organizationEmail: jdoe@redhat.com
-          commonName: tsa.hostname
+          commonName: tsa.hostname-intermediate
       leafCA:
         organizationName: Red Hat
         organizationEmail: jdoe@redhat.com
-        commonName: tsa.hostname
+        commonName: tsa.hostname-leaf


### PR DESCRIPTION
A library I am working with for model signing is extremely strict with self signed CA's, and will not allow them whatsoever. This change makes it possible for TAS to work out the box with no issues.