### PR TITLE
chore: bump go version to 1.24

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.63
+          version: v2.2.2
           args: --verbose --timeout=15m

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "main", "release*" ]
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
   IMG: ttl.sh/securesign/secure-sign-operator-${{github.run_number}}:1h
   BUNDLE_IMG: ttl.sh/securesign/bundle-secure-sign-${{github.run_number}}:1h
   CATALOG_IMG: ttl.sh/securesign/catalog-${{github.run_number}}:1h

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,11 @@ linters:
     - unconvert
     - unparam
     - unused
+  settings:
+    staticcheck:
+      dot-import-whitelist:
+        - github.com/onsi/gomega
+        - github.com/onsi/ginkgo/v2
   exclusions:
     generated: lax
     paths:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,38 +1,40 @@
+version: "2"
 run:
-  allow-parallel-runners: true
   build-tags:
     - integration
     - upgrade
     - custom_install
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude:
-  - 'SA1019: .*.Failed.* is deprecated'
-  - 'SA1019: .*.Ensure is deprecated'
-
+  allow-parallel-runners: true
 linters:
-  disable-all: true
+  default: none
   enable:
-    - errcheck
     - copyloopvar
+    - errcheck
     - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
     - prealloc
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.rhtas-operator.rh
+++ b/Dockerfile.rhtas-operator.rh
@@ -1,7 +1,10 @@
 # Build the manager binary
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23@sha256:4805e1cb2d1bd9d3c5de5d6986056bbda94ca7b01642f721d83d26579d333c60 as builder
+FROM registry.redhat.io/ubi9/go-toolset:1.24@sha256:6fd64cd7f38a9b87440f963b6c04953d04de65c35b9672dbd7f1805b0ae20d09 as builder
 ARG TARGETOS
 ARG TARGETARCH
+
+ENV GOEXPERIMENT=strictfipsruntime
+ENV CGO_ENABLED=1
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,6 +21,8 @@ COPY internal/ internal/
 
 # Copy images config resources
 COPY config/default/images.env config/default/images.env
+
+USER root
 RUN go generate -mod=readonly ./...
 
 # Build
@@ -25,7 +30,7 @@ RUN go generate -mod=readonly ./...
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=readonly -a -o manager cmd/main.go
+RUN GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=readonly -a -o manager cmd/main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:f172b3082a3d1bbe789a1057f03883c1113243564f01cd3020e27548b911d3f8
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.0
 ENVTEST_VERSION ?= release-0.17
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v2.2.2
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -265,7 +265,7 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/securesign/operator
 
-go 1.23.6
+go 1.24
+
+toolchain go1.24.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/internal/action/base_action.go
+++ b/internal/action/base_action.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	client2 "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -39,8 +38,8 @@ func (action *BaseAction) Continue() *Result {
 	return nil
 }
 
