### PR TITLE
test: enable searchui tests with headless browser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -404,6 +404,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "securesign/sigstore-e2e"
+          ref: tturek/no-sandbox
           path: e2e
 
       - name: Install Go
@@ -476,13 +477,13 @@ jobs:
           export TUF_URL=$(kubectl get tuf -o jsonpath='{.items[0].status.url}' -n ${{ env.TEST_NAMESPACE }})
           export TSA_URL=$(kubectl get timestampauthorities -o jsonpath='{.items[0].status.url}' -n ${{ env.TEST_NAMESPACE }})/api/v1/timestamp
           
-          export  CLI_STRATEGY=cli_server
+          export CLI_STRATEGY=cli_server
           export CLI_SERVER_URL="http://cli-server.local"
+          export HEADLESS_UI=true
           
           cd e2e
           source ./tas-env-variables.sh
-          # exclude UI tests
-          go test -v $(go list ./test/... | grep -v rekorsearchui)
+          go test -v $(go list ./test/...)
 
       - name: dump the logs of the operator
         run: |


### PR DESCRIPTION
## Summary by Sourcery

Enable end-to-end search UI tests in CI by running them in headless mode and removing their exclusion

CI:
- Add HEADLESS_UI environment variable to CI workflow
- Remove grep filter to include previously excluded rekorsearchui tests

Tests:
- Allow search UI tests to run under headless browser in e2e suite