### PR TITLE
fix(SECURESIGN-2058): Fix conditions for creating ingress objects

### DIFF
--- a/internal/controller/fulcio/actions/ingress.go
+++ b/internal/controller/fulcio/actions/ingress.go
@@ -34,7 +34,7 @@ func (i ingressAction) Name() string {
 
 func (i ingressAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Fulcio) bool {
 	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return c.Reason == constants.Creating || c.Reason == constants.Ready &&
+	return (c.Reason == constants.Creating || c.Reason == constants.Ready) &&
 		instance.Spec.ExternalAccess.Enabled
 }
 

--- a/internal/controller/fulcio/actions/ingress_test.go
+++ b/internal/controller/fulcio/actions/ingress_test.go
@@ -1,0 +1,59 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngress_CanHandle(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+	tests := []struct {
+		name           string
+		conditions     []metav1.Condition
+		externalAccess bool
+		expected       bool
+	}{
+		{
+			name:           "ingress is enabled and fulcio is ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: true,
+			expected:       true,
+		},
+		{
+			name:           "ingress is enabled and fulcio is not ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionFalse, Reason: constants.Pending}},
+			externalAccess: true,
+			expected:       false,
+		},
+		{
+			name:           "ingress is disabled",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: false,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := rhtasv1alpha1.Fulcio{
+				Spec: rhtasv1alpha1.FulcioSpec{
+					ExternalAccess: rhtasv1alpha1.ExternalAccess{
+						Enabled: tt.externalAccess,
+					},
+				},
+				Status: rhtasv1alpha1.FulcioStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			action := NewIngressAction()
+			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+		})
+	}
+}

--- a/internal/controller/rekor/actions/server/ingress_test.go
+++ b/internal/controller/rekor/actions/server/ingress_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngress_CanHandle(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+	tests := []struct {
+		name           string
+		conditions     []metav1.Condition
+		externalAccess bool
+		expected       bool
+	}{
+		{
+			name:           "ingress is enabled and rekor is ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: true,
+			expected:       true,
+		},
+		{
+			name:           "ingress is enabled and rekor is not ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionFalse, Reason: constants.Pending}},
+			externalAccess: true,
+			expected:       false,
+		},
+		{
+			name:           "ingress is disabled",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: false,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := rhtasv1alpha1.Rekor{
+				Spec: rhtasv1alpha1.RekorSpec{
+					ExternalAccess: rhtasv1alpha1.ExternalAccess{
+						Enabled: tt.externalAccess,
+					},
+				},
+				Status: rhtasv1alpha1.RekorStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			action := NewIngressAction()
+			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+		})
+	}
+}

--- a/internal/controller/rekor/actions/ui/ingress.go
+++ b/internal/controller/rekor/actions/ui/ingress.go
@@ -39,7 +39,7 @@ func (i ingressAction) CanHandle(ctx context.Context, instance *rhtasv1alpha1.Re
 	if c == nil {
 		return false
 	}
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && enabled(instance)
+	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && enabled(instance) && instance.Spec.ExternalAccess.Enabled
 }
 
 func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor) *action.Result {

--- a/internal/controller/rekor/actions/ui/ingress_test.go
+++ b/internal/controller/rekor/actions/ui/ingress_test.go
@@ -1,0 +1,74 @@
+package ui
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/securesign/operator/api/v1alpha1"
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngress_CanHandle(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+	tests := []struct {
+		name           string
+		conditions     []metav1.Condition
+		externalAccess bool
+		uiEnabled      bool
+		expected       bool
+	}{
+		{
+			name:           "ingress is enabled and ui is enabled and ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: true,
+			uiEnabled:      true,
+			expected:       true,
+		},
+		{
+			name:           "ingress is enabled and ui is enabled but not ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionFalse, Reason: constants.Pending}},
+			externalAccess: true,
+			uiEnabled:      true,
+			expected:       false,
+		},
+		{
+			name:           "ingress is disabled",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: false,
+			uiEnabled:      true,
+			expected:       false,
+		},
+		{
+			name:           "ingress is enabled but ui is disabled",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: true,
+			uiEnabled:      false,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := rhtasv1alpha1.Rekor{
+				Spec: rhtasv1alpha1.RekorSpec{
+					ExternalAccess: rhtasv1alpha1.ExternalAccess{
+						Enabled: tt.externalAccess,
+					},
+					RekorSearchUI: v1alpha1.RekorSearchUI{
+						Enabled: &tt.uiEnabled,
+					},
+				},
+				Status: rhtasv1alpha1.RekorStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			action := NewIngressAction()
+			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+		})
+	}
+}

--- a/internal/controller/tsa/actions/ingress.go
+++ b/internal/controller/tsa/actions/ingress.go
@@ -35,7 +35,7 @@ func (i ingressAction) Name() string {
 
 func (i ingressAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.TimestampAuthority) bool {
 	c := meta.FindStatusCondition(instance.GetConditions(), constants.Ready)
-	return c.Reason == constants.Creating || c.Reason == constants.Ready && instance.Spec.ExternalAccess.Enabled
+	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && instance.Spec.ExternalAccess.Enabled
 }
 
 func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.TimestampAuthority) *action.Result {

--- a/internal/controller/tsa/actions/ingress_test.go
+++ b/internal/controller/tsa/actions/ingress_test.go
@@ -1,0 +1,59 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngress_CanHandle(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+	tests := []struct {
+		name           string
+		conditions     []metav1.Condition
+		externalAccess bool
+		expected       bool
+	}{
+		{
+			name:           "ingress is enabled and tsa is ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: true,
+			expected:       true,
+		},
+		{
+			name:           "ingress is enabled and tsa is not ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionFalse, Reason: constants.Pending}},
+			externalAccess: true,
+			expected:       false,
+		},
+		{
+			name:           "ingress is disabled",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: false,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := rhtasv1alpha1.TimestampAuthority{
+				Spec: rhtasv1alpha1.TimestampAuthoritySpec{
+					ExternalAccess: rhtasv1alpha1.ExternalAccess{
+						Enabled: tt.externalAccess,
+					},
+				},
+				Status: rhtasv1alpha1.TimestampAuthorityStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			action := NewIngressAction()
+			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+		})
+	}
+}

--- a/internal/controller/tuf/actions/ingress_test.go
+++ b/internal/controller/tuf/actions/ingress_test.go
@@ -1,0 +1,59 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIngress_CanHandle(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+	tests := []struct {
+		name           string
+		conditions     []metav1.Condition
+		externalAccess bool
+		expected       bool
+	}{
+		{
+			name:           "ingress is enabled and tuf is ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: true,
+			expected:       true,
+		},
+		{
+			name:           "ingress is enabled and tuf is not ready",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionFalse, Reason: constants.Pending}},
+			externalAccess: true,
+			expected:       false,
+		},
+		{
+			name:           "ingress is disabled",
+			conditions:     []metav1.Condition{{Type: constants.Ready, Status: metav1.ConditionTrue, Reason: constants.Ready}},
+			externalAccess: false,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := rhtasv1alpha1.Tuf{
+				Spec: rhtasv1alpha1.TufSpec{
+					ExternalAccess: rhtasv1alpha1.ExternalAccess{
+						Enabled: tt.externalAccess,
+					},
+				},
+				Status: rhtasv1alpha1.TufStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			action := NewIngressAction()
+			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+		})
+	}
+}


### PR DESCRIPTION
Ingress objects for Fulcio, Rekor Search UI and TSA will now only be created when they should be. Additionally, tests are added for all CRDs that have externalAccess config that validate this correct behavior.