### PR TITLE
fix: prevent creating Redis cache with non-Redis provider

### DIFF
--- a/api/v1alpha1/rekor_types.go
+++ b/api/v1alpha1/rekor_types.go
@@ -90,6 +90,8 @@ type RekorSearchUI struct {
 	RouteSelectorLabels map[string]string `json:"routeSelectorLabels,omitempty"`
 }
 
+// SearchIndex define search index connection
+// +kubebuilder:validation:XValidation:rule=(!(self.create && self.provider != "redis")),message='create' field can only be true when 'provider' is 'redis'
 type SearchIndex struct {
 	// Create Database if a database is not created one must be defined using the Url field
 	//+kubebuilder:default:=true

--- a/config/crd/bases/rhtas.redhat.com_rekors.yaml
+++ b/config/crd/bases/rhtas.redhat.com_rekors.yaml
@@ -360,6 +360,10 @@ spec:
                 required:
                 - create
                 type: object
+                x-kubernetes-validations:
+                - message: '''create'' field can only be true when ''provider'' is
+                    ''redis'''
+                  rule: (!(self.create && self.provider != "redis"))
               sharding:
                 default: []
                 description: Inactive shards

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -2878,6 +2878,10 @@ spec:
                     required:
                     - create
                     type: object
+                    x-kubernetes-validations:
+                    - message: '''create'' field can only be true when ''provider''
+                        is ''redis'''
+                      rule: (!(self.create && self.provider != "redis"))
                   sharding:
                     default: []
                     description: Inactive shards

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/helper.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/helper.go
@@ -6,5 +6,5 @@ import (
 )
 
 func enabled(instance *v1alpha1.Rekor) bool {
-	return utils.OptionalBool(instance.Spec.SearchIndex.Create)
+	return utils.OptionalBool(instance.Spec.SearchIndex.Create) && instance.Spec.SearchIndex.Provider == "redis"
 }


### PR DESCRIPTION
## Summary by Sourcery

Enforce that the SearchIndex “create” flag can only be true when the provider is Redis by adding CRD validations, updating controller logic, and covering the behavior with unit tests.

Bug Fixes:
- Reject SearchIndex.create=true when provider is not Redis
- Reject unsupported SearchIndex.provider values

Enhancements:
- Add XValidation rules in the Rekor and SecureSigns CRDs and struct tags
- Update Redis search index helper to respect the provider before creating the cache

Tests:
- Add unit tests for invalid provider values and immutability of SearchIndex.create
- Add tests to verify create behaviors for Redis and MySQL providers, including external indexing cases