### PR TITLE
Fix: Remove prometheus-k8s RBAC and prune watch rules

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,15 +21,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create

--- a/config/samples/rhtas_v1alpha1_securesign.yaml
+++ b/config/samples/rhtas_v1alpha1_securesign.yaml
@@ -17,6 +17,8 @@ spec:
   trillian:
     database:
       create: true
+    monitoring:
+      enabled: true
   fulcio:
     externalAccess:
       enabled: true
@@ -47,7 +49,9 @@ spec:
         - ReadWriteOnce
       retain: true
       size: 100Mi
-  ctlog: {}
+  ctlog:
+    monitoring:
+      enabled: true
   tsa:
     externalAccess:
       enabled: true

--- a/internal/controller/ctlog/actions/monitoring.go
+++ b/internal/controller/ctlog/actions/monitoring.go
@@ -12,11 +12,8 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.CTlog] {
@@ -42,47 +39,6 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CT
 	)
 
 	monitoringLabels := labels.For(ComponentName, MonitoringRoleName, instance.Name)
-
-	// Role
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.Role](instance, i.Client),
-		ensure.Labels[*v1.Role](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleRules(
-			v1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"services", "endpoints", "pods"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		),
-	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring Role: %w", err)), instance)
-	}
-
-	// RoleBinding
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.RoleBinding](instance, i.Client),
-		ensure.Labels[*v1.RoleBinding](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleBinding(
-			v1.RoleRef{
-				APIGroup: v1.SchemeGroupVersion.Group,
-				Kind:     "Role",
-				Name:     MonitoringRoleName,
-			},
-			v1.Subject{Kind: "ServiceAccount", Name: "prometheus-k8s", Namespace: "openshift-monitoring"},
-		),
-	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
-	}
 
 	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
 		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),

--- a/internal/controller/fulcio/actions/monitoring.go
+++ b/internal/controller/fulcio/actions/monitoring.go
@@ -12,11 +12,8 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Fulcio] {
@@ -42,47 +39,6 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fu
 	)
 
 	monitoringLabels := labels.For(ComponentName, MonitoringRoleName, instance.Name)
-
-	// Role
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.Role](instance, i.Client),
-		ensure.Labels[*v1.Role](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleRules(
-			v1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"services", "endpoints", "pods"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		),
-	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring Role: %w", err)), instance)
-	}
-
-	// RoleBinding
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.RoleBinding](instance, i.Client),
-		ensure.Labels[*v1.RoleBinding](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleBinding(
-			v1.RoleRef{
-				APIGroup: v1.SchemeGroupVersion.Group,
-				Kind:     "Role",
-				Name:     MonitoringRoleName,
-			},
-			v1.Subject{Kind: "ServiceAccount", Name: "prometheus-k8s", Namespace: "openshift-monitoring"},
-		),
-	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
-	}
 
 	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
 		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),

--- a/internal/controller/rekor/actions/monitor/monitoring.go
+++ b/internal/controller/rekor/actions/monitor/monitoring.go
@@ -13,11 +13,9 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Rekor] {
@@ -43,59 +41,6 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 	)
 
 	monitoringLabels := labels.For(actions.MonitorComponentName, actions.MonitoringRoleName, instance.Name)
-
-	// Role
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.Role](instance, i.Client),
-		ensure.Labels[*v1.Role](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleRules(
-			v1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"services", "endpoints", "pods"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		),
-	); err != nil {
-		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    actions.MonitorCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
-		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring Role: %w", err)), instance)
-	}
-
-	// RoleBinding
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.RoleBinding](instance, i.Client),
-		ensure.Labels[*v1.RoleBinding](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleBinding(
-			v1.RoleRef{
-				APIGroup: v1.SchemeGroupVersion.Group,
-				Kind:     "Role",
-				Name:     actions.MonitoringRoleName,
-			},
-			v1.Subject{Kind: "ServiceAccount", Name: "prometheus-k8s", Namespace: "openshift-monitoring"},
-		),
-	); err != nil {
-		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    actions.MonitorCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
-		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
-	}
 
 	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.MonitorStatefulSetName),
 		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),

--- a/internal/controller/rekor/actions/server/monitoring.go
+++ b/internal/controller/rekor/actions/server/monitoring.go
@@ -13,11 +13,9 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Rekor] {
@@ -43,59 +41,6 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 	)
 
 	monitoringLabels := labels.For(actions.ServerComponentName, actions.MonitoringRoleName, instance.Name)
