### PR TITLE
fix: refactor PVC management and prevent immutable field updates

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -101,6 +101,8 @@ type SecretKeySelector struct {
 type PersistentVolumeAccessMode core.PersistentVolumeAccessMode
 
 // Pvc configuration of the persistent storage claim for deployment in the cluster.
+// +kubebuilder:validation:XValidation:rule="oldSelf == null || has(self.name) || (!has(oldSelf.storageClass) || has(self.storageClass) && oldSelf.storageClass == self.storageClass)",message="storageClass is immutable when a PVC name is not specified"
+// +kubebuilder:validation:XValidation:rule="oldSelf == null || has(self.name) || (!has(oldSelf.accessModes) || has(self.accessModes) && oldSelf.accessModes == self.accessModes)",message="accessModes is immutable when a PVC name is not specified"
 type Pvc struct {
 	// The requested size of the persistent volume attached to Pod.
 	// The format of this field matches that defined by kubernetes/apimachinery.

--- a/api/v1alpha1/trillian_types_test.go
+++ b/api/v1alpha1/trillian_types_test.go
@@ -139,6 +139,50 @@ var _ = Describe("Trillian", func() {
 			})
 		})
 
+		type pvcArgs struct {
+			name         string
+			storageClass string
+			accessModes  []PersistentVolumeAccessMode
+		}
+		DescribeTable("pvc", func(ctx context.Context, origObj pvcArgs, updateObj *pvcArgs, isValid bool, errMessage string) {
+			object := generateTrillianObject("")
+			object.GenerateName = "trillian-pvc-"
+			object.Spec.Db.Pvc.Name = origObj.name
+			object.Spec.Db.Pvc.StorageClass = origObj.storageClass
+			object.Spec.Db.Pvc.AccessModes = origObj.accessModes
+
+			err := k8sClient.Create(ctx, object)
+			if updateObj == nil && !isValid {
+				Expect(err).To(MatchError(ContainSubstring(errMessage)))
+				return
+			}
+			Expect(err).To(Succeed())
+			if updateObj == nil {
+				return
+			}
+
+			object.Spec.Db.Pvc.Name = updateObj.name
+			object.Spec.Db.Pvc.StorageClass = updateObj.storageClass
+			object.Spec.Db.Pvc.AccessModes = updateObj.accessModes
+
+			if isValid {
+				Expect(k8sClient.Update(ctx, object)).To(Succeed())
+			} else {
+				Expect(k8sClient.Update(ctx, object)).To(MatchError(ContainSubstring(errMessage)))
+			}
+		},
+			Entry("create default", pvcArgs{}, nil, true, ""),
+			Entry("bring your own pvc", pvcArgs{name: "byo-pvc"}, nil, true, ""),
+			Entry("change name", pvcArgs{}, &pvcArgs{name: "new"}, true, ""),
+			Entry("no changes", pvcArgs{storageClass: "default", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, &pvcArgs{storageClass: "default", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, true, ""),
+			Entry("immutable storageClass", pvcArgs{storageClass: "default"}, &pvcArgs{storageClass: "new"}, false, "storageClass is immutable"),
+			Entry("change storageClass when name is set", pvcArgs{name: "named", storageClass: "old"}, &pvcArgs{name: "named", storageClass: "new"}, true, ""),
+			Entry("change storageClass and name", pvcArgs{storageClass: "old"}, &pvcArgs{name: "new", storageClass: "new"}, true, ""),
+			Entry("immutable accessModes", pvcArgs{accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, &pvcArgs{accessModes: []PersistentVolumeAccessMode{"ReadWriteMany"}}, false, "accessModes is immutable"),
+			Entry("change accessModes when name is set", pvcArgs{name: "named", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, &pvcArgs{name: "named", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce", "ReadWriteMany"}}, true, ""),
+			Entry("change accessModes and name", pvcArgs{accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, &pvcArgs{name: "new", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce", "ReadWriteMany"}}, true, ""),
+		)
+
 		Context("Default settings", func() {
 			var (
 				trillianInstance         Trillian

--- a/api/v1alpha1/tuf_types.go
+++ b/api/v1alpha1/tuf_types.go
@@ -31,6 +31,9 @@ type TufSpec struct {
 	Pvc TufPvc `json:"pvc,omitempty"`
 }
 
+// TufPvc configuration of the persistent storage claim for deployment in the cluster.
+// +kubebuilder:validation:XValidation:rule="oldSelf == null || has(self.name) || (!has(oldSelf.storageClass) || has(self.storageClass) && oldSelf.storageClass == self.storageClass)",message="storageClass is immutable when a PVC name is not specified"
+// +kubebuilder:validation:XValidation:rule="oldSelf == null || has(self.name) || (!has(oldSelf.accessModes) || has(self.accessModes) && oldSelf.accessModes == self.accessModes)",message="accessModes is immutable when a PVC name is not specified"
 type TufPvc struct {
 	// The requested size of the persistent volume attached to Pod.
 	// The format of this field matches that defined by kubernetes/apimachinery.

--- a/api/v1alpha1/tuf_types_test.go
+++ b/api/v1alpha1/tuf_types_test.go
@@ -172,6 +172,50 @@ var _ = Describe("TUF", func() {
 			})
 		})
 
+		type pvcArgs struct {
+			name         string
+			storageClass string
+			accessModes  []PersistentVolumeAccessMode
+		}
+		DescribeTable("pvc", func(ctx context.Context, origObj pvcArgs, updateObj *pvcArgs, isValid bool, errMessage string) {
+			object := generateTufObject("")
+			object.GenerateName = "tuf-pvc-"
+			object.Spec.Pvc.Name = origObj.name
+			object.Spec.Pvc.StorageClass = origObj.storageClass
+			object.Spec.Pvc.AccessModes = origObj.accessModes
+
+			err := k8sClient.Create(ctx, object)
+			if updateObj == nil && !isValid {
+				Expect(err).To(MatchError(ContainSubstring(errMessage)))
+				return
+			}
+			Expect(err).To(Succeed())
+			if updateObj == nil {
+				return
+			}
+
+			object.Spec.Pvc.Name = updateObj.name
+			object.Spec.Pvc.StorageClass = updateObj.storageClass
+			object.Spec.Pvc.AccessModes = updateObj.accessModes
+
+			if isValid {
+				Expect(k8sClient.Update(ctx, object)).To(Succeed())
+			} else {
+				Expect(k8sClient.Update(ctx, object)).To(MatchError(ContainSubstring(errMessage)))
+			}
+		},
+			Entry("create default", pvcArgs{}, nil, true, ""),
+			Entry("bring your own pvc", pvcArgs{name: "byo-pvc"}, nil, true, ""),
+			Entry("change name", pvcArgs{}, &pvcArgs{name: "new"}, true, ""),
+			Entry("no changes", pvcArgs{storageClass: "default", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, &pvcArgs{storageClass: "default", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, true, ""),
+			Entry("immutable storageClass", pvcArgs{storageClass: "default"}, &pvcArgs{storageClass: "new"}, false, "storageClass is immutable"),
+			Entry("change storageClass when name is set", pvcArgs{name: "named", storageClass: "old"}, &pvcArgs{name: "named", storageClass: "new"}, true, ""),
+			Entry("change storageClass and name", pvcArgs{storageClass: "old"}, &pvcArgs{name: "new", storageClass: "new"}, true, ""),
+			Entry("immutable accessModes", pvcArgs{accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, &pvcArgs{accessModes: []PersistentVolumeAccessMode{"ReadWriteMany"}}, false, "accessModes is immutable"),
+			Entry("change accessModes when name is set", pvcArgs{name: "named", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, &pvcArgs{name: "named", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce", "ReadWriteMany"}}, true, ""),
+			Entry("change accessModes and name", pvcArgs{accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce"}}, &pvcArgs{name: "new", accessModes: []PersistentVolumeAccessMode{"ReadWriteOnce", "ReadWriteMany"}}, true, ""),
+		)
+
 		Context("Default settings", func() {
 			var (
 				tufInstance         Tuf

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/config/crd/bases/rhtas.redhat.com_rekors.yaml
+++ b/config/crd/bases/rhtas.redhat.com_rekors.yaml
@@ -1298,6 +1298,13 @@ spec:
                 required:
                 - retain
                 type: object
+                x-kubernetes-validations:
+                - message: storageClass is immutable when a PVC name is not specified
+                  rule: oldSelf == null || has(self.name) || (!has(oldSelf.storageClass)
+                    || has(self.storageClass) && oldSelf.storageClass == self.storageClass)
+                - message: accessModes is immutable when a PVC name is not specified
+                  rule: oldSelf == null || has(self.name) || (!has(oldSelf.accessModes)
+                    || has(self.accessModes) && oldSelf.accessModes == self.accessModes)
               rekorSearchUI:
                 default:
                   enabled: true

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -3911,6 +3911,13 @@ spec:
                     required:
                     - retain
                     type: object
+                    x-kubernetes-validations:
+                    - message: storageClass is immutable when a PVC name is not specified
+                      rule: oldSelf == null || has(self.name) || (!has(oldSelf.storageClass)
+                        || has(self.storageClass) && oldSelf.storageClass == self.storageClass)
+                    - message: accessModes is immutable when a PVC name is not specified
+                      rule: oldSelf == null || has(self.name) || (!has(oldSelf.accessModes)
+                        || has(self.accessModes) && oldSelf.accessModes == self.accessModes)
                   rekorSearchUI:
                     default:
                       enabled: true
@@ -5364,6 +5371,15 @@ spec:
                         required:
                         - retain
                         type: object
+                        x-kubernetes-validations:
+                        - message: storageClass is immutable when a PVC name is not
+                            specified
+                          rule: oldSelf == null || has(self.name) || (!has(oldSelf.storageClass)
+                            || has(self.storageClass) && oldSelf.storageClass == self.storageClass)
+                        - message: accessModes is immutable when a PVC name is not
+                            specified
+                          rule: oldSelf == null || has(self.name) || (!has(oldSelf.accessModes)
+                            || has(self.accessModes) && oldSelf.accessModes == self.accessModes)
                       tls:
                         description: Configuration for enabling TLS (Transport Layer
                           Security) encryption for manged database.
@@ -10424,6 +10440,13 @@ spec:
                     required:
                     - retain
                     type: object
+                    x-kubernetes-validations:
+                    - message: storageClass is immutable when a PVC name is not specified
+                      rule: oldSelf == null || has(self.name) || (!has(oldSelf.storageClass)
+                        || has(self.storageClass) && oldSelf.storageClass == self.storageClass)
+                    - message: accessModes is immutable when a PVC name is not specified
+                      rule: oldSelf == null || has(self.name) || (!has(oldSelf.accessModes)
+                        || has(self.accessModes) && oldSelf.accessModes == self.accessModes)
                   replicas:
                     default: 1
                     description: Number of desired pods.

--- a/config/crd/bases/rhtas.redhat.com_trillians.yaml
+++ b/config/crd/bases/rhtas.redhat.com_trillians.yaml
@@ -130,6 +130,13 @@ spec:
                     required:
                     - retain
                     type: object
+                    x-kubernetes-validations:
+                    - message: storageClass is immutable when a PVC name is not specified
+                      rule: oldSelf == null || has(self.name) || (!has(oldSelf.storageClass)
+                        || has(self.storageClass) && oldSelf.storageClass == self.storageClass)
+                    - message: accessModes is immutable when a PVC name is not specified
+                      rule: oldSelf == null || has(self.name) || (!has(oldSelf.accessModes)
+                        || has(self.accessModes) && oldSelf.accessModes == self.accessModes)
                   tls:
                     description: Configuration for enabling TLS (Transport Layer Security)
                       encryption for manged database.
@@ -2500,6 +2507,13 @@ spec:
                     required:
                     - retain
                     type: object
+                    x-kubernetes-validations:
+                    - message: storageClass is immutable when a PVC name is not specified
+                      rule: oldSelf == null || has(self.name) || (!has(oldSelf.storageClass)
+                        || has(self.storageClass) && oldSelf.storageClass == self.storageClass)
+                    - message: accessModes is immutable when a PVC name is not specified
+                      rule: oldSelf == null || has(self.name) || (!has(oldSelf.accessModes)
+                        || has(self.accessModes) && oldSelf.accessModes == self.accessModes)
                   tls:
                     description: Configuration for enabling TLS (Transport Layer Security)
                       encryption for manged database.

--- a/config/crd/bases/rhtas.redhat.com_tufs.yaml
+++ b/config/crd/bases/rhtas.redhat.com_tufs.yaml
@@ -1090,6 +1090,13 @@ spec:
                 required:
                 - retain
                 type: object
+                x-kubernetes-validations:
+                - message: storageClass is immutable when a PVC name is not specified
+                  rule: oldSelf == null || has(self.name) || (!has(oldSelf.storageClass)
+                    || has(self.storageClass) && oldSelf.storageClass == self.storageClass)
+                - message: accessModes is immutable when a PVC name is not specified
+                  rule: oldSelf == null || has(self.name) || (!has(oldSelf.accessModes)
+                    || has(self.accessModes) && oldSelf.accessModes == self.accessModes)
               replicas:
                 default: 1
                 description: Number of desired pods.

--- a/internal/action/pvc/action.go
+++ b/internal/action/pvc/action.go
@@ -1,0 +1,167 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/apis"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/labels"
+	"github.com/securesign/operator/internal/utils"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func NewAction[T apis.ConditionsAwareObject](pvcNameFormat, component, deployment string, wrapper func(T) *wrapper[T]) action.Action[T] {
+	a := &pvcAction[T]{
+		nameFormat: pvcNameFormat,
+		component:  component,
+		deployment: deployment,
+		wrapper:    wrapper,
+	}
+	return a
+}
+
+type pvcAction[T apis.ConditionsAwareObject] struct {
+	action.BaseAction
+	nameFormat string
+	component  string
+	deployment string
+	wrapper    func(T) *wrapper[T]
+}
+
+func (i pvcAction[T]) Name() string {
+	return "PVC"
+}
+
+func (i pvcAction[T]) CanHandle(_ context.Context, instance T) bool {
+	wrapped := i.wrapper(instance)
+
+	if !wrapped.EnabledPVC() {
+		return false
+	}
+
+	if wrapped.GetStatusPVCName() == "" {
+		return true
+	}
+
+	if !meta.IsStatusConditionTrue(instance.GetConditions(), ConditionType) {
+		return true
+	}
+
+	c := meta.FindStatusCondition(instance.GetConditions(), ConditionType)
+	return c.ObservedGeneration != instance.GetGeneration()
+}
+
+func (i pvcAction[T]) Handle(ctx context.Context, instance T) *action.Result {
+	var (
+		result controllerutil.OperationResult
+		err    error
+	)
+
+	wrapped := i.wrapper(instance)
+	pvcSpec := wrapped.GetPVCSpec()
+
+	if pvcSpec.Name != "" {
+		wrapped.SetStatusPVCName(pvcSpec.Name)
+		instance.SetCondition(metav1.Condition{
+			Type:               ConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             ReasonSpecified,
+			ObservedGeneration: instance.GetGeneration(),
+		})
+		return i.StatusUpdate(ctx, instance)
+	}
+
+	var name string
+	if strings.Contains(i.nameFormat, "%s") {
+		name = fmt.Sprintf(i.nameFormat, instance.GetName())
+	} else {
+		name = i.nameFormat
+	}
+
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: instance.GetNamespace(),
+		},
+	}
+
+	// discover existing default PVC and use it
+	if wrapped.GetStatusPVCName() == "" && i.Client.Get(ctx, client.ObjectKeyFromObject(pvc), pvc) == nil {
+		wrapped.SetStatusPVCName(pvc.GetName())
+		instance.SetCondition(metav1.Condition{
+			Type:               ConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             ReasonDiscovered,
+			Message:            fmt.Sprintf("Discovered and using  existing default PVC `%s`.", pvc.GetName()),
+			ObservedGeneration: instance.GetGeneration(),
+		})
+		return i.StatusUpdate(ctx, instance)
+	}
+
+	if pvcSpec.Size == nil {
+		return i.Error(ctx, reconcile.TerminalError(ErrPVCSizeNotSet), instance, metav1.Condition{
+			Type:               ConditionType,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            ErrPVCSizeNotSet.Error(),
+			ObservedGeneration: instance.GetGeneration(),
+		})
+	}
+
+	l := labels.For(i.component, i.deployment, instance.GetName())
+	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client, pvc,
+		kubernetes.EnsurePVCSpec(pvcSpec),
+		ensure.Optional[*v1.PersistentVolumeClaim](!utils.OptionalBool(pvcSpec.Retain), ensure.ControllerReference[*v1.PersistentVolumeClaim](instance, i.Client)),
+		ensure.Labels[*v1.PersistentVolumeClaim](slices.Collect(maps.Keys(l)), l),
+	); err != nil {
+		// do not terminate the deployment - retry with exponential backoff
+		return i.Error(ctx, fmt.Errorf("could not create DB PVC: %w", err), instance, metav1.Condition{
+			Type:               ConditionType,
+			Status:             metav1.ConditionFalse,
+			Reason:             constants.Failure,
+			Message:            err.Error(),
+			ObservedGeneration: instance.GetGeneration(),
+		})
+	}
+
+	switch result {
+	case controllerutil.OperationResultCreated:
+		instance.SetCondition(metav1.Condition{
+			Type:               ConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             ReasonCreated,
+			ObservedGeneration: instance.GetGeneration(),
+		})
+		i.Recorder.Eventf(instance, v1.EventTypeNormal, "PersistentVolumeClaimCreated", "New PersistentVolumeClaim created `%s`", pvc.Name)
+	case controllerutil.OperationResultUpdated:
+		instance.SetCondition(metav1.Condition{
+			Type:               ConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             ReasonUpdated,
+			ObservedGeneration: instance.GetGeneration(),
+		})
+		i.Recorder.Eventf(instance, v1.EventTypeNormal, "PersistentVolumeClaimUpdated", "PersistentVolumeClaim updated `%s`", pvc.Name)
+	case controllerutil.OperationResultNone:
+		instance.SetCondition(metav1.Condition{
+			Type:               ConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             constants.Ready,
+			ObservedGeneration: instance.GetGeneration(),
+		})
+	}
+
+	wrapped.SetStatusPVCName(pvc.Name)
+	return i.StatusUpdate(ctx, instance)
+}

--- a/internal/action/pvc/action_test.go
+++ b/internal/action/pvc/action_test.go
@@ -1,0 +1,475 @@
+package pvc
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/labels"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestHandle(t *testing.T) {
+	const namespace = "default"
+	const pvcNameFormat = "pvc"
+	const storageClass = "default"
+	var nnObj = types.NamespacedName{Name: "test", Namespace: namespace}
+
+	type pre struct {
+		before    func(context.Context, gomega.Gomega, client.WithWatch)
+		mutateObj func(*v1alpha1.Rekor)
+	}
+	type want struct {
+		result *action.Result
+		verify func(context.Context, gomega.Gomega, client.WithWatch)
+	}
+	tests := []struct {
+		name string
+		pre  pre
+		want want
+	}{
+		{
+			name: "bring your own PVC",
+			pre: pre{
+				mutateObj: func(obj *v1alpha1.Rekor) {
+					obj.Spec.Pvc.Name = "byo-pvc"
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, &v1.PersistentVolumeClaim{})).
+						To(gomega.WithTransform(apierrors.IsNotFound, gomega.BeTrue()))
+					obj := &v1alpha1.Rekor{}
+					g.Expect(c.Get(ctx, nnObj, obj)).To(gomega.Succeed())
+					g.Expect(obj.Status.PvcName).To(gomega.Equal("byo-pvc"))
+
+					con := meta.FindStatusCondition(obj.GetConditions(), ConditionType)
+					g.Expect(con).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Status": gomega.Equal(metav1.ConditionTrue),
+						"Reason": gomega.Equal(ReasonSpecified),
+					})))
+				},
+			},
+		},
+		{
+			name: "create a new PVC",
+			pre: pre{
+				mutateObj: func(obj *v1alpha1.Rekor) {
+					size := resource.MustParse("1Gi")
+					obj.Spec.Pvc.Size = &size
+					obj.Spec.Pvc.AccessModes = []v1alpha1.PersistentVolumeAccessMode{
+						v1alpha1.PersistentVolumeAccessMode(v1.ReadWriteOnce),
+					}
+					obj.Spec.Pvc.StorageClass = storageClass
+					obj.Spec.Pvc.Retain = ptr.To(true)
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					pvc := &v1.PersistentVolumeClaim{}
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, pvc)).
+						To(gomega.Succeed())
+					g.Expect(pvc.Spec.StorageClassName).To(gstruct.PointTo(gomega.Equal(storageClass)))
+					g.Expect(pvc.Spec.Resources.Requests.Storage()).To(gstruct.PointTo(gomega.Equal(resource.MustParse("1Gi"))))
+					g.Expect(pvc.Spec.AccessModes).To(gomega.Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+
+					obj := &v1alpha1.Rekor{}
+					g.Expect(c.Get(ctx, nnObj, obj)).To(gomega.Succeed())
+					g.Expect(obj.Status.PvcName).To(gomega.Equal(pvcNameFormat))
+
+					con := meta.FindStatusCondition(obj.GetConditions(), ConditionType)
+					g.Expect(con).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Status": gomega.Equal(metav1.ConditionTrue),
+						"Reason": gomega.Equal(ReasonCreated),
+					})))
+				},
+			},
+		},
+		{
+			name: "failure missing PVC size",
+			pre: pre{
+				mutateObj: func(obj *v1alpha1.Rekor) {
+					obj.Spec.Pvc.AccessModes = []v1alpha1.PersistentVolumeAccessMode{
+						v1alpha1.PersistentVolumeAccessMode(v1.ReadWriteOnce),
+					}
+					obj.Spec.Pvc.StorageClass = storageClass
+				},
+			},
+			want: want{
+				result: testAction.Error(reconcile.TerminalError(ErrPVCSizeNotSet)),
+				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, &v1.PersistentVolumeClaim{})).
+						To(gomega.WithTransform(apierrors.IsNotFound, gomega.BeTrue()))
+
+					obj := &v1alpha1.Rekor{}
+					g.Expect(c.Get(ctx, nnObj, obj)).To(gomega.Succeed())
+					g.Expect(obj.Status.PvcName).To(gomega.Equal(""))
+
+					con := meta.FindStatusCondition(obj.GetConditions(), ConditionType)
+					g.Expect(con).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Status": gomega.Equal(metav1.ConditionFalse),
+						"Reason": gomega.Equal(constants.Failure),
+					})))
+				},
+			},
+		},
+		{
+			name: "resize a PVC",
+			pre: pre{
+				before: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					pvc := &v1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pvcNameFormat,
+							Namespace: namespace,
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{
+								v1.ReadWriteOnce,
+							},
+							StorageClassName: ptr.To(storageClass),
+							Resources: v1.VolumeResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceStorage: resource.MustParse("100Mi"),
+								},
+							},
+						},
+					}
+					g.Expect(c.Create(ctx, pvc, &client.CreateOptions{})).To(gomega.Succeed())
+				},
+				mutateObj: func(obj *v1alpha1.Rekor) {
+					size := resource.MustParse("1Gi")
+					obj.Spec.Pvc.Size = &size
+					obj.Spec.Pvc.AccessModes = []v1alpha1.PersistentVolumeAccessMode{
+						v1alpha1.PersistentVolumeAccessMode(v1.ReadWriteOnce),
+					}
+					obj.Spec.Pvc.StorageClass = storageClass
+					obj.Spec.Pvc.Retain = ptr.To(true)
+					obj.Status.PvcName = pvcNameFormat
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					pvc := &v1.PersistentVolumeClaim{}
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, pvc)).
+						To(gomega.Succeed())
+					g.Expect(pvc.Spec.StorageClassName).To(gstruct.PointTo(gomega.Equal(storageClass)))
+					g.Expect(pvc.Spec.Resources.Requests.Storage()).To(gstruct.PointTo(gomega.Equal(resource.MustParse("1Gi"))))
+					g.Expect(pvc.Spec.AccessModes).To(gomega.Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+
+					obj := &v1alpha1.Rekor{}
+					g.Expect(c.Get(ctx, nnObj, obj)).To(gomega.Succeed())
+					g.Expect(obj.Status.PvcName).To(gomega.Equal(pvcNameFormat))
+
+					con := meta.FindStatusCondition(obj.GetConditions(), ConditionType)
+					g.Expect(con).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Status": gomega.Equal(metav1.ConditionTrue),
+						"Reason": gomega.Equal(ReasonUpdated),
+					})))
+				},
+			},
+		},
+		{
+			name: "bind existing default PVC",
+			pre: pre{
+				before: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					pvc := &v1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pvcNameFormat,
+							Namespace: namespace,
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{
+								v1.ReadWriteOnce,
+							},
+							StorageClassName: ptr.To(storageClass),
+							Resources: v1.VolumeResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceStorage: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					}
+					g.Expect(c.Create(ctx, pvc, &client.CreateOptions{})).To(gomega.Succeed())
+				},
+				mutateObj: func(obj *v1alpha1.Rekor) {},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					pvc := &v1.PersistentVolumeClaim{}
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, pvc)).
+						To(gomega.Succeed())
+					g.Expect(pvc.Spec.StorageClassName).To(gstruct.PointTo(gomega.Equal(storageClass)))
+					g.Expect(pvc.Spec.Resources.Requests.Storage()).To(gstruct.PointTo(gomega.Equal(resource.MustParse("1Gi"))))
+					g.Expect(pvc.Spec.AccessModes).To(gomega.Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+
+					obj := &v1alpha1.Rekor{}
+					g.Expect(c.Get(ctx, nnObj, obj)).To(gomega.Succeed())
+					g.Expect(obj.Status.PvcName).To(gomega.Equal(pvcNameFormat))
+
+					con := meta.FindStatusCondition(obj.GetConditions(), ConditionType)
+					g.Expect(con).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Status": gomega.Equal(metav1.ConditionTrue),
+						"Reason": gomega.Equal(ReasonDiscovered),
+					})))
+				},
+			},
+		},
+		{
+			name: "not changes",
+			pre: pre{
+				before: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					pvc := &v1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      pvcNameFormat,
+							Namespace: namespace,
+							Labels:    labels.For("component", "deployment", "test"),
+						},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes: []v1.PersistentVolumeAccessMode{
+								v1.ReadWriteOnce,
+							},
+							StorageClassName: ptr.To(storageClass),
+							Resources: v1.VolumeResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceStorage: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					}
+					g.Expect(c.Create(ctx, pvc, &client.CreateOptions{})).To(gomega.Succeed())
+				},
+				mutateObj: func(obj *v1alpha1.Rekor) {
+					size := resource.MustParse("1Gi")
+					obj.Spec.Pvc.Size = &size
+					obj.Spec.Pvc.AccessModes = []v1alpha1.PersistentVolumeAccessMode{
+						v1alpha1.PersistentVolumeAccessMode(v1.ReadWriteOnce),
+					}
+					obj.Spec.Pvc.StorageClass = storageClass
+					obj.Spec.Pvc.Retain = ptr.To(true)
+					obj.Status.PvcName = pvcNameFormat
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+					pvc := &v1.PersistentVolumeClaim{}
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, pvc)).
+						To(gomega.Succeed())
+					g.Expect(pvc.Spec.StorageClassName).To(gstruct.PointTo(gomega.Equal(storageClass)))
+					g.Expect(pvc.Spec.Resources.Requests.Storage()).To(gstruct.PointTo(gomega.Equal(resource.MustParse("1Gi"))))
+					g.Expect(pvc.Spec.AccessModes).To(gomega.Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}))
+
+					obj := &v1alpha1.Rekor{}
+					g.Expect(c.Get(ctx, nnObj, obj)).To(gomega.Succeed())
+					g.Expect(obj.Status.PvcName).To(gomega.Equal(pvcNameFormat))
+
+					con := meta.FindStatusCondition(obj.GetConditions(), ConditionType)
+					g.Expect(con).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Status": gomega.Equal(metav1.ConditionTrue),
+						"Reason": gomega.Equal(constants.Ready),
+					})))
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			g := gomega.NewGomegaWithT(t)
+			instance := &v1alpha1.Rekor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+			}
+
+			tt.pre.mutateObj(instance)
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				Build()
+			w := Wrapper[*v1alpha1.Rekor](
+				func(r *v1alpha1.Rekor) v1alpha1.Pvc {
+					return r.Spec.Pvc
+				},
+				func(r *v1alpha1.Rekor) string {
+					return r.Status.PvcName
+				},
+				func(r *v1alpha1.Rekor, s string) {
+					r.Status.PvcName = s
+				},
+				func(r *v1alpha1.Rekor) bool {
+					return true
+				},
+			)
+			if tt.pre.before != nil {
+				tt.pre.before(ctx, g, c)
+			}
+			a := testAction.PrepareAction(c, NewAction[*v1alpha1.Rekor]("pvc", "component", "deployment", w))
+			if got := a.Handle(ctx, instance); !reflect.DeepEqual(got, tt.want.result) {
+				t.Errorf("Handle() = %v, want %v", got, tt.want.result)
+			}
+			tt.want.verify(ctx, g, c)
+		})
+	}
+}
+
+func TestCanHandle(t *testing.T) {
+	type args struct {
+		condition  *metav1.Condition
+		enabled    bool
+		pvc        v1alpha1.Pvc
+		statusPvc  string
+		generation int64
+	}
+	tests := []struct {
+		name      string
+		args      args
+		canHandle bool
+	}{
+		{
+			name:      "disabled",
+			canHandle: false,
+			args: args{
+				enabled: false,
+			},
+		}, {
+			name:      "empty status pvc name",
+			canHandle: true,
+			args: args{
+				enabled:   true,
+				statusPvc: "",
+			},
+		}, {
+			name:      "status condition empty",
+			canHandle: true,
+			args: args{
+				enabled:   true,
+				statusPvc: "exists",
+				condition: nil,
+			},
+		}, {
+			name:      "status condition is false",
+			canHandle: true,
+			args: args{
+				enabled:   true,
+				statusPvc: "exists",
+				condition: &metav1.Condition{
+					Type:   ConditionType,
+					Status: metav1.ConditionFalse,
+				},
+			},
+		}, {
+			name:      "status condition is true",
+			canHandle: false,
+			args: args{
+				enabled:   true,
+				statusPvc: "exists",
+				condition: &metav1.Condition{
+					Type:   ConditionType,
+					Status: metav1.ConditionTrue,
+				},
+			},
+		}, {
+			name:      "status condition is Unknown",
+			canHandle: true,
+			args: args{
+				enabled:   true,
+				statusPvc: "exists",
+				condition: &metav1.Condition{
+					Type:   ConditionType,
+					Status: metav1.ConditionUnknown,
+				},
+			},
+		}, {
+			name:      "status observed generation empty",
+			canHandle: true,
+			args: args{
+				enabled:    true,
+				statusPvc:  "exists",
+				generation: 1,
+				condition: &metav1.Condition{
+					Type:   ConditionType,
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
+		{
+			name:      "status observed generation same",
+			canHandle: false,
+			args: args{
+				enabled:    true,
+				statusPvc:  "exists",
+				generation: 1,
+				condition: &metav1.Condition{
+					Type:               ConditionType,
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+				},
+			},
+		},
+		{
+			name:      "status observed generation different",
+			canHandle: true,
+			args: args{
+				enabled:    true,
+				statusPvc:  "exists",
+				generation: 2,
+				condition: &metav1.Condition{
+					Type:               ConditionType,
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := testAction.FakeClientBuilder().Build()
+			w := Wrapper[*v1alpha1.Rekor](
+				func(r *v1alpha1.Rekor) v1alpha1.Pvc {
+					return tt.args.pvc
+				},
+				func(r *v1alpha1.Rekor) string {
+					return tt.args.statusPvc
+				},
+				func(r *v1alpha1.Rekor, s string) {
+					t.Fatal("unexpected execution")
+				},
+				func(r *v1alpha1.Rekor) bool {
+					return tt.args.enabled
+				},
+			)
+
+			a := testAction.PrepareAction(c, NewAction[*v1alpha1.Rekor]("pvc", "component", "deployment", w))
+			instance := v1alpha1.Rekor{}
+			instance.SetGeneration(tt.args.generation)
+			if tt.args.condition != nil {
+				meta.SetStatusCondition(&instance.Status.Conditions, *tt.args.condition)
+			}
+
+			if got := a.CanHandle(context.Background(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
+			}
+		})
+	}
+}

--- a/internal/action/pvc/doc.go
+++ b/internal/action/pvc/doc.go
@@ -1,0 +1,48 @@
+/*
+Package pvc implements a generic action for managing [k8s.io/api/core/v1.PersistentVolumeClaim] (PVCs).
+
+This action handles the lifecycle of a PVC associated with a custom resource. It can create,
+update, or discover a PVC based on the specification within the custom resource. The primary
+goal is to abstract and standardize the logic for persistent storage provisioning within
+the operator's reconciliation loop, ensuring that stateful components have their required
+storage reliably managed.
+
+The action is implemented as a generic type to work with any custom resource that satisfies
+the [apis.ConditionsAwareObject] interface. It uses a wrapper to abstract the details of
+how to access the PVC specification and status fields from the custom resource object.
+
+Workflow:
+ 1. Check if an explicit PVC name is provided in the resource's spec. If so, adopt that
+    PVC, update the status, and the process is complete.
+ 2. If no PVC name is in the status, attempt to discover an existing PVC with a default name.
+    If found, adopt it and update the status.
+ 3. If no PVC is specified or discovered, proceed to create or update a PVC.
+    a. Validate that the PVC size is specified in the spec; if not, the reconciliation fails with a terminal error.
+    b. Create or update the PVC with the specified size, access modes, and storage class.
+    c. Set ownership labels and an optional controller reference on the PVC, unless the retain policy is enabled.
+ 4. Update the custom resource's status with the name of the managed PVC and a condition
+    reflecting the outcome (e.g., Created, Updated, Discovered, Specified).
+
+Usage:
+
+	// First, define a wrapper that provides access to the custom resource's PVC fields.
+	pvcWrapper := pvc.Wrapper[*v1alpha1.Rekor](
+	    func(r *v1alpha1.Rekor) v1alpha1.Pvc {
+	        return r.Spec.Pvc
+	    },
+	    func(r *v1alpha1.Rekor) string {
+	        return r.Status.PvcName
+	    },
+	    func(r *v1alpha1.Rekor, s string) {
+	        r.Status.PvcName = s
+	    },
+	    // This function determines if the PVC action should run.
+	    func(r *v1alpha1.Rekor) bool {
+	        return true
+	    },
+	)
+
+	// Then, create the action with a name format and component details.
+	pvc.NewAction[*v1alpha1.Rekor]("rekor-pvc", "rekor", "deployment", pvcWrapper)
+*/
+package pvc

--- a/internal/action/pvc/errors.go
+++ b/internal/action/pvc/errors.go
@@ -1,0 +1,9 @@
+package pvc
+
+import (
+	"errors"
+)
+
+var (
+	ErrPVCSizeNotSet = errors.New("PVC size is not set")
+)

--- a/internal/action/pvc/types.go
+++ b/internal/action/pvc/types.go
@@ -1,0 +1,56 @@
+package pvc
+
+import (
+	"github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/apis"
+)
+
+const (
+	ConditionType    = "PVC"
+	ReasonCreated    = "Created"
+	ReasonUpdated    = "Updated"
+	ReasonSpecified  = "Specified"
+	ReasonDiscovered = "Discovered"
+)
+
+func Wrapper[T apis.ConditionsAwareObject](
+	getPVCSpec func(T) v1alpha1.Pvc,
+	getStatusPVCName func(T) string,
+	setStatusPVCName func(T, string),
+	isEnabledPVC func(T) bool,
+) func(T) *wrapper[T] {
+	return func(obj T) *wrapper[T] {
+		return &wrapper[T]{
+			object:         obj,
+			callPVCSpec:    getPVCSpec,
+			callGetPVCName: getStatusPVCName,
+			callSetPVCName: setStatusPVCName,
+			callEnabledPVC: isEnabledPVC,
+		}
+	}
+}
+
+type wrapper[T apis.ConditionsAwareObject] struct {
+	object T
+
+	callPVCSpec    func(T) v1alpha1.Pvc
+	callGetPVCName func(T) string
+	callSetPVCName func(T, string)
+	callEnabledPVC func(T) bool
+}
+
+func (c *wrapper[T]) GetPVCSpec() v1alpha1.Pvc {
+	return c.callPVCSpec(c.object)
+}
+
+func (c *wrapper[T]) GetStatusPVCName() string {
+	return c.callGetPVCName(c.object)
+}
+
+func (c *wrapper[T]) SetStatusPVCName(pvcName string) {
+	c.callSetPVCName(c.object, pvcName)
+}
+
+func (c *wrapper[T]) EnabledPVC() bool {
+	return c.callEnabledPVC(c.object)
+}

--- a/internal/controller/rekor/actions/server/pvc.go
+++ b/internal/controller/rekor/actions/server/pvc.go
@@ -1,87 +1,34 @@
 package server
 
 import (
-	"context"
-	"fmt"
-	"maps"
-	"slices"
-
-	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
-	"github.com/securesign/operator/internal/controller/rekor/actions"
-	"github.com/securesign/operator/internal/labels"
-	"github.com/securesign/operator/internal/utils"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/pvc"
+	"github.com/securesign/operator/internal/controller/rekor/actions"
 )
 
 const PvcNameFormat = "rekor-%s-pvc"
 
 func NewCreatePvcAction() action.Action[*rhtasv1alpha1.Rekor] {
-	return &createPvcAction{}
-}
-
-type createPvcAction struct {
-	action.BaseAction
-}
-
-func (i createPvcAction) Name() string {
-	return "create PVC"
-}
-
-func (i createPvcAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Rekor) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	if c == nil {
-		return false
-	}
-	return c.Reason == constants.Creating && enabledFileAttestationStorage(instance) && instance.Status.PvcName == ""
-}
-
-func (i createPvcAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor) *action.Result {
-	var (
-		result controllerutil.OperationResult
-		err    error
-	)
-	if instance.Spec.Pvc.Name != "" {
-		instance.Status.PvcName = instance.Spec.Pvc.Name
-		return i.StatusUpdate(ctx, instance)
-	}
-
-	if instance.Spec.Pvc.Size == nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("PVC size is not set")), instance)
-	}
-
-	// PVC does not exist, create a new one
-	i.Logger.V(1).Info("Creating new PVC")
-
-	pvc := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf(PvcNameFormat, instance.Name),
-			Namespace: instance.Namespace,
+	wrapper := pvc.Wrapper[*rhtasv1alpha1.Rekor](
+		func(r *rhtasv1alpha1.Rekor) rhtasv1alpha1.Pvc {
+			return r.Spec.Pvc
 		},
-	}
+		func(r *rhtasv1alpha1.Rekor) string {
+			return r.Status.PvcName
+		},
+		func(r *rhtasv1alpha1.Rekor, s string) {
+			r.Status.PvcName = s
+		},
+		func(r *rhtasv1alpha1.Rekor) bool {
+			return enabledFileAttestationStorage(r)
+		},
+	)
 
-	l := labels.For(actions.ServerComponentName, actions.ServerDeploymentName, instance.Name)
-	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client, pvc,
-		kubernetes.EnsurePVCSpec(instance.Spec.Pvc),
-		ensure.Optional[*v1.PersistentVolumeClaim](!utils.OptionalBool(instance.Spec.Pvc.Retain), ensure.ControllerReference[*v1.PersistentVolumeClaim](instance, i.Client)),
-		ensure.Labels[*v1.PersistentVolumeClaim](slices.Collect(maps.Keys(l)), l),
-	); err != nil {
-		// do not terminate the deployment - retry with exponential backoff
-		return i.Error(ctx, fmt.Errorf("could not create DB PVC: %w", err), instance)
-	}
-
-	if result != controllerutil.OperationResultNone {
-		i.Recorder.Event(instance, v1.EventTypeNormal, "PersistentVolumeCreated", "New PersistentVolume created")
-	}
-
-	instance.Status.PvcName = pvc.Name
-	return i.StatusUpdate(ctx, instance)
+	return pvc.NewAction[*rhtasv1alpha1.Rekor](
+		PvcNameFormat,
+		actions.ServerComponentName,
+		actions.ServerDeploymentName,
+		wrapper,
+	)
 }

