### PR TITLE
fix: copy entire ctlog TLS config from spec to status

### DIFF
--- a/internal/controller/ctlog/actions/tls.go
+++ b/internal/controller/ctlog/actions/tls.go
@@ -32,7 +32,7 @@ func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *a
 	// TLS
 	switch {
 	case instance.Spec.TLS.CertRef != nil:
-		instance.Status.TLS.CertRef = instance.Spec.TLS.CertRef
+		instance.Status.TLS = instance.Spec.TLS
 	case kubernetes.IsOpenShift():
 		instance.Status.TLS = rhtasv1alpha1.TLS{
 			CertRef: &rhtasv1alpha1.SecretKeySelector{


### PR DESCRIPTION
This change is needed to avoid empty field errors `privateKeyRef cannot be empty`

## Summary by Sourcery

Bug Fixes:
- Copy entire TLS spec into status instead of only CertRef to prevent empty privateKeyRef errors