### PR TITLE
ci: add crdify linter to pull requests workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,3 +22,40 @@ jobs:
         with:
           version: v2.2.2
           args: --verbose --timeout=15m
+  crdify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Install crdifi
+        run: |
+          go install sigs.k8s.io/crdify@v0.4.0
+      - name: Compare CTlog CRD
+        run: |
+          crdify "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_ctlogs.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_ctlogs.yaml"
+      - name: Compare Fulcio CRD
+        run: |
+          crdify "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_fulcios.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_fulcios.yaml"
+      - name: Compare Rekor CRD
+        run: |
+          crdify "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_rekors.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_rekors.yaml"
+      - name: Compare TSA CRD
+        run: |
+          crdify "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_timestampauthorities.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_timestampauthorities.yaml"
+      - name: Compare Trillian CRD
+        run: |
+          crdify "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_trillians.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_trillians.yaml"
+      - name: Compare TUF CRD
+        run: |
+          crdify "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_tufs.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_tufs.yaml"
+      - name: Compare Securesign CRD
+        run: |
+          crdify "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_securesigns.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_securesigns.yaml"
+
+


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Introduce a ‘crdifi’ job that checks out code, installs Go and crdify, and compares CTlog, Fulcio, Rekor, TSA, Trillian, TUF, and Securesign CRDs between the PR head and base commits