### PR TITLE
fix: add monitoring.coreos.com prometheuses/api rule

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -151,6 +151,14 @@ rules:
 - apiGroups:
   - monitoring.coreos.com
   resources:
+  - prometheuses/api
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
   - servicemonitors
   verbs:
   - create

--- a/internal/controller/securesign/securesign_controller.go
+++ b/internal/controller/securesign/securesign_controller.go
@@ -65,6 +65,7 @@ func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.Even
 //+kubebuilder:rbac:groups=rhtas.redhat.com,resources=securesigns/finalizers,verbs=update
 //+kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=get;list
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,verbs=create;get;update
 
 // TODO: rework Securesign controller to watch resources
 func (r *securesignReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Access to prometheuses/api is needed by cluster-monitoring-view rule.

## Summary by Sourcery

Grant RBAC access to monitoring.coreos.com prometheuses/api resources to satisfy cluster-monitoring-view requirements

Bug Fixes:
- Grant create, get, and update access to monitoring.coreos.com/prometheuses/api in RBAC role configuration
- Add kubebuilder RBAC annotation for prometheuses/api to the Securesign controller