### PR TITLE
test: pass context via Eventually function

### DIFF
--- a/test/e2e/common_install_test.go
+++ b/test/e2e/common_install_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 
 		It("operator should generate Fulcio's secret", func() {
 			Eventually(func(g Gomega) *v1.Secret {
-				f := fulcio.Get(ctx, cli, namespace.Name, s.Name)()
+				f := fulcio.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(f).ToNot(BeNil())
 				g.Expect(f.Status.Certificate).ToNot(BeNil())
 				g.Expect(f.Status.Certificate.PrivateKeyRef).ToNot(BeNil())
@@ -99,10 +99,10 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 
 		It("operator should generate rekor secret", func() {
 			Eventually(func() *v1alpha1.SecretKeySelector {
-				return rekor.Get(ctx, cli, namespace.Name, s.Name)().Status.Signer.KeyRef
+				return rekor.Get(ctx, cli, namespace.Name, s.Name).Status.Signer.KeyRef
 			}).Should(Not(BeNil()))
 			Eventually(func(g Gomega) *v1.Secret {
-				r := rekor.Get(ctx, cli, namespace.Name, s.Name)()
+				r := rekor.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(r).ToNot(BeNil())
 				scr := &v1.Secret{}
 				g.Expect(cli.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: r.Status.Signer.KeyRef.Name}, scr)).To(Succeed())
@@ -116,7 +116,7 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 
 		It("operator should generate TSA secret", func() {
 			Eventually(func() *v1.Secret {
-				tsa := tsa.Get(ctx, cli, namespace.Name, s.Name)()
+				tsa := tsa.Get(ctx, cli, namespace.Name, s.Name)
 				scr := &v1.Secret{}
 				Expect(cli.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: tsa.Status.Signer.File.PrivateKeyRef.Name}, scr)).To(Succeed())
 				return scr
@@ -150,13 +150,13 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 				ContainElement(
 					WithTransform(func(sp v1.SecretProjection) string {
 						return sp.Name
-					}, Equal(fulcio.Get(ctx, cli, namespace.Name, s.Name)().Status.Certificate.CARef.Name)),
+					}, Equal(fulcio.Get(ctx, cli, namespace.Name, s.Name).Status.Certificate.CARef.Name)),
 				))
 		})
 
 		It("rekor is running with mounted certs", func() {
 			rekor.Verify(ctx, cli, namespace.Name, s.Name, true)
-			server := rekor.GetServerPod(ctx, cli, namespace.Name)()
+			server := rekor.GetServerPod(ctx, cli, namespace.Name)
 			Expect(server).NotTo(BeNil())
 			Expect(server.Spec.Volumes).To(
 				ContainElement(
@@ -165,7 +165,7 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 							return volume.Secret.SecretName
 						}
 						return ""
-					}, Equal(rekor.Get(ctx, cli, namespace.Name, s.Name)().Status.Signer.KeyRef.Name))),
+					}, Equal(rekor.Get(ctx, cli, namespace.Name, s.Name).Status.Signer.KeyRef.Name))),
 			)
 
 		})
@@ -181,7 +181,7 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 							return volume.Secret.SecretName
 						}
 						return ""
-					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name)().Status.Signer.CertificateChain.CertificateChainRef.Name))),
+					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name).Status.Signer.CertificateChain.CertificateChainRef.Name))),
 			)
 			Expect(server.Spec.Volumes).To(
 				ContainElement(
@@ -190,7 +190,7 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 							return volume.Secret.SecretName
 						}
 						return ""
-					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name)().Status.Signer.File.PrivateKeyRef.Name))),
+					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name).Status.Signer.File.PrivateKeyRef.Name))),
 			)
 		})
 
@@ -205,13 +205,13 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 							return volume.ConfigMap.Name
 						}
 						return ""
-					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name)().Status.NTPMonitoring.Config.NtpConfigRef.Name))),
+					}, Equal(tsa.Get(ctx, cli, namespace.Name, s.Name).Status.NTPMonitoring.Config.NtpConfigRef.Name))),
 			)
 		})
 
 		It("Tuf repository root key secret was created", func() {
 			tuf.Verify(ctx, cli, namespace.Name, s.Name)
-			tuf := tuf.Get(ctx, cli, namespace.Name, s.Name)()
+			tuf := tuf.Get(ctx, cli, namespace.Name, s.Name)
 			Expect(tuf.Spec.RootKeySecretRef).NotTo(BeNil())
 			Expect(cli.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: tuf.Spec.RootKeySecretRef.Name}, &v1.Secret{})).To(Succeed())
 		})