-
-	// Role
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.Role](instance, i.Client),
-		ensure.Labels[*v1.Role](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleRules(
-			v1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"services", "endpoints", "pods"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		),
-	); err != nil {
-		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    actions.ServerCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
-		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring Role: %w", err)), instance)
-	}
-
-	// RoleBinding
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.RoleBinding](instance, i.Client),
-		ensure.Labels[*v1.RoleBinding](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleBinding(
-			v1.RoleRef{
-				APIGroup: v1.SchemeGroupVersion.Group,
-				Kind:     "Role",
-				Name:     actions.MonitoringRoleName,
-			},
-			v1.Subject{Kind: "ServiceAccount", Name: "prometheus-k8s", Namespace: "openshift-monitoring"},
-		),
-	); err != nil {
-		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    actions.ServerCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
-		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
-	}
 
 	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.ServerDeploymentName),
 		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),

--- a/internal/controller/trillian/actions/logsigner/monitoring.go
+++ b/internal/controller/trillian/actions/logsigner/monitoring.go
@@ -13,11 +13,9 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Trillian] {
@@ -43,46 +41,6 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tr
 	)
 
 	monitoringLabels := labels.For(actions.LogSignerComponentName, actions.LogSignerMonitoringName, instance.Name)
-	// monitoring Role
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.LogSignerMonitoringName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.Role](instance, i.Client),
-		ensure.Labels[*v1.Role](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleRules(
-			v1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"services", "endpoints", "pods"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		),
-	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring Role: %w", err)), instance)
-	}
-
-	// RoleBinding
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.LogSignerMonitoringName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.RoleBinding](instance, i.Client),
-		ensure.Labels[*v1.RoleBinding](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleBinding(
-			v1.RoleRef{
-				APIGroup: v1.SchemeGroupVersion.Group,
-				Kind:     "Role",
-				Name:     actions.LogSignerMonitoringName,
-			},
-			v1.Subject{Kind: "ServiceAccount", Name: "prometheus-k8s", Namespace: "openshift-monitoring"},
-		),
-	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
-	}
 
 	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.LogSignerComponentName),
 		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),

--- a/internal/controller/tsa/actions/monitoring.go
+++ b/internal/controller/tsa/actions/monitoring.go
@@ -12,11 +12,8 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func NewMonitoringAction() action.Action[*rhtasv1alpha1.TimestampAuthority] {
@@ -41,46 +38,6 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Ti
 		err error
 	)
 	monitoringLabels := labels.For(ComponentName, MonitoringRoleName, instance.Name)
-	// Role
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.Role{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.Role](instance, i.Client),
-		ensure.Labels[*v1.Role](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleRules(
-			v1.PolicyRule{
-				APIGroups: []string{""},
-				Resources: []string{"services", "endpoints", "pods"},
-				Verbs:     []string{"get", "list", "watch"},
-			},
-		),
-	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring Role: %w", err)), instance)
-	}
-
-	// RoleBinding
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, &v1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      MonitoringRoleName,
-			Namespace: instance.Namespace,
-		},
-	},
-		ensure.ControllerReference[*v1.RoleBinding](instance, i.Client),
-		ensure.Labels[*v1.RoleBinding](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureRoleBinding(
-			v1.RoleRef{
-				APIGroup: v1.SchemeGroupVersion.Group,
-				Kind:     "Role",
-				Name:     MonitoringRoleName,
-			},
-			v1.Subject{Kind: "ServiceAccount", Name: "prometheus-k8s", Namespace: "openshift-monitoring"},
-		),
-	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring RoleBinding: %w", err)), instance)
-	}
 
 	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
 		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -33,8 +33,6 @@ import (
 
 //+kubebuilder:rbac:groups="config.openshift.io",resources=ingresses,resourceNames=cluster,verbs=get;list;watch
 
-//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
-//+kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;get;list;watch;update;patch
 
 type Controller interface {


### PR DESCRIPTION
## Summary by Sourcery

Remove automatic creation of RBAC roles and bindings for the prometheus-k8s service account and update sample configurations accordingly

Bug Fixes:
- Remove Role and RoleBinding provisioning for prometheus-k8s in all monitoring actions
- Prune pod and endpoint watch rules from the operator’s cluster role

Enhancements:
- Strip out unused rbac/v1 and reconcile imports in monitoring controllers

Documentation:
- Add monitoring enabled flags to sample CRs for trillian and ctlog