--- a/internal/controller/trillian/actions/db/pvc.go
+++ b/internal/controller/trillian/actions/db/pvc.go
@@ -1,83 +1,32 @@
 package db
 
 import (
-	"context"
-	"fmt"
-	"maps"
-	"slices"
-
-	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
-	"github.com/securesign/operator/internal/labels"
-	"github.com/securesign/operator/internal/utils"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/securesign/operator/internal/controller/trillian/actions"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/pvc"
+	"github.com/securesign/operator/internal/controller/trillian/actions"
 )
 
 func NewCreatePvcAction() action.Action[*rhtasv1alpha1.Trillian] {
-	return &createPvcAction{}
-}
-
-type createPvcAction struct {
-	action.BaseAction
-}
-
-func (i createPvcAction) Name() string {
-	return "create PVC"
-}
-
-func (i createPvcAction) CanHandle(ctx context.Context, instance *rhtasv1alpha1.Trillian) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return c.Reason == constants.Creating && enabled(instance) && instance.Status.Db.Pvc.Name == ""
-}
-
-func (i createPvcAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian) *action.Result {
-	var (
-		err    error
-		result controllerutil.OperationResult
+	wrapper := pvc.Wrapper[*rhtasv1alpha1.Trillian](
+		func(t *rhtasv1alpha1.Trillian) rhtasv1alpha1.Pvc {
+			return t.Spec.Db.Pvc
+		},
+		func(t *rhtasv1alpha1.Trillian) string {
+			return t.Status.Db.Pvc.Name
+		},
+		func(t *rhtasv1alpha1.Trillian, s string) {
+			t.Status.Db.Pvc.Name = s
+		},
+		func(t *rhtasv1alpha1.Trillian) bool {
+			return enabled(t)
+		},
 	)
 
-	if instance.Spec.Db.Pvc.Name != "" {
-		instance.Status.Db.Pvc.Name = instance.Spec.Db.Pvc.Name
-		return i.StatusUpdate(ctx, instance)
-	}
-
-	if instance.Spec.Db.Pvc.Size == nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("PVC size is not set")), instance)
-	}
-
-	// PVC does not exist, create a new one
-	i.Logger.V(1).Info("Creating new PVC")
-
-	pvc := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      actions.DbPvcName,
-			Namespace: instance.Namespace,
-		},
-	}
-
-	l := labels.For(actions.DbComponentName, actions.DbDeploymentName, instance.Name)
-	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client, pvc,
-		kubernetes.EnsurePVCSpec(instance.Spec.Db.Pvc),
-		ensure.Optional[*v1.PersistentVolumeClaim](!utils.OptionalBool(instance.Spec.Db.Pvc.Retain), ensure.ControllerReference[*v1.PersistentVolumeClaim](instance, i.Client)),
-		ensure.Labels[*v1.PersistentVolumeClaim](slices.Collect(maps.Keys(l)), l),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create DB PVC: %w", err), instance)
-	}
-
-	if result != controllerutil.OperationResultNone {
-		i.Recorder.Event(instance, v1.EventTypeNormal, "PersistentVolumeCreated", "New PersistentVolume created")
-	}
-
-	instance.Status.Db.Pvc.Name = pvc.Name
-	return i.StatusUpdate(ctx, instance)
+	return pvc.NewAction[*rhtasv1alpha1.Trillian](
+		actions.DbPvcName,
+		actions.DbComponentName,
+		actions.DbDeploymentName,
+		wrapper,
+	)
 }

