### PR TITLE
feat: Set request size limits in Rekor

### DIFF
--- a/api/v1alpha1/rekor_types.go
+++ b/api/v1alpha1/rekor_types.go
@@ -53,6 +53,11 @@ type RekorSpec struct {
 	//Configuration for authentication for key management services
 	//+optional
 	Auth *Auth `json:"auth,omitempty"`
+
+	// MaxRequestBodySize sets the maximum size in bytes for HTTP request body. Passed as --max_request_body_size.
+	//+kubebuilder:default:=10485760
+	//+optional
+	MaxRequestBodySize *int64 `json:"maxRequestBodySize,omitempty"`
 }
 
 // RekorAttestations defines the configuration for storing attestations.

--- a/api/v1alpha1/rekor_types_test.go
+++ b/api/v1alpha1/rekor_types_test.go
@@ -623,6 +623,7 @@ func generateRekorObject(name string) *Rekor {
 			Trillian: TrillianService{
 				Port: ptr.To(int32(8091)),
 			},
+			MaxRequestBodySize: ptr.To(int64(10485760)),
 		},
 	}
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -942,6 +942,11 @@ func (in *RekorSpec) DeepCopyInto(out *RekorSpec) {
 		in, out := &in.Auth, &out.Auth
 		*out = new(Auth)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.MaxRequestBodySize != nil {
+		in, out := &in.MaxRequestBodySize, &out.MaxRequestBodySize
+		*out = new(int64)
+		**out = **in
 	}
 }
 

--- a/config/crd/bases/rhtas.redhat.com_rekors.yaml
+++ b/config/crd/bases/rhtas.redhat.com_rekors.yaml
@@ -1209,6 +1209,12 @@ spec:
                 required:
                 - enabled
                 type: object
+              maxRequestBodySize:
+                default: 10485760
+                description: MaxRequestBodySize sets the maximum size in bytes for
+                  HTTP request body. Passed as --max_request_body_size.
+                format: int64
+                type: integer
               monitoring:
                 description: Enable Service monitors for rekor
                 properties:

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -3821,6 +3821,12 @@ spec:
                     required:
                     - enabled
                     type: object
+                  maxRequestBodySize:
+                    default: 10485760
+                    description: MaxRequestBodySize sets the maximum size in bytes
+                      for HTTP request body. Passed as --max_request_body_size.
+                    format: int64
+                    type: integer
                   monitoring:
                     description: Enable Service monitors for rekor
                     properties:

--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -189,6 +189,9 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 		}
 
 		//TODO mount additional ENV variables and secrets to enable cloud KMS service
+		if instance.Spec.MaxRequestBodySize != nil {
+			args = append(args, "--max_request_body_size", fmt.Sprintf("%d", *instance.Spec.MaxRequestBodySize))
+		}
 		container.Args = args
 		if err := searchIndex.EnsureSearchIndex(instance, ensureRedisParams(), ensureMysqlParams())(container); err != nil {
 			return err


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable HTTP request body size limit to Rekor by extending the CRD and API, updating deepcopy logic, and forwarding the flag to the server deployment

New Features:
- Introduce MaxRequestBodySize field in the Rekor CRD and Go API with a default of 10485760 bytes
- Pass the --max_request_body_size flag to the Rekor server container when the field is set

Enhancements:
- Update the autogenerated DeepCopy function to handle the new MaxRequestBodySize field

Tests:
- Add a default MaxRequestBodySize value in the Rekor types unit test