### PR TITLE
fix: manager's security context

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,13 +58,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,6 +74,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             drop:
               - "ALL"


### PR DESCRIPTION
- read only root filesystem
- RuntimeDefault seccomp profile

## Summary by Sourcery

Tighten the manager’s security context by enabling the RuntimeDefault seccomp profile and making its root filesystem read-only.

Enhancements:
- Enable seccomp RuntimeDefault profile for the manager pod
- Enforce read-only root filesystem in the manager container