-func (action *BaseAction) StatusUpdate(ctx context.Context, obj client2.Object) *Result {
-	current := obj.DeepCopyObject().(client2.Object)
+func (action *BaseAction) StatusUpdate(ctx context.Context, obj client.Object) *Result {
+	current := obj.DeepCopyObject().(client.Object)
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var (
 			currentStatus, expectedStatus *reflect.Value
@@ -111,7 +110,7 @@ func (action *BaseAction) Requeue() *Result {
 	}
 }
 
-func getStatus(obj client2.Object) (*reflect.Value, error) {
+func getStatus(obj client.Object) (*reflect.Value, error) {
 	stat := reflect.ValueOf(obj).Elem().FieldByName("Status")
 	if stat == reflect.ValueOf(nil) {
 		return nil, errors.New("status field not found")

--- a/internal/action/tree/action.go
+++ b/internal/action/tree/action.go
@@ -201,7 +201,7 @@ func (i resolveTree[T]) handleJob(ctx context.Context, instance T) *action.Resul
 
 	switch {
 	case trillianService.Port == nil:
-		err = fmt.Errorf("%s: %v", i.Name(), TrillianPortNotSpecified)
+		err = fmt.Errorf("%s: %v", i.Name(), ErrTrillianPortNotSpecified)
 	case trillianService.Address == "":
 		trillUrl = fmt.Sprintf("%s.%s.svc:%d", logserverDeploymentName, instance.GetNamespace(), *trillianService.Port)
 	default:
@@ -314,9 +314,9 @@ func (i resolveTree[T]) handleJobFinished(ctx context.Context, instance T) *acti
 			Type:    JobCondition,
 			Status:  metav1.ConditionFalse,
 			Reason:  constants.Failure,
-			Message: JobFailed.Error(),
+			Message: ErrJobFailed.Error(),
 		})
-		return i.Error(ctx, reconcile.TerminalError(JobFailed), instance)
+		return i.Error(ctx, reconcile.TerminalError(ErrJobFailed), instance)
 	}
 
 	return i.Continue()

--- a/internal/action/tree/action_test.go
+++ b/internal/action/tree/action_test.go
@@ -382,7 +382,7 @@ func testMonitorJob(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.Error(reconcile.TerminalError(JobFailed)),
+				result: testAction.Error(reconcile.TerminalError(ErrJobFailed)),
 			},
 		},
 		{

--- a/internal/action/tree/errors.go
+++ b/internal/action/tree/errors.go
@@ -5,6 +5,6 @@ import (
 )
 
 var (
-	TrillianPortNotSpecified = errors.New("trillian port not specified")
-	JobFailed                = errors.New("createtree job failed")
+	ErrTrillianPortNotSpecified = errors.New("trillian port not specified")
+	ErrJobFailed                = errors.New("createtree job failed")
 )

--- a/internal/controller/ctlog/actions/deployment.go
+++ b/internal/controller/ctlog/actions/deployment.go
@@ -58,8 +58,8 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 
 	labels := labels.For(ComponentName, DeploymentName, instance.Name)
 
-	switch {
-	case instance.Spec.Trillian.Address == "":
+	switch instance.Spec.Trillian.Address {
+	case "":
 		instance.Spec.Trillian.Address = fmt.Sprintf("%s.%s.svc", trillian.LogserverDeploymentName, instance.Namespace)
 	}
 
@@ -103,13 +103,13 @@ func (i deployAction) ensureDeployment(instance *rhtasv1alpha1.CTlog, sa string,
 	return func(dp *v1.Deployment) error {
 		switch {
 		case instance.Status.ServerConfigRef == nil:
-			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ServerConfigNotSpecified)
+			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ErrServerConfigNotSpecified)
 		case instance.Status.TreeID == nil:
-			return fmt.Errorf("CreateCTLogDeployment: %w", utils.TreeNotSpecified)
+			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ErrTreeNotSpecified)
 		case instance.Spec.Trillian.Address == "":
-			return fmt.Errorf("CreateCTLogDeployment: %w", utils.TrillianAddressNotSpecified)
+			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ErrTrillianAddressNotSpecified)
 		case instance.Spec.Trillian.Port == nil:
-			return fmt.Errorf("CreateCTLogDeployment: %w", utils.TrillianPortNotSpecified)
+			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ErrTrillianPortNotSpecified)
 		}
 
 		spec := &dp.Spec

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -76,11 +76,11 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 
 	switch {
 	case instance.Status.TreeID == nil:
-		return i.Error(ctx, fmt.Errorf("%s: %v", i.Name(), ctlogUtils.TreeNotSpecified), instance)
+		return i.Error(ctx, fmt.Errorf("%s: %v", i.Name(), ctlogUtils.ErrTreeNotSpecified), instance)
 	case instance.Status.PrivateKeyRef == nil:
-		return i.Error(ctx, fmt.Errorf("%s: %v", i.Name(), ctlogUtils.PrivateKeyNotSpecified), instance)
+		return i.Error(ctx, fmt.Errorf("%s: %v", i.Name(), ctlogUtils.ErrPrivateKeyNotSpecified), instance)
 	case instance.Spec.Trillian.Port == nil:
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("%s: %v", i.Name(), ctlogUtils.TrillianPortNotSpecified)), instance)
+		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("%s: %v", i.Name(), ctlogUtils.ErrTrillianPortNotSpecified)), instance)
 	case instance.Spec.Trillian.Address == "":
 		instance.Spec.Trillian.Address = fmt.Sprintf("%s.%s.svc", trillian.LogserverDeploymentName, instance.Namespace)
 	}

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -80,7 +80,7 @@ func (r *ctlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	var instance rhtasv1alpha1.CTlog
 	rlog := log.FromContext(ctx)
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/internal/controller/ctlog/utils/ctlog_config.go
+++ b/internal/controller/ctlog/utils/ctlog_config.go
@@ -179,13 +179,13 @@ func CreateCtlogConfig(trillianUrl string, treeID int64, rootCerts []RootCertifi
 
 	for _, cert := range rootCerts {
 		if err = ctlogConfig.AddRootCertificate(cert); err != nil {
-			return nil, fmt.Errorf("Failed to add fulcio root: %v", err)
+			return nil, fmt.Errorf("failed to add fulcio root: %v", err)
 		}
 	}
 
 	config, err := ctlogConfig.MarshalConfig()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal ctlog config: %v", err)
+		return nil, fmt.Errorf("failed to marshal ctlog config: %v", err)
 	}
 
 	data := map[string][]byte{

--- a/internal/controller/ctlog/utils/errors.go
+++ b/internal/controller/ctlog/utils/errors.go
@@ -3,9 +3,9 @@ package utils
 import "errors"
 
 var (
-	ServerConfigNotSpecified    = errors.New("server config name not specified")
-	TreeNotSpecified            = errors.New("tree not specified")
-	TrillianAddressNotSpecified = errors.New("trillian address not specified")
-	TrillianPortNotSpecified    = errors.New("trillian port not specified")
-	PrivateKeyNotSpecified      = errors.New("private key not specified")
+	ErrServerConfigNotSpecified    = errors.New("server config name not specified")
+	ErrTreeNotSpecified            = errors.New("tree not specified")
+	ErrTrillianAddressNotSpecified = errors.New("trillian address not specified")
+	ErrTrillianPortNotSpecified    = errors.New("trillian port not specified")
+	ErrPrivateKeyNotSpecified      = errors.New("private key not specified")
 )

--- a/internal/controller/fulcio/actions/deployment.go
+++ b/internal/controller/fulcio/actions/deployment.go
@@ -86,7 +86,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulcio
 
 func (i deployAction) resolveCTlogUrl(instance *rhtasv1alpha1.Fulcio) (string, error) {
 	if instance.Spec.Ctlog.Prefix == "" {
-		return "", futils.CtlogPrefixNotSpecified
+		return "", futils.ErrCtlogPrefixNotSpecified
 	}
 
 	if instance.Spec.Ctlog.Address != "" {

--- a/internal/controller/fulcio/actions/fulcio_deployment_test.go
+++ b/internal/controller/fulcio/actions/fulcio_deployment_test.go
@@ -150,7 +150,7 @@ func TestCtlogConfig(t *testing.T) {
 			},
 			verify: func(g Gomega, deployment *v13.Deployment, err error) {
 				g.Expect(err).Should(HaveOccurred())
-				g.Expect(err).Should(MatchError(utils.CtlogPrefixNotSpecified))
+				g.Expect(err).Should(MatchError(utils.ErrCtlogPrefixNotSpecified))
 			},
 		},
 		{
@@ -255,7 +255,7 @@ func TestResolveCTLUrl(t *testing.T) {
 			ctl:  v1alpha1.CtlogService{Prefix: ""},
 			assert: func(g Gomega, url string, err error) {
 				g.Expect(err).Should(HaveOccurred())
-				g.Expect(err).Should(MatchError(utils.CtlogPrefixNotSpecified))
+				g.Expect(err).Should(MatchError(utils.ErrCtlogPrefixNotSpecified))
 			},
 		},
 		{

--- a/internal/controller/fulcio/actions/generate_cert.go
+++ b/internal/controller/fulcio/actions/generate_cert.go
@@ -56,7 +56,7 @@ func (g handleCert) CanHandle(_ context.Context, instance *v1alpha1.Fulcio) bool
 	switch {
 	case c == nil:
 		return false
-	case !(c.Reason == constants.Pending || c.Reason == constants.Ready):
+	case c.Reason != constants.Pending && c.Reason != constants.Ready:
 		return false
 	case !meta.IsStatusConditionTrue(instance.GetConditions(), CertCondition):
 		return true

--- a/internal/controller/fulcio/fulcio_controller.go
+++ b/internal/controller/fulcio/fulcio_controller.go
@@ -80,7 +80,7 @@ func (r *fulcioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	var instance rhtasv1alpha1.Fulcio
 	log := ctrllog.FromContext(ctx)
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/internal/controller/fulcio/utils/errors.go
+++ b/internal/controller/fulcio/utils/errors.go
@@ -3,7 +3,7 @@ package utils
 import "errors"
 
 var (
-	CtlogAddressNotSpecified = errors.New("ctlog address not specified")
-	CtlogPortNotSpecified    = errors.New("ctlog port not specified")
-	CtlogPrefixNotSpecified  = errors.New("ctlog prefix not specified")
+	ErrCtlogAddressNotSpecified = errors.New("ctlog address not specified")
+	ErrCtlogPortNotSpecified    = errors.New("ctlog port not specified")
+	ErrCtlogPrefixNotSpecified  = errors.New("ctlog prefix not specified")
 )

--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -106,13 +106,13 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 	return func(dp *v2.Deployment) error {
 		switch {
 		case instance.Status.ServerConfigRef == nil:
-			return fmt.Errorf("CreateRekorDeployment: %w", utils.ServerConfigNotSpecified)
+			return fmt.Errorf("CreateRekorDeployment: %w", utils.ErrServerConfigNotSpecified)
 		case instance.Status.TreeID == nil:
-			return fmt.Errorf("CreateRekorDeployment: %w", utils.TreeNotSpecified)
+			return fmt.Errorf("CreateRekorDeployment: %w", utils.ErrTreeNotSpecified)
 		case instance.Spec.Trillian.Address == "":
-			return fmt.Errorf("CreateRekorDeployment: %w", utils.TrillianAddressNotSpecified)
+			return fmt.Errorf("CreateRekorDeployment: %w", utils.ErrTrillianAddressNotSpecified)
 		case instance.Spec.Trillian.Port == nil:
-			return fmt.Errorf("CreateRekorDeployment: %w", utils.TrillianPortNotSpecified)
+			return fmt.Errorf("CreateRekorDeployment: %w", utils.ErrTrillianPortNotSpecified)
 		}
 
 		spec := &dp.Spec
@@ -151,7 +151,7 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 		// KMS secret
 		if instance.Spec.Signer.KMS == "secret" || instance.Spec.Signer.KMS == "" { //nolint:goconst
 			if instance.Status.Signer.KeyRef == nil {
-				return utils.SignerKeyNotSpecified
+				return utils.ErrSignerKeyNotSpecified
 			}
 			var volumeName = "rekor-private-key-volume"
 			privateVolume := kubernetes.FindVolumeByNameOrCreate(&template.Spec, volumeName)

--- a/internal/controller/rekor/actions/server/generate_signer_test.go
+++ b/internal/controller/rekor/actions/server/generate_signer_test.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
-	core "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 
 	. "github.com/onsi/gomega"
 	"github.com/securesign/operator/internal/controller/rekor/actions"
-	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
@@ -482,7 +481,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 			env: env{
 				status: rhtasv1alpha1.RekorSigner{},
 				objects: []client.Object{
-					&core.Secret{
+					&v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "unassigned-secret",
 							Namespace: "default",
@@ -513,7 +512,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 			env: env{
 				status: rhtasv1alpha1.RekorSigner{},
 				objects: []client.Object{
-					&core.Secret{
+					&v1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "unassigned-secret",
 							Namespace: "default",
@@ -533,7 +532,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 					g.Expect(events).To(HaveLen(1))
 					for event := range events {
 						g.Expect(event.Type).Should(Equal(watch.Added))
-						g.Expect(event.Object.(*core.Secret).GenerateName).Should(Equal(fmt.Sprintf(secretNameFormat, "rekor")))
+						g.Expect(event.Object.(*v1.Secret).GenerateName).Should(Equal(fmt.Sprintf(secretNameFormat, "rekor")))
 					}
 				},
 			},
@@ -570,7 +569,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 				WithObjects(tt.env.objects...).
 				Build()
 
-			watchSecrets, err := c.Watch(ctx, &core.SecretList{}, client.InNamespace(instance.Namespace))
+			watchSecrets, err := c.Watch(ctx, &v1.SecretList{}, client.InNamespace(instance.Namespace))
 			g.Expect(err).ShouldNot(HaveOccurred())
 
 			a := testAction.PrepareAction(c, NewGenerateSignerAction())

--- a/internal/controller/rekor/actions/ui/ingress_test.go
+++ b/internal/controller/rekor/actions/ui/ingress_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/securesign/operator/api/v1alpha1"
-	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -54,16 +53,16 @@ func TestIngress_CanHandle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			instance := rhtasv1alpha1.Rekor{
-				Spec: rhtasv1alpha1.RekorSpec{
-					ExternalAccess: rhtasv1alpha1.ExternalAccess{
+			instance := v1alpha1.Rekor{
+				Spec: v1alpha1.RekorSpec{
+					ExternalAccess: v1alpha1.ExternalAccess{
 						Enabled: tt.externalAccess,
 					},
 					RekorSearchUI: v1alpha1.RekorSearchUI{
 						Enabled: &tt.uiEnabled,
 					},
 				},
-				Status: rhtasv1alpha1.RekorStatus{
+				Status: v1alpha1.RekorStatus{
 					Conditions: tt.conditions,
 				},
 			}

--- a/internal/controller/rekor/rekor_controller.go
+++ b/internal/controller/rekor/rekor_controller.go
@@ -86,7 +86,7 @@ func (r *rekorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	var instance rhtasv1alpha1.Rekor
 	log := ctrllog.FromContext(ctx)
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/internal/controller/rekor/utils/errors.go
+++ b/internal/controller/rekor/utils/errors.go
@@ -3,9 +3,9 @@ package utils
 import "errors"
 
 var (
-	ServerConfigNotSpecified    = errors.New("server config name not specified")
-	TreeNotSpecified            = errors.New("tree not specified")
-	TrillianAddressNotSpecified = errors.New("trillian address not specified")
-	TrillianPortNotSpecified    = errors.New("trillian port not specified")
-	SignerKeyNotSpecified       = errors.New("signer key reference not specified")
+	ErrServerConfigNotSpecified    = errors.New("server config name not specified")
+	ErrTreeNotSpecified            = errors.New("tree not specified")
+	ErrTrillianAddressNotSpecified = errors.New("trillian address not specified")
+	ErrTrillianPortNotSpecified    = errors.New("trillian port not specified")
+	ErrSignerKeyNotSpecified       = errors.New("signer key reference not specified")
 )

--- a/internal/controller/securesign/securesign_controller.go
+++ b/internal/controller/securesign/securesign_controller.go
@@ -93,7 +93,7 @@ func (r *securesignReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	var instance rhtasv1alpha1.Securesign
 	log := ctrllog.FromContext(ctx)
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -114,16 +114,16 @@ func (r *securesignReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if instance.DeletionTimestamp != nil {
 		instanceLabels := labels.For(actions.SegmentBackupJobName, actions.SegmentBackupCronJobName, instance.Name)
 		instanceLabels[labels.LabelAppNamespace] = instance.Namespace
-		if err := r.Client.DeleteAllOf(ctx, &v1.ClusterRoleBinding{}, client.MatchingLabels(instanceLabels)); err != nil {
+		if err := r.DeleteAllOf(ctx, &v1.ClusterRoleBinding{}, client.MatchingLabels(instanceLabels)); err != nil {
 			log.Error(err, "problem with removing clusterRoleBinding resource")
 		}
-		if err := r.Client.DeleteAllOf(ctx, &v1.ClusterRole{}, client.MatchingLabels(instanceLabels)); err != nil {
+		if err := r.DeleteAllOf(ctx, &v1.ClusterRole{}, client.MatchingLabels(instanceLabels)); err != nil {
 			log.Error(err, "problem with removing ClusterRole resource")
 		}
-		if err := r.Client.DeleteAllOf(ctx, &v1.Role{}, client.InNamespace(actions.OpenshiftMonitoringNS), client.MatchingLabels(instanceLabels)); err != nil {
+		if err := r.DeleteAllOf(ctx, &v1.Role{}, client.InNamespace(actions.OpenshiftMonitoringNS), client.MatchingLabels(instanceLabels)); err != nil {
 			log.Error(err, "problem with removing Role resource in %s", actions.OpenshiftMonitoringNS)
 		}
-		if err := r.Client.DeleteAllOf(ctx, &v1.RoleBinding{}, client.InNamespace(actions.OpenshiftMonitoringNS), client.MatchingLabels(instanceLabels)); err != nil {
+		if err := r.DeleteAllOf(ctx, &v1.RoleBinding{}, client.InNamespace(actions.OpenshiftMonitoringNS), client.MatchingLabels(instanceLabels)); err != nil {
 			log.Error(err, "problem with removing RoleBinding resource in %s", actions.OpenshiftMonitoringNS)
 		}
 

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -77,7 +77,7 @@ func (r *trillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	var instance rhtasv1alpha1.Trillian
 	log := ctrllog.FromContext(ctx)
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -47,7 +47,7 @@ func (g generateSigner) CanHandle(_ context.Context, instance *v1alpha1.Timestam
 	switch {
 	case c == nil:
 		return false
-	case !(c.Reason == constants.Pending || c.Reason == constants.Ready):
+	case c.Reason != constants.Pending && c.Reason != constants.Ready:
 		return false
 	case !meta.IsStatusConditionTrue(instance.GetConditions(), TSASignerCondition):
 		return true

--- a/internal/controller/tsa/actions/service.go
+++ b/internal/controller/tsa/actions/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +55,7 @@ func (i serviceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Times
 	if instance.Spec.Monitoring.Enabled {
 		ports = append(ports, v1.ServicePort{
 			Name:       MetricsPortName,
-			Protocol:   corev1.ProtocolTCP,
+			Protocol:   v1.ProtocolTCP,
 			Port:       MetricsPort,
 			TargetPort: intstr.FromInt32(MetricsPort),
 		})

--- a/internal/controller/tsa/timestampauthority_controller.go
+++ b/internal/controller/tsa/timestampauthority_controller.go
@@ -73,7 +73,7 @@ func (r *timestampAuthorityReconciler) Reconcile(ctx context.Context, req ctrl.R
 	log := ctrllog.FromContext(ctx)
 	log.V(1).Info("Reconciling Timestamp Authority", "request", req)
 
-	if err := r.Client.Get(ctx, req.NamespacedName, &instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, &instance); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/internal/controller/tsa/utils/tsa_cert_chain.go
+++ b/internal/controller/tsa/utils/tsa_cert_chain.go
@@ -119,7 +119,7 @@ func CreateTSACertChain(ctx context.Context, instance *rhtasv1alpha1.TimestampAu
 	oidTimeStamping := asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8}
 	ekuValues, err := asn1.Marshal([]asn1.ObjectIdentifier{oidTimeStamping})
 	if err != nil {
-		return nil, fmt.Errorf("Failed to encode EKU values: %s", err)
+		return nil, fmt.Errorf("failed to encode EKU values: %s", err)
 	}
 	ekuExtension := pkix.Extension{
 		Id:       oidExtendedKeyUsage,

--- a/internal/controller/tuf/tuf_controller.go
+++ b/internal/controller/tuf/tuf_controller.go
@@ -75,7 +75,7 @@ func (r *tufReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	// Fetch the Tuf instance
 	instance := &rhtasv1alpha1.Tuf{}
 
-	if err := r.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"embed"
-	_ "embed"
 	"fmt"
 	"strings"
 	"sync"

--- a/internal/utils/kubernetes/common.go
+++ b/internal/utils/kubernetes/common.go
@@ -90,12 +90,12 @@ func GetOpenshiftPodSecurityContextRestricted(ctx context.Context, client client
 		return nil, fmt.Errorf("failed to get namespace %q: %w", namespace, err)
 	}
 
-	uidRange, ok := ns.ObjectMeta.Annotations["openshift.io/sa.scc.uid-range"]
+	uidRange, ok := ns.Annotations["openshift.io/sa.scc.uid-range"]
 	if !ok {
 		return nil, errors.New("annotation 'openshift.io/sa.scc.uid-range' not found")
 	}
 
-	supplementalGroups, ok := ns.ObjectMeta.Annotations["openshift.io/sa.scc.supplemental-groups"]
+	supplementalGroups, ok := ns.Annotations["openshift.io/sa.scc.supplemental-groups"]
 	if !ok {
 		supplementalGroups = uidRange
 	}

--- a/renovate.json
+++ b/renovate.json
@@ -16,37 +16,5 @@
       "datasourceTemplate": "docker",
       "versioningTemplate": "redhat"
     }
-  ],
-  "packageRules": [
-    {
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackageNames": [
-        "k8s.io/api",
-        "k8s.io/apiextensions-apiserver",
-        "k8s.io/apimachinery",
-        "k8s.io/client-go"
-      ],
-      "allowedVersions": "<0.33.0"
-    },
-    {
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackageNames": [
-        "sigs.k8s.io/controller-runtime"
-      ],
-      "allowedVersions": "<0.21.0"
-    },
-    {
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackageNames": [
-        "github.com/google/go-containerregistry"
-      ],
-      "allowedVersions": "<=0.20.3"
-    }
   ]
 }

--- a/test/e2e/common_install_test.go
+++ b/test/e2e/common_install_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 			sp := []v1.SecretProjection{}
 			for _, volume := range server.Spec.Volumes {
 				if volume.Name == "fulcio-cert" {
-					for _, source := range volume.VolumeSource.Projected.Sources {
+					for _, source := range volume.Projected.Sources {
 						sp = append(sp, *source.Secret)
 					}
 				}
@@ -236,8 +236,8 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 			Expect(server.Spec.Volumes).To(
 				ContainElement(
 					WithTransform(func(volume v1.Volume) string {
-						if volume.VolumeSource.Secret != nil {
-							return volume.VolumeSource.Secret.SecretName
+						if volume.Secret != nil {
+							return volume.Secret.SecretName
 						}
 						return ""
 					}, Equal(rekor.Get(ctx, cli, namespace.Name, s.Name)().Status.Signer.KeyRef.Name))),
@@ -252,8 +252,8 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 			Expect(server.Spec.Volumes).To(
 				ContainElement(
 					WithTransform(func(volume v1.Volume) string {
-						if volume.VolumeSource.Secret != nil {
-							return volume.VolumeSource.Secret.SecretName
+						if volume.Secret != nil {
+							return volume.Secret.SecretName
 						}
 						return ""
 					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name)().Status.Signer.CertificateChain.CertificateChainRef.Name))),
@@ -261,8 +261,8 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 			Expect(server.Spec.Volumes).To(
 				ContainElement(
 					WithTransform(func(volume v1.Volume) string {
-						if volume.VolumeSource.Secret != nil {
-							return volume.VolumeSource.Secret.SecretName
+						if volume.Secret != nil {
+							return volume.Secret.SecretName
 						}
 						return ""
 					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name)().Status.Signer.File.PrivateKeyRef.Name))),
@@ -276,8 +276,8 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 			Expect(server.Spec.Volumes).To(
 				ContainElement(
 					WithTransform(func(volume v1.Volume) string {
-						if volume.VolumeSource.ConfigMap != nil {
-							return volume.VolumeSource.ConfigMap.Name
+						if volume.ConfigMap != nil {
+							return volume.ConfigMap.Name
 						}
 						return ""
 					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name)().Status.NTPMonitoring.Config.NtpConfigRef.Name))),

--- a/test/e2e/provided_certs_test.go
+++ b/test/e2e/provided_certs_test.go
@@ -230,7 +230,7 @@ var _ = Describe("Securesign install with provided certs", Ordered, func() {
 			sp := []v1.SecretProjection{}
 			for _, volume := range server.Spec.Volumes {
 				if volume.Name == "fulcio-cert" {
-					for _, source := range volume.VolumeSource.Projected.Sources {
+					for _, source := range volume.Projected.Sources {
 						sp = append(sp, *source.Secret)
 					}
 				}
@@ -252,8 +252,8 @@ var _ = Describe("Securesign install with provided certs", Ordered, func() {
 			Expect(server.Spec.Volumes).To(
 				ContainElement(
 					WithTransform(func(volume v1.Volume) string {
-						if volume.VolumeSource.Secret != nil {
-							return volume.VolumeSource.Secret.SecretName
+						if volume.Secret != nil {
+							return volume.Secret.SecretName
 						}
 						return ""
 					}, Equal("my-rekor-secret")),
@@ -268,8 +268,8 @@ var _ = Describe("Securesign install with provided certs", Ordered, func() {
 			Expect(tsa.Spec.Volumes).To(
 				ContainElement(
 					WithTransform(func(volume v1.Volume) string {
-						if volume.VolumeSource.Secret != nil {
-							return volume.VolumeSource.Secret.SecretName
+						if volume.Secret != nil {
+							return volume.Secret.SecretName
 						}
 						return ""
 					}, Equal("test-tsa-secret")),

--- a/test/e2e/support/archive.go
+++ b/test/e2e/support/archive.go
@@ -112,7 +112,7 @@ func Tar(src string, writer io.Writer) error {
 
 	// ensure the src actually exists before trying to tar it
 	if _, err := os.Stat(src); err != nil {
-		return fmt.Errorf("Unable to tar files - %v", err.Error())
+		return fmt.Errorf("unable to tar files - %v", err.Error())
 	}
 
 	tw := tar.NewWriter(writer)
@@ -138,7 +138,7 @@ func Tar(src string, writer io.Writer) error {
 		}
 
 		// update the name to correctly reflect the desired destination when untaring
-		header.Name = strings.TrimPrefix(strings.Replace(file, src, "", -1), string(filepath.Separator))
+		header.Name = strings.TrimPrefix(strings.ReplaceAll(file, src, ""), string(filepath.Separator))
 
 		// write the header
 		if err := tw.WriteHeader(header); err != nil {

--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -32,13 +32,11 @@ import (
 	olm "github.com/operator-framework/api/pkg/operators/v1"
 	olmAlpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/securesign/operator/api/v1alpha1"
-	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	runtimeCli "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func IsCIEnvironment() bool {
@@ -49,10 +47,10 @@ func IsCIEnvironment() bool {
 	return false
 }
 
-func CreateClient() (runtimeCli.Client, error) {
+func CreateClient() (client.Client, error) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-	utilruntime.Must(rhtasv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(olmAlpha.AddToScheme(scheme))
 	utilruntime.Must(olm.AddToScheme(scheme))
@@ -62,7 +60,7 @@ func CreateClient() (runtimeCli.Client, error) {
 		return nil, err
 	}
 
-	return runtimeCli.New(cfg, runtimeCli.Options{Scheme: scheme})
+	return client.New(cfg, client.Options{Scheme: scheme})
 
 }
 func CreateTestNamespace(ctx context.Context, cli client.Client) *v1.Namespace {

--- a/test/e2e/update/ctlog_test.go
+++ b/test/e2e/update/ctlog_test.go
@@ -171,7 +171,7 @@ var _ = Describe("CTlog update", Ordered, func() {
 
 			Expect(ctlPod.Spec.Volumes).To(ContainElements(And(
 				WithTransform(func(v v1.Volume) string { return v.Name }, Equal("keys")),
-				WithTransform(func(v v1.Volume) string { return v.VolumeSource.Secret.SecretName }, Equal(ctl.Status.ServerConfigRef.Name)))))
+				WithTransform(func(v v1.Volume) string { return v.Secret.SecretName }, Equal(ctl.Status.ServerConfigRef.Name)))))
 
 			existing := &v1.Secret{}
 			expected := &v1.Secret{}

--- a/test/e2e/update/fulcio_test.go
+++ b/test/e2e/update/fulcio_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Fulcio update", Ordered, func() {
 			}).Should(Succeed())
 			Expect(fulcioPod.Spec.Volumes).To(ContainElements(And(
 				WithTransform(func(v v1.Volume) string { return v.Name }, Equal("fulcio-cert")),
-				WithTransform(func(v v1.Volume) string { return v.VolumeSource.Projected.Sources[0].Secret.Name }, Equal("my-fulcio-secret")))))
+				WithTransform(func(v v1.Volume) string { return v.Projected.Sources[0].Secret.Name }, Equal("my-fulcio-secret")))))
 
 		})
 

--- a/test/e2e/update/rekor_test.go
+++ b/test/e2e/update/rekor_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Rekor update", Ordered, func() {
 			}).Should(Succeed())
 			Expect(r.Spec.Volumes).To(ContainElements(And(
 				WithTransform(func(v v1.Volume) string { return v.Name }, Equal("rekor-private-key-volume")),
-				WithTransform(func(v v1.Volume) string { return v.VolumeSource.Secret.SecretName }, Equal("my-rekor-secret")))))
+				WithTransform(func(v v1.Volume) string { return v.Secret.SecretName }, Equal("my-rekor-secret")))))
 		})
 
 		It("verify by cosign", func() {

--- a/test/e2e/update/tsa_test.go
+++ b/test/e2e/update/tsa_test.go
@@ -189,12 +189,12 @@ var _ = Describe("TSA update", Ordered, func() {
 
 			Expect(pod.Spec.Volumes).To(ContainElement(And(
 				WithTransform(func(v v1.Volume) string { return v.Name }, Equal("tsa-cert-chain")),
-				WithTransform(func(v v1.Volume) string { return v.VolumeSource.Secret.SecretName }, Equal("my-tsa-secret")),
+				WithTransform(func(v v1.Volume) string { return v.Secret.SecretName }, Equal("my-tsa-secret")),
 			)))
 
 			Expect(pod.Spec.Volumes).To(ContainElement(And(
 				WithTransform(func(v v1.Volume) string { return v.Name }, Equal("tsa-file-signer-config")),
-				WithTransform(func(v v1.Volume) string { return v.VolumeSource.Secret.SecretName }, Equal("my-tsa-secret")),
+				WithTransform(func(v v1.Volume) string { return v.Secret.SecretName }, Equal("my-tsa-secret")),
 			)))
 
 			certChainSecret := &v1.Secret{}
@@ -270,7 +270,7 @@ var _ = Describe("TSA update", Ordered, func() {
 
 			Expect(pod.Spec.Volumes).To(ContainElements(And(
 				WithTransform(func(v v1.Volume) string { return v.Name }, Equal("ntp-config")),
-				WithTransform(func(v v1.Volume) string { return v.VolumeSource.ConfigMap.Name }, Equal(t.Status.NTPMonitoring.Config.NtpConfigRef.Name)))))
+				WithTransform(func(v v1.Volume) string { return v.ConfigMap.Name }, Equal(t.Status.NTPMonitoring.Config.NtpConfigRef.Name)))))
 
 			cm := &v1.ConfigMap{}
 			Expect(cli.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: t.Status.NTPMonitoring.Config.NtpConfigRef.Name}, cm)).To(Succeed())


### PR DESCRIPTION
## Summary by Sourcery

Upgrade the project to Go 1.24 and harmonize tooling, linting, and code conventions

Enhancements:
- Rename error variables across multiple packages to use Err* prefix and update corresponding error checks
- Refactor reconciler methods to use r.Get/r.DeleteAllOf and unify client.Object usage in BaseAction
- Flatten VolumeSource fields to use direct v1.Volume.Secret, ConfigMap, and Projected.Sources and update imports accordingly
- Revise .golangci.yml with version 2 schema, custom lint settings, formatter rules, and exclusion paths
- Apply miscellaneous code cleanups (lowercase error messages, strings.ReplaceAll, import reordering)

Build:
- Update go.mod and toolchain to Go 1.24 and adjust Dockerfiles to use the new base image
- Bump golangci-lint to v2.2.2 in Makefile and download path

CI:
- Switch GitHub Actions workflows to Go 1.24 and golangci-lint-action v7

Tests:
- Adjust unit and end-to-end tests to reflect renamed errors, updated volume fields, and revised import paths

Chores:
- Overhaul .golangci-lint configuration for improved lint coverage and formatting