--- a/internal/controller/tuf/actions/pvc.go
+++ b/internal/controller/tuf/actions/pvc.go
@@ -1,92 +1,38 @@
 package actions
 
 import (
-	"context"
-	"fmt"
-	"maps"
-	"slices"
-
-	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
-	tufConstants "github.com/securesign/operator/internal/controller/tuf/constants"
-	"github.com/securesign/operator/internal/labels"
-	"github.com/securesign/operator/internal/utils"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/pvc"
+	tufConstants "github.com/securesign/operator/internal/controller/tuf/constants"
 )
 
 func NewCreatePvcAction() action.Action[*rhtasv1alpha1.Tuf] {
-	return &createPvcAction{}
-}
-
-type createPvcAction struct {
-	action.BaseAction
-}
-
-func (i createPvcAction) Name() string {
-	return "create PVC"
-}
-
-func (i createPvcAction) CanHandle(ctx context.Context, instance *rhtasv1alpha1.Tuf) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && instance.Status.PvcName == ""
-}
-
-func (i createPvcAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tuf) *action.Result {
-	var (
-		result controllerutil.OperationResult
-		err    error
+	wrapper := pvc.Wrapper[*rhtasv1alpha1.Tuf](
+		func(t *rhtasv1alpha1.Tuf) rhtasv1alpha1.Pvc {
+			return rhtasv1alpha1.Pvc{
+				Name:         t.Spec.Pvc.Name,
+				Size:         t.Spec.Pvc.Size,
+				StorageClass: t.Spec.Pvc.StorageClass,
+				AccessModes:  t.Spec.Pvc.AccessModes,
+				Retain:       t.Spec.Pvc.Retain,
+			}
+		},
+		func(t *rhtasv1alpha1.Tuf) string {
+			return t.Status.PvcName
+		},
+		func(t *rhtasv1alpha1.Tuf, s string) {
+			t.Status.PvcName = s
+		},
+		func(t *rhtasv1alpha1.Tuf) bool {
+			return true
+		},
 	)
 
-	if instance.Spec.Pvc.Name != "" {
-		instance.Status.PvcName = instance.Spec.Pvc.Name
-		return i.StatusUpdate(ctx, instance)
-	}
-
-	if instance.Spec.Pvc.Size == nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("PVC size is not set")), instance)
-	}
-
-	// PVC does not exist, create a new one
-	i.Logger.V(1).Info("Creating new PVC")
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:   constants.Ready,
-		Status: metav1.ConditionFalse,
-		Reason: constants.Creating,
-	})
-
-	pvc := &v1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      tufConstants.DeploymentName,
-			Namespace: instance.Namespace,
-		},
-	}
-
-	l := labels.For(tufConstants.DeploymentName, tufConstants.DeploymentName, instance.Name)
-	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client, pvc,
-		kubernetes.EnsurePVCSpec(rhtasv1alpha1.Pvc{
-			Size:         instance.Spec.Pvc.Size,
-			AccessModes:  instance.Spec.Pvc.AccessModes,
-			StorageClass: instance.Spec.Pvc.StorageClass,
-		}),
-		ensure.Optional[*v1.PersistentVolumeClaim](!utils.OptionalBool(instance.Spec.Pvc.Retain), ensure.ControllerReference[*v1.PersistentVolumeClaim](instance, i.Client)),
-		ensure.Labels[*v1.PersistentVolumeClaim](slices.Collect(maps.Keys(l)), l),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create DB PVC: %w", err), instance)
-	}
-
-	if result != controllerutil.OperationResultNone {
-		i.Recorder.Event(instance, v1.EventTypeNormal, "PersistentVolumeCreated", "New PersistentVolume created")
-	}
-
-	instance.Status.PvcName = pvc.Name
-	return i.StatusUpdate(ctx, instance)
+	return pvc.NewAction[*rhtasv1alpha1.Tuf](
+		"tuf",
+		tufConstants.DeploymentName,
+		tufConstants.DeploymentName,
+		wrapper,
+	)
 }

