### PR TITLE
fix: Add missing JobCondition handling and refactor TLS

### DIFF
--- a/internal/controller/trillian/actions/db/deployment.go
+++ b/internal/controller/trillian/actions/db/deployment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
+	trillianUtils "github.com/securesign/operator/internal/controller/trillian/utils"
 	"github.com/securesign/operator/internal/images"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils"
@@ -18,7 +19,6 @@ import (
 	"github.com/securesign/operator/internal/utils/tls"
 
 	"github.com/securesign/operator/internal/controller/trillian/actions"
-	trillianUtils "github.com/securesign/operator/internal/controller/trillian/utils"
 	v2 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/internal/controller/trillian/actions/db/tls.go
+++ b/internal/controller/trillian/actions/db/tls.go
@@ -28,8 +28,20 @@ func (i tlsAction) Name() string {
 
 func (i tlsAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Trillian) bool {
 	c := meta.FindStatusCondition(instance.Status.Conditions, actions.DbCondition)
-	return c != nil && enabled(instance) &&
-		(c.Reason == constants.Pending || !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)))
+
+	switch {
+	case c == nil:
+		return false
+	case !enabled(instance):
+		return false
+	case c.Reason == constants.Pending:
+		return true
+	case !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)):
+		return true
+	default:
+		// enable TLS on OCP by default
+		return c.Reason == constants.Ready && kubernetes.IsOpenShift() && statusTLS(instance).CertRef == nil
+	}
 }
 
 func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian) *action.Result {

--- a/internal/controller/trillian/actions/logserver/deployment.go
+++ b/internal/controller/trillian/actions/logserver/deployment.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/controller/trillian/actions"
+	trillianUtils "github.com/securesign/operator/internal/controller/trillian/utils"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	"github.com/securesign/operator/internal/utils/tls"
-
-	"github.com/securesign/operator/internal/controller/trillian/actions"
-	trillianUtils "github.com/securesign/operator/internal/controller/trillian/utils"
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/trillian/actions/logserver/tls.go
+++ b/internal/controller/trillian/actions/logserver/tls.go
@@ -28,7 +28,18 @@ func (i tlsAction) Name() string {
 
 func (i tlsAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Trillian) bool {
 	c := meta.FindStatusCondition(instance.Status.Conditions, actions.ServerCondition)
-	return c != nil && (c.Reason == constants.Pending || !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)))
+
+	switch {
+	case c == nil:
+		return false
+	case c.Reason == constants.Pending:
+		return true
+	case !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)):
+		return true
+	default:
+		// enable TLS on OCP by default
+		return c.Reason == constants.Ready && kubernetes.IsOpenShift() && statusTLS(instance).CertRef == nil
+	}
 }
 
 func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian) *action.Result {

--- a/internal/controller/trillian/actions/logserver/tls_test.go
+++ b/internal/controller/trillian/actions/logserver/tls_test.go
@@ -1,0 +1,242 @@
+package logserver
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/config"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/controller/trillian/actions"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTlsAction_CanHandle(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+
+	type env struct {
+		conditions  []metav1.Condition
+		specTLS     rhtasv1alpha1.TLS
+		statusTLS   rhtasv1alpha1.TLS
+		isOpenShift bool
+	}
+	type want struct {
+		canHandle bool
+	}
+	tests := []struct {
+		name string
+		env  env
+		want want
+	}{
+		{
+			name: "can handle when ServerCondition has Pending reason",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.ServerCondition,
+						Status: metav1.ConditionFalse,
+						Reason: constants.Pending,
+					},
+				},
+			},
+			want: want{
+				canHandle: true,
+			},
+		},
+		{
+			name: "can handle when spec and status TLS differ",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.ServerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new-key"},
+						Key:                  "tls.key",
+					},
+				},
+				statusTLS: rhtasv1alpha1.TLS{},
+			},
+			want: want{
+				canHandle: true,
+			},
+		},
+
+		{
+			name: "can handle when spec and status TLS differ - changed",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.ServerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "key"},
+						Key:                  "tls.key",
+					},
+				},
+				statusTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "old-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "key"},
+						Key:                  "tls.key",
+					},
+				},
+			},
+			want: want{
+				canHandle: true,
+			},
+		},
+		{
+			name: "cannot handle when spec and status TLS are identical",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.ServerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "same-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "key"},
+						Key:                  "tls.key",
+					},
+				},
+				statusTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "same-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "key"},
+						Key:                  "tls.key",
+					},
+				},
+				isOpenShift: false,
+			},
+			want: want{
+				canHandle: false,
+			},
+		},
+		{
+			name: "can handle on OpenShift when Ready and no cert ref in status (enable TLS by default)",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.ServerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS:     rhtasv1alpha1.TLS{},
+				statusTLS:   rhtasv1alpha1.TLS{},
+				isOpenShift: true,
+			},
+			want: want{
+				canHandle: true,
+			},
+		},
+		{
+			name: "cannot handle on OpenShift when Ready and cert ref exists in status",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.ServerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS: rhtasv1alpha1.TLS{},
+				statusTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "existing-cert"},
+						Key:                  "tls.crt",
+					},
+				},
+				isOpenShift: true,
+			},
+			want: want{
+				canHandle: false,
+			},
+		},
+		{
+			name: "cannot handle on non-OpenShift when Ready - no TLS config",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.ServerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS:     rhtasv1alpha1.TLS{},
+				statusTLS:   rhtasv1alpha1.TLS{},
+				isOpenShift: false,
+			},
+			want: want{
+				canHandle: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &rhtasv1alpha1.Trillian{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-trillian",
+					Namespace: "default",
+				},
+				Spec: rhtasv1alpha1.TrillianSpec{
+					LogServer: rhtasv1alpha1.TrillianLogServer{
+						TLS: tt.env.specTLS,
+					},
+				},
+				Status: rhtasv1alpha1.TrillianStatus{
+					LogServer: rhtasv1alpha1.TrillianLogServer{
+						TLS: tt.env.statusTLS,
+					},
+					Conditions: tt.env.conditions,
+				},
+			}
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				Build()
+
+			action := testAction.PrepareAction(c, NewTlsAction())
+			config.Openshift = tt.env.isOpenShift
+
+			result := action.CanHandle(ctx, instance)
+
+			g.Expect(result).To(Equal(tt.want.canHandle))
+
+		})
+	}
+}

