### PR TITLE
:robot: [RHTAS-build-bot] [release-1.2] Update Operator Bundle Controller Image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # redhat.com/operator-bundle:$VERSION and redhat.com/operator-catalog:$VERSION.
 IMAGE_TAG_BASE ?= registry.redhat.io/rhtas/rhtas-rhel9-operator
-IMAGE_DIGEST ?= sha256:c5c1d5509d2f5f434ff141d01cecd6c539d4d472730047c73a2feb0c13adff56
+IMAGE_DIGEST ?= sha256:a8619d3b6bdd5c841427296854a0bdadad56eaaf61ad41e99b45a537953403ca
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)

--- a/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhtas-operator.clusterserviceversion.yaml
@@ -296,8 +296,8 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:c5c1d5509d2f5f434ff141d01cecd6c539d4d472730047c73a2feb0c13adff56
-    createdAt: "2025-08-14T10:48:09Z"
+    containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:a8619d3b6bdd5c841427296854a0bdadad56eaaf61ad41e99b45a537953403ca
+    createdAt: "2025-08-14T12:59:19Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -663,7 +663,7 @@ spec:
                   value: registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:fb7a8de711483abd71a59ae48448903e2243926c3ce39bb387cce08d513f585f
                 - name: RELATED_IMAGE_CLIENT_SERVER
                   value: registry.redhat.io/rhtas/client-server-rhel9@sha256:5cf11c8e6c7a8731629310ae415e405a35c0526ea4ee9fc9dd2911d084e66390
-                image: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:c5c1d5509d2f5f434ff141d01cecd6c539d4d472730047c73a2feb0c13adff56
+                image: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:a8619d3b6bdd5c841427296854a0bdadad56eaaf61ad41e99b45a537953403ca
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,6 +4,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- digest: sha256:c5c1d5509d2f5f434ff141d01cecd6c539d4d472730047c73a2feb0c13adff56
+- digest: sha256:a8619d3b6bdd5c841427296854a0bdadad56eaaf61ad41e99b45a537953403ca
   name: controller
   newName: registry.redhat.io/rhtas/rhtas-rhel9-operator

--- a/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
-    containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:c5c1d5509d2f5f434ff141d01cecd6c539d4d472730047c73a2feb0c13adff56
+    containerImage: registry.redhat.io/rhtas/rhtas-rhel9-operator@sha256:a8619d3b6bdd5c841427296854a0bdadad56eaaf61ad41e99b45a537953403ca
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"


### PR DESCRIPTION
This PR contains the following changes

| Image | Old SHA | New SHA |
|--------|---------|---------|
| registry.redhat.io/rhtas/rhtas-rhel9-operator | c5c1d55 | a8619d3 |
---

## Summary by Sourcery

Update the RHTAS operator bundle controller image SHA across CSV manifests, build files, and configuration

Enhancements:
- Bump registry.redhat.io/rhtas/rhtas-rhel9-operator image digest to sha256:a8619d3b6bdd5c841427296854a0bdadad56eaaf61ad41e99b45a537953403ca
- Refresh createdAt timestamp in the ClusterServiceVersion manifest to reflect the new image