--- a/internal/utils/kubernetes/pvc.go
+++ b/internal/utils/kubernetes/pvc.go
@@ -1,40 +1,36 @@
 package kubernetes
 
 import (
-	"context"
-
 	"github.com/securesign/operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func GetPVC(ctx context.Context, c client.Client, namespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
-	pvc := &corev1.PersistentVolumeClaim{}
-	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: pvcName}, pvc)
-	return pvc, err
-}
 
 func EnsurePVCSpec(instancePvc v1alpha1.Pvc) func(pvc *corev1.PersistentVolumeClaim) error {
 	return func(pvc *corev1.PersistentVolumeClaim) error {
-		modes := make([]corev1.PersistentVolumeAccessMode, len(instancePvc.AccessModes))
-		for i, m := range instancePvc.AccessModes {
-			modes[i] = corev1.PersistentVolumeAccessMode(m)
-		}
-		var computedStorageClass *string
-		if instancePvc.StorageClass == "" {
-			computedStorageClass = nil
-		} else {
-			computedStorageClass = &instancePvc.StorageClass
-		}
-
 		spec := &pvc.Spec
 
-		spec.AccessModes = modes
+		// immutable for bound claims
+		if len(spec.AccessModes) == 0 {
+			modes := make([]corev1.PersistentVolumeAccessMode, len(instancePvc.AccessModes))
+			for i, m := range instancePvc.AccessModes {
+				modes[i] = corev1.PersistentVolumeAccessMode(m)
+			}
+			spec.AccessModes = modes
+		}
+
+		// immutable volumeAttributesClassName for bound claims
+		if spec.StorageClassName == nil {
+			if instancePvc.StorageClass != "" {
+				spec.StorageClassName = &instancePvc.StorageClass
+			}
+		}
+
 		spec.Resources = corev1.VolumeResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceStorage: *instancePvc.Size,
-			}}
-		spec.StorageClassName = computedStorageClass
+			},
+		}
+
 		return nil
 	}
 }

