### PR TITLE
fix: Fix providing custom CA for the rekor createtree job

### DIFF
--- a/internal/action/tree/action.go
+++ b/internal/action/tree/action.go
@@ -234,7 +234,7 @@ func (i resolveTree[T]) handleJob(ctx context.Context, instance T) *action.Resul
 		ensure.ControllerReference[*batchv1.Job](instance, i.Client),
 		ensure.Labels[*batchv1.Job](slices.Collect(maps.Keys(labels)), labels),
 		func(object *batchv1.Job) error {
-			return ensureTls.TrustedCA(instance.GetTrustedCA())(&object.Spec.Template)
+			return ensureTls.TrustedCA(instance.GetTrustedCA(), createTreeContainerName)(&object.Spec.Template)
 		},
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create segment backup job: %w", err), instance,
@@ -367,7 +367,7 @@ func (i resolveTree[T]) ensureJob(cfgName, adminServer, displayName string, extr
 		templateSpec.ServiceAccountName = fmt.Sprintf(RBACNameMask, i.component)
 		templateSpec.RestartPolicy = "OnFailure"
 
-		container := kubernetes.FindContainerByNameOrCreate(templateSpec, "createtree")
+		container := kubernetes.FindContainerByNameOrCreate(templateSpec, createTreeContainerName)
 		container.Image = images.Registry.Get(images.TrillianCreateTree)
 		container.Command = []string{"/bin/sh", "-c"}
 		container.Args = []string{string(jobScript)}

--- a/internal/action/tree/types.go
+++ b/internal/action/tree/types.go
@@ -11,11 +11,12 @@ import (
 var jobScript []byte
 
 const (
-	RBACNameMask         = "%s-createtree-job"
-	JobNameMask          = "%s-createtree-job-"
-	JobCondition         = "Tree"
-	configMapResultMask  = "%s-%s-createtree-result"
-	configMapResultField = "tree_id"
+	RBACNameMask            = "%s-createtree-job"
+	JobNameMask             = "%s-createtree-job-"
+	JobCondition            = "Tree"
+	createTreeContainerName = "createtree"
+	configMapResultMask     = "%s-%s-createtree-result"
+	configMapResultField    = "tree_id"
 )
 
 func Wrapper[T tlsAwareObject](getTree, getStatusTree func(T) *int64, setStatusTree func(T, *int64), getTrillianService func(T) *v1alpha1.TrillianService) func(T) *wrapper[T] {

--- a/internal/utils/kubernetes/ensure/deployment/deployment.go
+++ b/internal/utils/kubernetes/ensure/deployment/deployment.go
@@ -17,9 +17,9 @@ func Proxy(noProxy ...string) func(*v1.Deployment) error {
 }
 
 // TrustedCA mount config map with trusted CA bundle to all deployment's containers.
-func TrustedCA(lor *v1alpha1.LocalObjectReference, containerNames ...string) func(dp *v1.Deployment) error {
+func TrustedCA(lor *v1alpha1.LocalObjectReference, containerName string, moreNames ...string) func(dp *v1.Deployment) error {
 	return func(dp *v1.Deployment) error {
-		return tlsensure.TrustedCA(lor, containerNames...)(&dp.Spec.Template)
+		return tlsensure.TrustedCA(lor, containerName, moreNames...)(&dp.Spec.Template)
 	}
 }
 

--- a/internal/utils/tls/ensure/client.go
+++ b/internal/utils/tls/ensure/client.go
@@ -9,11 +9,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// TrustedCA mount config map with trusted CA bundle to all pod template's containers.
-func TrustedCA(lor *v1alpha1.LocalObjectReference, containerNames ...string) func(template *corev1.PodTemplateSpec) error {
+// TrustedCA mount config map with trusted CA bundle to the provided pod template's containers.
+func TrustedCA(lor *v1alpha1.LocalObjectReference, containerName string, moreNames ...string) func(template *corev1.PodTemplateSpec) error {
+	// NOTE: the "containerName" argument ensures that this function is never called with
 	return func(template *corev1.PodTemplateSpec) error {
 		for i, c := range template.Spec.Containers {
-			if slices.Contains(containerNames, c.Name) {
+			if slices.Contains(append(moreNames, containerName), c.Name) {
 				env := kubernetes.FindEnvByNameOrCreate(&template.Spec.Containers[i], "SSL_CERT_DIR")
 				env.Value = tls.CATrustMountPath + ":/var/run/secrets/kubernetes.io/serviceaccount"
 

--- a/internal/utils/tls/ensure/client.go
+++ b/internal/utils/tls/ensure/client.go
@@ -13,8 +13,9 @@ import (
 func TrustedCA(lor *v1alpha1.LocalObjectReference, containerName string, moreNames ...string) func(template *corev1.PodTemplateSpec) error {
 	// NOTE: the "containerName" argument ensures that this function is never called with
 	return func(template *corev1.PodTemplateSpec) error {
+		containerNames := append(moreNames, containerName)
 		for i, c := range template.Spec.Containers {
-			if slices.Contains(append(moreNames, containerName), c.Name) {
+			if slices.Contains(containerNames, c.Name) {
 				env := kubernetes.FindEnvByNameOrCreate(&template.Spec.Containers[i], "SSL_CERT_DIR")
 				env.Value = tls.CATrustMountPath + ":/var/run/secrets/kubernetes.io/serviceaccount"
 

--- a/internal/utils/tls/tls.go
+++ b/internal/utils/tls/tls.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"path/filepath"
 	"slices"
 
 	"github.com/securesign/operator/internal/apis"
@@ -28,7 +29,7 @@ func CAPath(ctx context.Context, cli client.Client, instance objectWithTlsClient
 			err = fmt.Errorf("%s ConfigMap can contain only 1 record", lor.Name)
 			return "", err
 		}
-		return CATrustMountPath + slices.Collect(maps.Keys(cfgTrust.Data))[0], nil
+		return filepath.Join(CATrustMountPath, slices.Collect(maps.Keys(cfgTrust.Data))[0]), nil
 	case kubernetes.IsOpenShift():
 		return "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt", nil
 	default:

--- a/internal/utils/tls/tls_test.go
+++ b/internal/utils/tls/tls_test.go
@@ -1,0 +1,126 @@
+package tls
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/apis"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	v1 "k8s.io/api/core/v1"
+	v2 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type fakeObjectWithTlsClient struct {
+	client.Object
+	apis.TlsClient
+}
+
+type fakeTlsClient struct {
+	lor v1alpha1.LocalObjectReference
+}
+
+func (f fakeTlsClient) GetTrustedCA() *v1alpha1.LocalObjectReference {
+	return &f.lor
+}
+
+func TestCAPath(t *testing.T) {
+	gomega.RegisterTestingT(t)
+	tests := []struct {
+		name     string
+		objects  []client.Object
+		instance objectWithTlsClient
+		result   string
+		err      bool
+	}{
+		{
+			"trustedCA is defined",
+			[]client.Object{
+				&v1.ConfigMap{
+					ObjectMeta: v2.ObjectMeta{Name: "ca-configmap", Namespace: "tas"},
+					Data:       map[string]string{"ca.pem": "PEM data here"},
+				},
+			},
+			fakeObjectWithTlsClient{
+				Object: &v1.Pod{
+					ObjectMeta: v2.ObjectMeta{
+						Namespace: "tas",
+					},
+				},
+				TlsClient: fakeTlsClient{
+					lor: v1alpha1.LocalObjectReference{
+						Name: "ca-configmap",
+					},
+				},
+			},
+			"/var/run/configs/tas/ca-trust/ca.pem",
+			false,
+		},
+		{
+			"trustedCA is defined but configmap not found",
+			[]client.Object{
+				&v1.ConfigMap{
+					ObjectMeta: v2.ObjectMeta{Name: "ca-configmap", Namespace: "tas"},
+					Data:       map[string]string{"ca.pem": "PEM data here"},
+				},
+			},
+			fakeObjectWithTlsClient{
+				Object: &v1.Pod{
+					ObjectMeta: v2.ObjectMeta{
+						Namespace: "wrong-namespace",
+					},
+				},
+				TlsClient: fakeTlsClient{
+					lor: v1alpha1.LocalObjectReference{
+						Name: "wrong-name",
+					},
+				},
+			},
+			"",
+			true,
+		},
+		{
+			"trustedCA is defined but configmap has multiple keys",
+			[]client.Object{
+				&v1.ConfigMap{
+					ObjectMeta: v2.ObjectMeta{Name: "ca-configmap", Namespace: "tas"},
+					Data:       map[string]string{"ca.pem": "PEM data here", "not": "supposed to be here"},
+				},
+			},
+			fakeObjectWithTlsClient{
+				Object: &v1.Pod{
+					ObjectMeta: v2.ObjectMeta{
+						Namespace: "tas",
+					},
+				},
+				TlsClient: fakeTlsClient{
+					lor: v1alpha1.LocalObjectReference{
+						Name: "ca-configmap",
+					},
+				},
+			},
+			"",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(tt.objects...).
+				Build()
+
+			result, err := CAPath(ctx, c, tt.instance)
+			if tt.err {
+				gomega.Expect(err).To(gomega.HaveOccurred())
+			} else {
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			}
+			gomega.Expect(result).To(gomega.Equal(tt.result))
+		})
+	}
+}


### PR DESCRIPTION
This fixes two issues:
* First, the path provided to the createtree binary was incorrect (missed a file separator)
* Second, the configmap wasn't actually mounted in because no container name was provided to the TrustedCA function.
  * This was possible because the ellipsis argument to TrustedCA would allow the caller to pass in no container names; I fixed this by adding an extra argument before ellipsis, so that the compilation would fail if the user doesn't provide at least one container name.

## Summary by Sourcery

Fix custom CA provisioning for the Trillian create-tree (rekor) job by correcting path construction and guaranteeing config map mounting

Bug Fixes:
- Construct the CA bundle path with filepath.Join to include path separators
- Mount the custom CA config map to the createtree container by enforcing a required container name in TrustedCA helpers and passing it where needed

Enhancements:
- Introduce createTreeContainerName constant and update TrustedCA function signatures to require at least one explicit container name