### PR TITLE
fix: Boolean flags must use equal sign

### DIFF
--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -138,7 +138,8 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 			"--trillian_log_server.sharding_config", "/sharding/sharding-config.yaml",
 
 			"--rekor_server.address", "0.0.0.0",
-			"--enable_retrieve_api", "true",
+			// boolean flag MUST be without parameter (default value) or use the equal sign (https://github.com/spf13/pflag?tab=readme-ov-file#command-line-flag-syntax)
+			"--enable_retrieve_api=true",
 			"--trillian_log_server.tlog_id", strconv.FormatInt(*instance.Status.TreeID, 10),
 			"--log_type", utils2.GetOrDefault(instance.GetAnnotations(), annotations.LogType, string(constants.Prod)),
 		}
@@ -239,8 +240,8 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 func (i deployAction) ensureTlsTrillian() func(*v2.Deployment) error {
 	return func(dp *v2.Deployment) error {
 		container := kubernetes.FindContainerByNameOrCreate(&dp.Spec.Template.Spec, actions.ServerDeploymentName)
-
-		container.Args = append(container.Args, "--trillian_log_server.tls", "true")
+		// boolean flag MUST be without parameter (default value) or use the equal sign (https://github.com/spf13/pflag?tab=readme-ov-file#command-line-flag-syntax)
+		container.Args = append(container.Args, "--trillian_log_server.tls=true")
 		return nil
 	}
 }
@@ -251,7 +252,8 @@ func (i deployAction) ensureAttestation(instance *rhtasv1alpha1.Rekor) func(*v2.
 		container := kubernetes.FindContainerByNameOrCreate(&dp.Spec.Template.Spec, actions.ServerDeploymentName)
 		enabled := ptr.Deref(instance.Spec.Attestations.Enabled, false)
 
-		container.Args = append(container.Args, "--enable_attestation_storage", strconv.FormatBool(enabled))
+		// boolean flag MUST be without parameter (default value) or use the equal sign (https://github.com/spf13/pflag?tab=readme-ov-file#command-line-flag-syntax)
+		container.Args = append(container.Args, fmt.Sprintf("--enable_attestation_storage=%t", enabled))
 
 		bucketUrl := instance.Spec.Attestations.Url
 		if bucketUrl == "" {
@@ -302,7 +304,8 @@ func ensureRedisParams() func(*redis.RedisOptions, *v1.Container) {
 			container.Args = append(container.Args, "--redis_server.password", options.Password)
 		}
 		if options.TlsEnabled {
-			container.Args = append(container.Args, "--redis_server.enable-tls", "true")
+			// boolean flag MUST be without parameter (default value) or use the equal sign (https://github.com/spf13/pflag?tab=readme-ov-file#command-line-flag-syntax)
+			container.Args = append(container.Args, "--redis_server.enable-tls=true")
 		}
 	}
 }

--- a/test/e2e/common_install_test.go
+++ b/test/e2e/common_install_test.go
@@ -68,6 +68,10 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 					RekorSearchUI: v1alpha1.RekorSearchUI{
 						Enabled: utils.Pointer(true),
 					},
+					Attestations: v1alpha1.RekorAttestations{
+						// cover SECURESIGN-2694
+						Enabled: ptr.To(false),
+					},
 				},
 				Fulcio: v1alpha1.FulcioSpec{
 					ExternalAccess: v1alpha1.ExternalAccess{


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/SECURESIGN-2694

## Summary by Sourcery

Enforce pflag-compliant equal sign syntax for boolean flags in deployment configurations and add E2E test coverage for disabling attestation storage.

Bug Fixes:
- Correct boolean flags to use equal sign syntax (--flag=true) for Rekor server options and Redis TLS enablement

Tests:
- Add E2E test case covering disabled attestation storage flag in the common install scenario