### PR TITLE
fix: remove default port for ctlog service

### DIFF
--- a/api/v1alpha1/fulcio_types.go
+++ b/api/v1alpha1/fulcio_types.go
@@ -21,7 +21,7 @@ type FulcioSpec struct {
 	ExternalAccess ExternalAccess `json:"externalAccess,omitempty"`
 	// Ctlog service configuration
 	//+optional
-	//+kubebuilder:default:={port: 80, prefix: trusted-artifact-signer}
+	//+kubebuilder:default:={prefix: trusted-artifact-signer}
 	Ctlog CtlogService `json:"ctlog,omitempty"`
 	// Fulcio Configuration
 	//+required

--- a/config/crd/bases/rhtas.redhat.com_fulcios.yaml
+++ b/config/crd/bases/rhtas.redhat.com_fulcios.yaml
@@ -1242,7 +1242,6 @@ spec:
                     (has(self.MetaIssuers) && (size(self.MetaIssuers) > 0))
               ctlog:
                 default:
-                  port: 80
                   prefix: trusted-artifact-signer
                 description: Ctlog service configuration
                 properties:

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -2480,7 +2480,6 @@ spec:
                         || (has(self.MetaIssuers) && (size(self.MetaIssuers) > 0))
                   ctlog:
                     default:
-                      port: 80
                       prefix: trusted-artifact-signer
                     description: Ctlog service configuration
                     properties:


### PR DESCRIPTION
Refs: https://issues.redhat.com/browse/SECURESIGN-2484

## Summary by Sourcery

Remove the default port setting for the Ctlog service across API types and CRD schemas

Bug Fixes:
- Remove hardcoded default port (80) from CtlogService in FulcioSpec Go type
- Remove default port (80) entries for Ctlog service in CRD definitions