### PR TITLE
fix: ctlog configuration in securesign sample

### DIFF
--- a/config/samples/rhtas_v1alpha1_securesign.yaml
+++ b/config/samples/rhtas_v1alpha1_securesign.yaml
@@ -47,7 +47,7 @@ spec:
         - ReadWriteOnce
       retain: true
       size: 100Mi
-  ctlog:
+  ctlog: {}
   tsa:
     externalAccess:
       enabled: true


### PR DESCRIPTION
Set empty object to ctlog specification to correctly propagate default values for OLM webform.

## Summary by Sourcery

Bug Fixes:
- Initialize ctlog specification as an empty object in the securesign sample config to allow default values to propagate.