### PR TITLE
ci: run linter workflow only for pull requests

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,9 +1,5 @@
 name: linter
 on:
-  workflow_dispatch:
-  push:
-    branches: [ "main", "release*" ]
-    tags: [ "*" ]
   pull_request:
     branches: [ "main", "release*" ]
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Run linter only on pull_request events, removing workflow_dispatch and push triggers