### PR TITLE
ci: add kustomize deployments for NFS CSI storage class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ k8s-dump-*.tar.gz
 
 #tsa certificate chain file
 ts_chain.pem
+
+# HELM Charts
+ci/**/charts

--- a/ci/nfs/csi-driver-nfs/kustomization.yaml
+++ b/ci/nfs/csi-driver-nfs/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+helmCharts:
+  - name: csi-driver-nfs
+    releaseName: 4.11.0
+    repo: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts

--- a/ci/nfs/overlay/kustomization.yaml
+++ b/ci/nfs/overlay/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+components:
+  - ../server
+  - ../csi-driver-nfs
+
+resources:
+  - storageclass.yaml

--- a/ci/nfs/overlay/storageclass.yaml
+++ b/ci/nfs/overlay/storageclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-csi
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: nfs-server.nfs-storage.svc.cluster.local
+  share: /

--- a/ci/nfs/server/deployment.yaml
+++ b/ci/nfs/server/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-server
+  namespace: nfs-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfs-server
+  template:
+    metadata:
+      labels:
+        app: nfs-server
+    spec:
+      serviceAccountName: nfs-server-sa
+      containers:
+        - name: nfs-server
+          image: itsthenetwork/nfs-server-alpine:latest
+          env:
+            - name: SHARED_DIRECTORY
+              value: /exports
+          ports:
+            - name: tcp-2049
+              containerPort: 2049
+              protocol: TCP
+            - name: udp-111
+              containerPort: 111
+              protocol: UDP
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: nfs-storage
+              mountPath: /exports
+      volumes:
+        - name: nfs-storage
+          persistentVolumeClaim:
+            claimName: nfs-pvc

--- a/ci/nfs/server/kustomization.yaml
+++ b/ci/nfs/server/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+#namespace: nfs-storage
+
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml

--- a/ci/nfs/server/namespace.yaml
+++ b/ci/nfs/server/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nfs-storage

--- a/ci/nfs/server/pvc.yaml
+++ b/ci/nfs/server/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nfs-pvc
+  namespace: nfs-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/ci/nfs/server/rbac.yaml
+++ b/ci/nfs/server/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-server-sa
+  namespace: nfs-storage
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nfs-server-role
+  namespace: nfs-storage
+rules:
+  - apiGroups: [ "security.openshift.io" ]
+    resources: [ "securitycontextconstraints" ]
+    verbs: [ "use" ]
+    resourceNames: [ "privileged" ]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nfs-server-rb
+  namespace: nfs-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nfs-server-role
+subjects:
+  - kind: ServiceAccount
+    name: nfs-server-sa

--- a/ci/nfs/server/service.yaml
+++ b/ci/nfs/server/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nfs-server
+  namespace: nfs-storage
+spec:
+  selector:
+    app: nfs-server
+  ports:
+    - name: tcp-2049
+      port: 2049
+      protocol: TCP
+    - name: udp-111
+      port: 111
+      protocol: UDP
+  type: ClusterIP

--- a/ci/nfs/test/claim.yaml
+++ b/ci/nfs/test/claim.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-claim
+spec:
+  storageClassName: nfs-csi
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi

--- a/ci/nfs/test/kustomization.yaml
+++ b/ci/nfs/test/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: pvc-test
+
+resources:
+  - namespace.yaml
+  - claim.yaml
+  - pod.yaml

--- a/ci/nfs/test/namespace.yaml
+++ b/ci/nfs/test/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pvc-test

--- a/ci/nfs/test/pod.yaml
+++ b/ci/nfs/test/pod.yaml
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod
+spec:
+  containers:
+    - name: test-pod
+      image: busybox:stable
+      command:
+        - "/bin/sh"
+      args:
+        - "-c"
+        - "touch /mnt/SUCCESS && exit 0 || exit 1"
+      volumeMounts:
+        - name: nfs-pvc
+          mountPath: "/mnt"
+  restartPolicy: "Never"
+  volumes:
+    - name: nfs-pvc
+      persistentVolumeClaim:
+        claimName: test-claim


### PR DESCRIPTION
## Summary by Sourcery

Deploy NFS CSI storage with kustomize and Helm by provisioning an NFS server, installing the NFS CSI driver and related CRDs, configuring a dynamic storage class with snapshot support, and adding overlays and test manifests to validate the setup

New Features:
- Add kustomize-based deployment of an NFS server with PVC, service, namespace and RBAC
- Introduce Helm chart for CSI NFS driver including CRDs, CSIDriver resource, controller Deployment, node DaemonSet, snapshot controller and RBAC
- Configure storage class and snapshot class templates for dynamic NFS provisioning via CSI
- Provide kustomize overlays to combine NFS server, CSI driver chart and storage class

Tests:
- Add kustomize test scenario with a namespace, PVC and busybox pod to verify NFS CSI volume mounting and provisioning