### PR TITLE
feat(deployment): add liveness and readiness probes for components

### DIFF
--- a/internal/controller/tuf/actions/deployment.go
+++ b/internal/controller/tuf/actions/deployment.go
@@ -129,7 +129,8 @@ func (i deployAction) createTufDeployment(instance *rhtasv1alpha1.Tuf, sa string
 
 		container.ReadinessProbe.InitialDelaySeconds = 10
 		container.ReadinessProbe.PeriodSeconds = 10
-		container.ReadinessProbe.FailureThreshold = 10
+		container.ReadinessProbe.FailureThreshold = 3
+		container.ReadinessProbe.TimeoutSeconds = 5
 
 		return nil
 	}


### PR DESCRIPTION
Adding missing or incorrect container probes (rekor-redis, rekor-search-ui, tuf)

## Summary by Sourcery

Add or correct container probes for Rekor Redis, Rekor Search UI, and TUF deployments to improve health checks.

Enhancements:
- Add Redis liveness probes (plain and TLS) with exec commands and initial delays to the Rekor Redis deployment
- Introduce HTTP readiness and liveness probes for the Rekor Search UI container on port 3000
- Adjust the TUF deployment’s readiness probe failure threshold to 3 and add a timeout setting