--- a/internal/controller/trillian/actions/logsigner/tls.go
+++ b/internal/controller/trillian/actions/logsigner/tls.go
@@ -28,7 +28,18 @@ func (i tlsAction) Name() string {
 
 func (i tlsAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Trillian) bool {
 	c := meta.FindStatusCondition(instance.Status.Conditions, actions.SignerCondition)
-	return c != nil && (c.Reason == constants.Pending || !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)))
+
+	switch {
+	case c == nil:
+		return false
+	case c.Reason == constants.Pending:
+		return true
+	case !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)):
+		return true
+	default:
+		// enable TLS on OCP by default
+		return c.Reason == constants.Ready && kubernetes.IsOpenShift() && statusTLS(instance).CertRef == nil
+	}
 }
 
 func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian) *action.Result {

--- a/internal/controller/trillian/actions/logsigner/tls_test.go
+++ b/internal/controller/trillian/actions/logsigner/tls_test.go
@@ -1,0 +1,242 @@
+package logsigner
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/config"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/controller/trillian/actions"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTlsAction_CanHandle(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+
+	type env struct {
+		conditions  []metav1.Condition
+		specTLS     rhtasv1alpha1.TLS
+		statusTLS   rhtasv1alpha1.TLS
+		isOpenShift bool
+	}
+	type want struct {
+		canHandle bool
+	}
+	tests := []struct {
+		name string
+		env  env
+		want want
+	}{
+		{
+			name: "can handle when SignerCondition has Pending reason",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.SignerCondition,
+						Status: metav1.ConditionFalse,
+						Reason: constants.Pending,
+					},
+				},
+			},
+			want: want{
+				canHandle: true,
+			},
+		},
+		{
+			name: "can handle when spec and status TLS differ",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.SignerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new-key"},
+						Key:                  "tls.key",
+					},
+				},
+				statusTLS: rhtasv1alpha1.TLS{},
+			},
+			want: want{
+				canHandle: true,
+			},
+		},
+
+		{
+			name: "can handle when spec and status TLS differ - changed",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.SignerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "new-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "key"},
+						Key:                  "tls.key",
+					},
+				},
+				statusTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "old-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "key"},
+						Key:                  "tls.key",
+					},
+				},
+			},
+			want: want{
+				canHandle: true,
+			},
+		},
+		{
+			name: "cannot handle when spec and status TLS are identical",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.SignerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "same-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "key"},
+						Key:                  "tls.key",
+					},
+				},
+				statusTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "same-cert"},
+						Key:                  "tls.crt",
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "key"},
+						Key:                  "tls.key",
+					},
+				},
+				isOpenShift: false,
+			},
+			want: want{
+				canHandle: false,
+			},
+		},
+		{
+			name: "can handle on OpenShift when Ready and no cert ref in status (enable TLS by default)",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.SignerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS:     rhtasv1alpha1.TLS{},
+				statusTLS:   rhtasv1alpha1.TLS{},
+				isOpenShift: true,
+			},
+			want: want{
+				canHandle: true,
+			},
+		},
+		{
+			name: "cannot handle on OpenShift when Ready and cert ref exists in status",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.SignerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS: rhtasv1alpha1.TLS{},
+				statusTLS: rhtasv1alpha1.TLS{
+					CertRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "existing-cert"},
+						Key:                  "tls.crt",
+					},
+				},
+				isOpenShift: true,
+			},
+			want: want{
+				canHandle: false,
+			},
+		},
+		{
+			name: "cannot handle on non-OpenShift when Ready - no TLS config",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   actions.SignerCondition,
+						Status: metav1.ConditionTrue,
+						Reason: constants.Ready,
+					},
+				},
+				specTLS:     rhtasv1alpha1.TLS{},
+				statusTLS:   rhtasv1alpha1.TLS{},
+				isOpenShift: false,
+			},
+			want: want{
+				canHandle: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &rhtasv1alpha1.Trillian{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-trillian",
+					Namespace: "default",
+				},
+				Spec: rhtasv1alpha1.TrillianSpec{
+					LogSigner: rhtasv1alpha1.TrillianLogSigner{
+						TLS: tt.env.specTLS,
+					},
+				},
+				Status: rhtasv1alpha1.TrillianStatus{
+					LogSigner: rhtasv1alpha1.TrillianLogSigner{
+						TLS: tt.env.statusTLS,
+					},
+					Conditions: tt.env.conditions,
+				},
+			}
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				Build()
+
+			action := testAction.PrepareAction(c, NewTlsAction())
+			config.Openshift = tt.env.isOpenShift
+
+			result := action.CanHandle(ctx, instance)
+
+			g.Expect(result).To(Equal(tt.want.canHandle))
+
+		})
+	}
+}


### PR DESCRIPTION
## Summary by Sourcery

Add support for handling missing JobCondition in resolveTree, refactor TLS handling logic across controllers for consistency and OpenShift defaults, streamline deployment TLS configuration, and add corresponding tests

New Features:
- Add backward compatibility check to handle missing JobCondition when TreeID is set

Enhancements:
- Refactor TLS CanHandle logic across Trillian and Rekor controllers to use switch statements with OpenShift default enablement
- Simplify deployment TLS configuration by replacing utility functions with direct status-based checks and remove deprecated tls utility

Tests:
- Add tests for handleMissingCondition to verify setting missing JobCondition

Chores:
- Remove internal trillian tls utility file