@@ -235,7 +235,7 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 		})
 
 		It("Verify Rekor Search UI is accessible", func() {
-			r := rekor.Get(ctx, cli, namespace.Name, s.Name)()
+			r := rekor.Get(ctx, cli, namespace.Name, s.Name)
 			Expect(r).ToNot(BeNil())
 			Expect(r.Status.RekorSearchUIUrl).NotTo(BeEmpty())
 

--- a/test/e2e/fulcio_key_rotation_test.go
+++ b/test/e2e/fulcio_key_rotation_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Fulcio cert rotation test", Ordered, func() {
 	Describe("Fulcio cert rotation", func() {
 
 		It("Download fulcio cert", func() {
-			f := fulcio.Get(ctx, cli, namespace.Name, s.Name)()
+			f := fulcio.Get(ctx, cli, namespace.Name, s.Name)
 			Expect(f).ToNot(BeNil())
 			oldCert, err = kubernetes.GetSecretData(cli, namespace.Name, f.Status.Certificate.CARef)
 			Expect(err).ToNot(HaveOccurred())
@@ -93,7 +93,7 @@ var _ = Describe("Fulcio cert rotation test", Ordered, func() {
 			Expect(cli.Create(ctx, newCert)).To(Succeed())
 
 			Eventually(func(g Gomega) error {
-				f := securesign.Get(ctx, cli, namespace.Name, s.Name)()
+				f := securesign.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(f).ToNot(BeNil())
 				f.Spec.Fulcio.Certificate.PrivateKeyRef = &v1alpha1.SecretKeySelector{
 					LocalObjectReference: v1alpha1.LocalObjectReference{

--- a/test/e2e/key_autodiscovery_test.go
+++ b/test/e2e/key_autodiscovery_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Securesign key autodiscovery test", Ordered, func() {
 		})
 
 		It("Verify TUF keys", func() {
-			t := tuf.Get(ctx, cli, namespace.Name, s.Name)()
+			t := tuf.Get(ctx, cli, namespace.Name, s.Name)
 			Expect(t).ToNot(BeNil())
 			Expect(t.Status.Keys).To(HaveEach(WithTransform(func(k v1alpha1.TufKey) string { return k.SecretRef.Name }, Not(BeEmpty()))))
 			var (

--- a/test/e2e/namespaced.go
+++ b/test/e2e/namespaced.go
@@ -344,16 +344,16 @@ var _ = Describe("Install components to separate namespaces", Ordered, func() {
 		})
 
 		It("Use cosign cli", func() {
-			f := fulcio.Get(ctx, cli, namespaces["fulcio"].Name, fulcioObject.Name)()
+			f := fulcio.Get(ctx, cli, namespaces["fulcio"].Name, fulcioObject.Name)
 			Expect(f).ToNot(BeNil())
 
-			r := rekor.Get(ctx, cli, namespaces["rekor"].Name, rekorObject.Name)()
+			r := rekor.Get(ctx, cli, namespaces["rekor"].Name, rekorObject.Name)
 			Expect(r).ToNot(BeNil())
 
-			t := tuf.Get(ctx, cli, namespaces["tuf"].Name, tufObject.Name)()
+			t := tuf.Get(ctx, cli, namespaces["tuf"].Name, tufObject.Name)
 			Expect(t).ToNot(BeNil())
 
-			ts := tsa.Get(ctx, cli, namespaces["tsa"].Name, tsaObject.Name)()
+			ts := tsa.Get(ctx, cli, namespaces["tsa"].Name, tsaObject.Name)
 			Expect(ts).ToNot(BeNil())
 
 			Eventually(func() error {

--- a/test/e2e/provided_certs_test.go
+++ b/test/e2e/provided_certs_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Securesign install with provided certs", Ordered, func() {
 
 		It("Rekor is running with mounted certs", func() {
 			rekor.Verify(ctx, cli, namespace.Name, s.Name, true)
-			server := rekor.GetServerPod(ctx, cli, namespace.Name)()
+			server := rekor.GetServerPod(ctx, cli, namespace.Name)
 			Expect(server).NotTo(BeNil())
 			Expect(server.Spec.Volumes).To(
 				ContainElement(

--- a/test/e2e/support/condition/condition.go
+++ b/test/e2e/support/condition/condition.go
@@ -3,7 +3,6 @@ package condition
 import (
 	"context"
 
-	"github.com/onsi/gomega"
 	"github.com/securesign/operator/internal/apis"
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/labels"
@@ -19,11 +18,9 @@ func IsReady(f apis.ConditionsAwareObject) bool {
 	return meta.IsStatusConditionTrue(f.GetConditions(), constants.Ready)
 }
 
-func DeploymentIsRunning(ctx context.Context, cli client.Client, namespace, component string) func(g gomega.Gomega) (bool, error) {
-	return func(g gomega.Gomega) (bool, error) {
-		return kubernetes.DeploymentIsRunning(ctx, cli, namespace, map[string]string{
-			labels.LabelAppPartOf:    constants.AppName,
-			labels.LabelAppComponent: component,
-		})
-	}
+func DeploymentIsRunning(ctx context.Context, cli client.Client, namespace, component string) (bool, error) {
+	return kubernetes.DeploymentIsRunning(ctx, cli, namespace, map[string]string{
+		labels.LabelAppPartOf:    constants.AppName,
+		labels.LabelAppComponent: component,
+	})
 }

--- a/test/e2e/support/tas/fulcio/fulcio.go
+++ b/test/e2e/support/tas/fulcio/fulcio.go
@@ -17,13 +17,16 @@ import (
 )
 
 func Verify(ctx context.Context, cli client.Client, namespace string, name string) {
-	Eventually(Get(ctx, cli, namespace, name)).Should(
-		And(
-			Not(BeNil()),
-			WithTransform(condition.IsReady, BeTrue()),
-		))
+	Eventually(Get).WithContext(ctx).
+		WithArguments(cli, namespace, name).
+		Should(
+			And(
+				Not(BeNil()),
+				WithTransform(condition.IsReady, BeTrue()),
+			))
 
-	Eventually(condition.DeploymentIsRunning(ctx, cli, namespace, actions.ComponentName)).
+	Eventually(condition.DeploymentIsRunning).WithContext(ctx).
+		WithArguments(cli, namespace, actions.ComponentName).
 		Should(BeTrue())
 }
 
@@ -38,17 +41,15 @@ func GetServerPod(ctx context.Context, cli client.Client, ns string) func() *v1.
 	}
 }
 
-func Get(ctx context.Context, cli client.Client, ns string, name string) func() *v1alpha1.Fulcio {
-	return func() *v1alpha1.Fulcio {
-		instance := &v1alpha1.Fulcio{}
-		if e := cli.Get(ctx, types.NamespacedName{
-			Namespace: ns,
-			Name:      name,
-		}, instance); errors.IsNotFound(e) {
-			return nil
-		}
-		return instance
+func Get(ctx context.Context, cli client.Client, ns string, name string) *v1alpha1.Fulcio {
+	instance := &v1alpha1.Fulcio{}
+	if e := cli.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}, instance); errors.IsNotFound(e) {
+		return nil
 	}
+	return instance
 }
 
 func CreateSecret(ns string, name string) *v1.Secret {

--- a/test/e2e/support/tas/rekor/search_ui.go
+++ b/test/e2e/support/tas/rekor/search_ui.go
@@ -10,6 +10,7 @@ import (
 )
 
 func VerifySearchUI(ctx context.Context, cli client.Client, namespace string) {
-	Eventually(condition.DeploymentIsRunning(ctx, cli, namespace, actions.UIComponentName)).
+	Eventually(condition.DeploymentIsRunning).WithContext(ctx).
+		WithArguments(cli, namespace, actions.UIComponentName).
 		Should(BeTrue())
 }

--- a/test/e2e/support/tas/securesign/securesign.go
+++ b/test/e2e/support/tas/securesign/securesign.go
@@ -16,24 +16,24 @@ import (
 )
 
 func Verify(ctx context.Context, cli client.Client, namespace string, name string) {
-	Eventually(Get(ctx, cli, namespace, name)).Should(
-		And(
-			Not(BeNil()),
-			WithTransform(condition.IsReady, BeTrue()),
-		))
+	Eventually(Get).WithContext(ctx).
+		WithArguments(cli, namespace, name).
+		Should(
+			And(
+				Not(BeNil()),
+				WithTransform(condition.IsReady, BeTrue()),
+			))
 }
 
-func Get(ctx context.Context, cli client.Client, ns string, name string) func() *v1alpha1.Securesign {
-	return func() *v1alpha1.Securesign {
-		instance := &v1alpha1.Securesign{}
-		if e := cli.Get(ctx, types.NamespacedName{
-			Namespace: ns,
-			Name:      name,
-		}, instance); errors.IsNotFound(e) {
-			return nil
-		}
-		return instance
+func Get(ctx context.Context, cli client.Client, ns string, name string) *v1alpha1.Securesign {
+	instance := &v1alpha1.Securesign{}
+	if e := cli.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}, instance); errors.IsNotFound(e) {
+		return nil
 	}
+	return instance
 }
 
 type Opts func(*v1alpha1.Securesign)

--- a/test/e2e/support/tas/tas.go
+++ b/test/e2e/support/tas/tas.go
@@ -30,21 +30,21 @@ func VerifyAllComponents(ctx context.Context, cli runtimeCli.Client, s *rhtasv1a
 }
 
 func VerifyByCosign(ctx context.Context, cli runtimeCli.Client, s *rhtasv1alpha1.Securesign, targetImageName string) {
-	f := fulcio.Get(ctx, cli, s.Namespace, s.Name)()
+	f := fulcio.Get(ctx, cli, s.Namespace, s.Name)
 	Expect(f).ToNot(BeNil())
 
-	r := rekor.Get(ctx, cli, s.Namespace, s.Name)()
+	r := rekor.Get(ctx, cli, s.Namespace, s.Name)
 	Expect(r).ToNot(BeNil())
 
-	t := tuf.Get(ctx, cli, s.Namespace, s.Name)()
+	t := tuf.Get(ctx, cli, s.Namespace, s.Name)
 	Expect(t).ToNot(BeNil())
 
-	ts := tsa.Get(ctx, cli, s.Namespace, s.Name)()
+	ts := tsa.Get(ctx, cli, s.Namespace, s.Name)
 	Expect(ts).ToNot(BeNil())
 
-	Eventually(func() error {
+	Eventually(func(ctx context.Context) error {
 		return tsa.GetCertificateChain(ctx, cli, s.Namespace, s.Name, ts.Status.Url)
-	}).Should(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 
 	oidcToken, err := support.OidcToken(ctx)
 	Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/support/tas/trillian/trillian.go
+++ b/test/e2e/support/tas/trillian/trillian.go
@@ -13,36 +13,38 @@ import (
 )
 
 func Verify(ctx context.Context, cli client.Client, namespace string, name string, dbPresent bool) {
-	Eventually(Get(ctx, cli, namespace, name)).Should(
-		And(
-			Not(BeNil()),
-			WithTransform(condition.IsReady, BeTrue()),
-		))
+	Eventually(Get).WithContext(ctx).WithArguments(cli, namespace, name).
+		Should(
+			And(
+				Not(BeNil()),
+				WithTransform(condition.IsReady, BeTrue()),
+			))
 
 	if dbPresent {
 		// trillian-db
-		Eventually(condition.DeploymentIsRunning(ctx, cli, namespace, actions.DbComponentName)).
+		Eventually(condition.DeploymentIsRunning).
+			WithContext(ctx).WithArguments(cli, namespace, actions.DbComponentName).
 			Should(BeTrue())
 	}
 
 	// log server
-	Eventually(condition.DeploymentIsRunning(ctx, cli, namespace, actions.LogServerComponentName)).
+	Eventually(condition.DeploymentIsRunning).
+		WithContext(ctx).WithArguments(cli, namespace, actions.LogServerComponentName).
 		Should(BeTrue())
 
 	// log signer
-	Eventually(condition.DeploymentIsRunning(ctx, cli, namespace, actions.LogSignerComponentName)).
+	Eventually(condition.DeploymentIsRunning).
+		WithContext(ctx).WithArguments(cli, namespace, actions.LogSignerComponentName).
 		Should(BeTrue())
 }
 
-func Get(ctx context.Context, cli client.Client, ns string, name string) func() *v1alpha1.Trillian {
-	return func() *v1alpha1.Trillian {
-		instance := &v1alpha1.Trillian{}
-		if e := cli.Get(ctx, types.NamespacedName{
-			Namespace: ns,
-			Name:      name,
-		}, instance); errors.IsNotFound(e) {
-			return nil
-		}
-		return instance
+func Get(ctx context.Context, cli client.Client, ns string, name string) *v1alpha1.Trillian {
+	instance := &v1alpha1.Trillian{}
+	if e := cli.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}, instance); errors.IsNotFound(e) {
+		return nil
 	}
+	return instance
 }

--- a/test/e2e/support/tas/tsa/tsa.go
+++ b/test/e2e/support/tas/tsa/tsa.go
@@ -28,28 +28,29 @@ import (
 )
 
 func Verify(ctx context.Context, cli client.Client, namespace string, name string) {
-	Eventually(Get(ctx, cli, namespace, name)).Should(
-		And(
-			Not(BeNil()),
-			WithTransform(condition.IsReady, BeTrue()),
-		))
+	Eventually(Get).WithContext(ctx).
+		WithArguments(cli, namespace, name).
+		Should(
+			And(
+				Not(BeNil()),
+				WithTransform(condition.IsReady, BeTrue()),
+			))
 
 	// server
-	Eventually(condition.DeploymentIsRunning(ctx, cli, namespace, "timestamp-authority")).
+	Eventually(condition.DeploymentIsRunning).WithContext(ctx).
+		WithArguments(cli, namespace, "timestamp-authority").
 		Should(BeTrue())
 }
 
-func Get(ctx context.Context, cli client.Client, ns string, name string) func() *v1alpha1.TimestampAuthority {
-	return func() *v1alpha1.TimestampAuthority {
-		instance := &v1alpha1.TimestampAuthority{}
-		if e := cli.Get(ctx, types.NamespacedName{
-			Namespace: ns,
-			Name:      name,
-		}, instance); errors.IsNotFound(e) {
-			return nil
-		}
-		return instance
+func Get(ctx context.Context, cli client.Client, ns string, name string) *v1alpha1.TimestampAuthority {
+	instance := &v1alpha1.TimestampAuthority{}
+	if e := cli.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      name,
+	}, instance); errors.IsNotFound(e) {
+		return nil
 	}
+	return instance
 }
 
 func GetServerPod(ctx context.Context, cli client.Client, ns string) func() *v1.Pod {

--- a/test/e2e/update/ctlog_test.go
+++ b/test/e2e/update/ctlog_test.go
@@ -96,7 +96,7 @@ var _ = Describe("CTlog update", Ordered, func() {
 
 		It("has status Creating: waiting on my-ctlog-secret", func() {
 			Eventually(func(g Gomega) string {
-				ctl := ctlog.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := ctlog.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				return meta.FindStatusCondition(ctl.Status.Conditions, constants.Ready).Reason
 			}).Should(Equal(constants.Creating))
@@ -108,7 +108,7 @@ var _ = Describe("CTlog update", Ordered, func() {
 
 		It("has status Ready", func() {
 			Eventually(func(g Gomega) string {
-				ctl := ctlog.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := ctlog.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				return meta.FindStatusCondition(ctl.Status.Conditions, constants.Ready).Reason
 			}).Should(Equal(constants.Ready))
@@ -146,7 +146,7 @@ var _ = Describe("CTlog update", Ordered, func() {
 				return cli.Update(ctx, s)
 			}).WithTimeout(1 * time.Second).Should(Succeed())
 			Eventually(func(g Gomega) []v1alpha1.TufKey {
-				t := tuf.Get(ctx, cli, namespace.Name, s.Name)()
+				t := tuf.Get(ctx, cli, namespace.Name, s.Name)
 				return t.Status.Keys
 			}).Should(And(HaveLen(4), WithTransform(func(keys []v1alpha1.TufKey) string {
 				return keys[3].SecretRef.Name
@@ -163,9 +163,9 @@ var _ = Describe("CTlog update", Ordered, func() {
 			var ctl *v1alpha1.CTlog
 			var ctlPod *v1.Pod
 			Eventually(func(g Gomega) {
-				ctl = ctlog.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl = ctlog.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
-				ctlPod = ctlog.GetServerPod(ctx, cli, namespace.Name)()
+				ctlPod = ctlog.GetServerPod(ctx, cli, namespace.Name)
 				g.Expect(ctlPod).NotTo(BeNil())
 			}).Should(Succeed())
 

--- a/test/e2e/update/fulcio_test.go
+++ b/test/e2e/update/fulcio_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Fulcio update", Ordered, func() {
 
 		It("has status FulcioCertAvailable == Failure: waiting on my-fulcio-secret", func() {
 			Eventually(func(g Gomega) string {
-				ctl := fulcio.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := fulcio.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				c := meta.FindStatusCondition(ctl.Status.Conditions, fulcioAction.CertCondition)
 				g.Expect(c).ToNot(BeNil())
@@ -126,7 +126,7 @@ var _ = Describe("Fulcio update", Ordered, func() {
 
 		It("has status Ready", func() {
 			Eventually(func(g Gomega) string {
-				ctl := fulcio.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := fulcio.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				return meta.FindStatusCondition(ctl.Status.Conditions, constants.Ready).Reason
 			}).Should(Equal(constants.Ready))
@@ -170,7 +170,7 @@ var _ = Describe("Fulcio update", Ordered, func() {
 				return cli.Update(ctx, s)
 			}).WithTimeout(1 * time.Second).Should(Succeed())
 			Eventually(func(g Gomega) []v1alpha1.TufKey {
-				t := tuf.Get(ctx, cli, namespace.Name, s.Name)()
+				t := tuf.Get(ctx, cli, namespace.Name, s.Name)
 				return t.Status.Keys
 			}).Should(And(HaveLen(4), WithTransform(func(keys []v1alpha1.TufKey) string {
 				return keys[1].SecretRef.Name
@@ -226,7 +226,7 @@ var _ = Describe("Fulcio update", Ordered, func() {
 
 		It("has status Ready", func() {
 			Eventually(func(g Gomega) string {
-				ctl := fulcio.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := fulcio.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				return meta.FindStatusCondition(ctl.Status.Conditions, constants.Ready).Reason
 			}).Should(Equal(constants.Ready))
@@ -246,7 +246,7 @@ var _ = Describe("Fulcio update", Ordered, func() {
 			var f *v1alpha1.Fulcio
 			var fulcioPod *v1.Pod
 			Eventually(func(g Gomega) {
-				f = fulcio.Get(ctx, cli, namespace.Name, s.Name)()
+				f = fulcio.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(f).NotTo(BeNil())
 				fulcioPod = fulcio.GetServerPod(ctx, cli, namespace.Name)()
 				g.Expect(fulcioPod).NotTo(BeNil())

--- a/test/e2e/update/rekor_test.go
+++ b/test/e2e/update/rekor_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Rekor update", Ordered, func() {
 
 		It("has status SignerAvailable == Failure: waiting on my-rekor-secret", func() {
 			Eventually(func(g Gomega) string {
-				ctl := rekor.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := rekor.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				c := meta.FindStatusCondition(ctl.Status.Conditions, rekorAction.ServerCondition)
 				g.Expect(c).ToNot(BeNil())
@@ -107,7 +107,7 @@ var _ = Describe("Rekor update", Ordered, func() {
 
 		It("has status Ready", func() {
 			Eventually(func(g Gomega) string {
-				ctl := rekor.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := rekor.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				return meta.FindStatusCondition(ctl.Status.Conditions, constants.Ready).Reason
 			}).Should(Equal(constants.Ready))
@@ -145,7 +145,7 @@ var _ = Describe("Rekor update", Ordered, func() {
 				return cli.Update(ctx, s)
 			}).WithTimeout(1 * time.Second).Should(Succeed())
 			Eventually(func(g Gomega) []v1alpha1.TufKey {
-				t := tuf.Get(ctx, cli, namespace.Name, s.Name)()
+				t := tuf.Get(ctx, cli, namespace.Name, s.Name)
 				return t.Status.Keys
 			}).Should(And(HaveLen(4), WithTransform(func(keys []v1alpha1.TufKey) string {
 				return keys[0].SecretRef.Name
@@ -161,7 +161,7 @@ var _ = Describe("Rekor update", Ordered, func() {
 		It("verify new configuration", func() {
 			var r *v1.Pod
 			Eventually(func(g Gomega) {
-				r = rekor.GetServerPod(ctx, cli, namespace.Name)()
+				r = rekor.GetServerPod(ctx, cli, namespace.Name)
 				g.Expect(r).NotTo(BeNil())
 			}).Should(Succeed())
 			Expect(r.Spec.Volumes).To(ContainElements(And(

--- a/test/e2e/update/tsa_test.go
+++ b/test/e2e/update/tsa_test.go
@@ -112,7 +112,7 @@ var _ = Describe("TSA update", Ordered, func() {
 
 		It("has status Pending: waiting on my-tsa-secret", func() {
 			Eventually(func(g Gomega) string {
-				ctl := tsa.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := tsa.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				c := meta.FindStatusCondition(ctl.Status.Conditions, constants.Ready)
 				g.Expect(c).ToNot(BeNil())
@@ -126,7 +126,7 @@ var _ = Describe("TSA update", Ordered, func() {
 
 		It("has status Ready", func() {
 			Eventually(func(g Gomega) string {
-				ctl := rekor.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := rekor.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				return meta.FindStatusCondition(ctl.Status.Conditions, constants.Ready).Reason
 			}).Should(Equal(constants.Ready))
@@ -164,7 +164,7 @@ var _ = Describe("TSA update", Ordered, func() {
 				return cli.Update(ctx, s)
 			}).WithTimeout(1 * time.Second).Should(Succeed())
 			Eventually(func(g Gomega) []v1alpha1.TufKey {
-				t := tuf.Get(ctx, cli, namespace.Name, s.Name)()
+				t := tuf.Get(ctx, cli, namespace.Name, s.Name)
 				return t.Status.Keys
 			}).Should(And(HaveLen(4), WithTransform(func(keys []v1alpha1.TufKey) string {
 				return keys[2].SecretRef.Name
@@ -183,7 +183,7 @@ var _ = Describe("TSA update", Ordered, func() {
 			Eventually(func(g Gomega) {
 				pod = tsa.GetServerPod(ctx, cli, namespace.Name)()
 				g.Expect(pod).ToNot(BeNil())
-				t = tsa.Get(ctx, cli, namespace.Name, s.Name)()
+				t = tsa.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(t).ToNot(BeNil())
 			}).Should(Succeed())
 
@@ -242,7 +242,7 @@ var _ = Describe("TSA update", Ordered, func() {
 
 		It("has status Ready", func() {
 			Eventually(func(g Gomega) string {
-				ctl := rekor.Get(ctx, cli, namespace.Name, s.Name)()
+				ctl := rekor.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(ctl).NotTo(BeNil())
 				return meta.FindStatusCondition(ctl.Status.Conditions, constants.Ready).Reason
 			}).Should(Equal(constants.Ready))
@@ -264,7 +264,7 @@ var _ = Describe("TSA update", Ordered, func() {
 			Eventually(func(g Gomega) {
 				pod = tsa.GetServerPod(ctx, cli, namespace.Name)()
 				g.Expect(pod).ToNot(BeNil())
-				t = tsa.Get(ctx, cli, namespace.Name, s.Name)()
+				t = tsa.Get(ctx, cli, namespace.Name, s.Name)
 				g.Expect(t).ToNot(BeNil())
 			}).Should(Succeed())
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Operator upgrade", Ordered, func() {
 	})
 
 	It("Verify image signature after upgrade", func() {
-		rrekor = rekor.Get(ctx, cli, namespace.Name, securesignDeployment.Name)()
+		rrekor = rekor.Get(ctx, cli, namespace.Name, securesignDeployment.Name)
 		gomega.Expect(rrekor).ToNot(gomega.BeNil())
 
 		gomega.Expect(clients.Execute(
@@ -263,7 +263,7 @@ var _ = Describe("Operator upgrade", Ordered, func() {
 
 	It("Make sure securesign can be deleted after upgrade", func() {
 		gomega.Eventually(func(g gomega.Gomega) {
-			s := securesign.Get(ctx, cli, namespace.Name, securesignDeployment.Name)()
+			s := securesign.Get(ctx, cli, namespace.Name, securesignDeployment.Name)
 			gomega.Expect(cli.Delete(ctx, s)).Should(gomega.Succeed())
 		}).Should(gomega.Succeed())
 	})


### PR DESCRIPTION
## Summary by Sourcery

Refactor E2E tests to leverage Gomega’s context-aware Eventually API and simplify test helpers

Enhancements:
- Use Gomega’s .WithContext and .WithArguments in Eventually calls to pass context explicitly
- Simplify Get and GetServerPod helpers to return resources directly instead of returning closures
- Change DeploymentIsRunning helper to return (bool, error) rather than wrapping it in a closure

Tests:
- Update tests to remove redundant function invocations on helpers and adapt assertions to the new signatures