--- a/internal/utils/kubernetes/pvc_test.go
+++ b/internal/utils/kubernetes/pvc_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	"github.com/securesign/operator/api/v1alpha1"
 	testAction "github.com/securesign/operator/internal/testing/action"
 	"github.com/securesign/operator/internal/utils"
@@ -18,16 +19,36 @@ import (
 const name = "test"
 
 func TestEnsurePVCSpec(t *testing.T) {
+	storage := resource.MustParse("987Gi")
+	mode := v1.ReadWriteOnce
+	pvc := v1alpha1.Pvc{
+		Size:         &storage,
+		Retain:       utils.Pointer(true),
+		Name:         "test",
+		StorageClass: "class",
+		AccessModes:  []v1alpha1.PersistentVolumeAccessMode{v1alpha1.PersistentVolumeAccessMode(mode)},
+	}
+
+	verify := func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+		existing := &v1.PersistentVolumeClaim{}
+		g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+		g.Expect(existing.Spec.AccessModes).To(gomega.Equal([]v1.PersistentVolumeAccessMode{mode}))
+		g.Expect(existing.Spec.Resources.Requests.Storage()).To(gomega.Equal(pvc.Size))
+		g.Expect(existing.Spec.StorageClassName).To(gstruct.PointTo(gomega.Equal(pvc.StorageClass)))
+	}
+
 	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
 		result  controllerutil.OperationResult
+		verify  func(context.Context, gomega.Gomega, client.WithWatch)
 	}{
 		{
 			"create new object",
 			[]client.Object{},
 			controllerutil.OperationResultCreated,
+			verify,
 		},
 		{
 			"update existing object",
@@ -35,15 +56,73 @@ func TestEnsurePVCSpec(t *testing.T) {
 				&v1.PersistentVolumeClaim{
 					ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
 					Spec: v1.PersistentVolumeClaimSpec{
-						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany, v1.ReadWriteOnce},
+						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 						Resources: v1.VolumeResourceRequirements{Requests: v1.ResourceList{
 							v1.ResourceStorage: resource.MustParse("1Gi"),
 						}},
-						StorageClassName: utils.Pointer("fake"),
+						StorageClassName: utils.Pointer("class"),
 					},
 				},
 			},
 			controllerutil.OperationResultUpdated,
+			verify,
+		},
+		{
+			"do not update immutable fields",
+			[]client.Object{
+				&v1.PersistentVolumeClaim{
+					ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: v1.PersistentVolumeClaimSpec{
+						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany, v1.ReadWriteOnce},
+						Resources: v1.VolumeResourceRequirements{Requests: v1.ResourceList{
+							v1.ResourceStorage: resource.MustParse("987Gi"),
+						}},
+						StorageClassName: utils.Pointer("test"),
+					},
+				},
+			},
+			controllerutil.OperationResultNone,
+			func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
+				existing := &v1.PersistentVolumeClaim{}
+				g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+				g.Expect(existing.Spec.AccessModes).To(gomega.Equal([]v1.PersistentVolumeAccessMode{v1.ReadWriteMany, v1.ReadWriteOnce}))
+				g.Expect(existing.Spec.Resources.Requests.Storage()).To(gomega.Equal(pvc.Size))
+				g.Expect(existing.Spec.StorageClassName).To(gstruct.PointTo(gomega.Equal("test")))
+			},
+		},
+		{
+			"set storage class only when nil",
+			[]client.Object{
+				&v1.PersistentVolumeClaim{
+					ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: v1.PersistentVolumeClaimSpec{
+						AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+						Resources: v1.VolumeResourceRequirements{Requests: v1.ResourceList{
+							v1.ResourceStorage: resource.MustParse("987Gi"),
+						}},
+						StorageClassName: nil,
+					},
+				},
+			},
+			controllerutil.OperationResultUpdated,
+			verify,
+		},
+		{
+			"set access mode only when empty",
+			[]client.Object{
+				&v1.PersistentVolumeClaim{
+					ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: v1.PersistentVolumeClaimSpec{
+						AccessModes: []v1.PersistentVolumeAccessMode{},
+						Resources: v1.VolumeResourceRequirements{Requests: v1.ResourceList{
+							v1.ResourceStorage: resource.MustParse("987Gi"),
+						}},
+						StorageClassName: utils.Pointer("class"),
+					},
+				},
+			},
+			controllerutil.OperationResultUpdated,
+			verify,
 		},
 		{
 			"existing object with expected values",
@@ -60,37 +139,25 @@ func TestEnsurePVCSpec(t *testing.T) {
 				},
 			},
 			controllerutil.OperationResultNone,
