### PR TITLE
fix: SCC must be present on every pod on OCP>4.19

### DIFF
--- a/test/e2e/byodb_test.go
+++ b/test/e2e/byodb_test.go
@@ -400,6 +400,16 @@ func createDB(ctx context.Context, cli runtimeCli.Client, ns string, secretRef s
 						FailureThreshold:    3,
 					},
 					VolumeMounts: volumesMounts,
+					SecurityContext: &v1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{"ALL"},
+						},
+						RunAsNonRoot: ptr.To(true),
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary by Sourcery

Enforce SCC on byodb e2e test pods for OCP 4.19+ by adding a default SecurityContext to the container spec

Bug Fixes:
- Fix failing e2e tests on OCP 4.19+ by ensuring each byodb pod complies with SCC requirements

Tests:
- Update byodb e2e test containers to include SecurityContext settings: disable privilege escalation, drop all capabilities, run as non-root, and use the runtime default seccomp profile