+			verify,
 		},
 	}
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
+			g := gomega.NewGomegaWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
-			storage := resource.MustParse("987Gi")
-			mode := v1.ReadWriteOnce
-			pvc := v1alpha1.Pvc{
-				Size:         &storage,
-				Retain:       utils.Pointer(true),
-				Name:         "test",
-				StorageClass: "class",
-				AccessModes:  []v1alpha1.PersistentVolumeAccessMode{v1alpha1.PersistentVolumeAccessMode(mode)},
-			}
-
 			result, err := CreateOrUpdate(ctx, c,
 				&v1.PersistentVolumeClaim{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsurePVCSpec(pvc))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
-			existing := &v1.PersistentVolumeClaim{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Spec.AccessModes).To(gomega.Equal([]v1.PersistentVolumeAccessMode{mode}))
-			gomega.Expect(existing.Spec.Resources.Requests.Storage()).To(gomega.Equal(pvc.Size))
-			gomega.Expect(*existing.Spec.StorageClassName).To(gomega.Equal(pvc.StorageClass))
+			tt.verify(ctx, g, c)
 		})
 	}
 }


### PR DESCRIPTION
This commit refactors the PersistentVolumeClaim (PVC) management logic into a centralized, generic action and fixes a bug where the operator would attempt to modify an immutable field on bound claims.

Refs: [SECURESIGN-2734](https://issues.redhat.com/browse/SECURESIGN-2734)

## Summary by Sourcery

Centralize PersistentVolumeClaim handling into a generic reusable action and enforce immutability of storageClass and accessModes on bound claims

New Features:
- Add a new generic PVC action package to standardize PVC creation, discovery, and updates across all controllers
- Add CRD validations to prevent storageClass and accessModes changes when PVC name is not specified

Enhancements:
- Refactor Trillian, Rekor, and Tuf controllers to use the generic PVC action instead of custom logic
- Improve EnsurePVCSpec to skip modifying immutable fields on existing bound PVCs

Documentation:
- Add package documentation for the generic PVC action

Tests:
- Introduce comprehensive unit tests for the new generic PVC action
- Extend PVC spec tests and CRD API tests to cover immutability and validation scenarios