### PR TITLE
fix: configure security context for pods with pvc

### DIFF
--- a/internal/controller/rekor/actions/monitor/statefulset.go
+++ b/internal/controller/rekor/actions/monitor/statefulset.go
@@ -64,6 +64,9 @@ func (i statefulSetAction) Handle(ctx context.Context, instance *rhtasv1alpha1.R
 		i.ensureInitContainer(rekorServerHost),
 		ensure.ControllerReference[*v1.StatefulSet](instance, i.Client),
 		ensure.Labels[*v1.StatefulSet](slices.Collect(maps.Keys(labels)), labels),
+		func(object *v1.StatefulSet) error {
+			return ensure.PodSecurityContext(&object.Spec.Template.Spec)
+		},
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create %s statefulset: %w", actions.MonitorStatefulSetName, err), instance,
 			metav1.Condition{

--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -75,6 +75,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 		},
 		i.ensureServerDeployment(insCopy, actions.RBACName, labels),
 		deployment.PodRequirements(insCopy.Spec.PodRequirements, actions.ServerDeploymentName),
+		deployment.PodSecurityContext(),
 		i.ensureAttestation(insCopy),
 		ensure.ControllerReference[*v2.Deployment](instance, i.Client),
 		ensure.Labels[*v2.Deployment](slices.Collect(maps.Keys(labels)), labels),

--- a/internal/controller/tuf/actions/deployment.go
+++ b/internal/controller/tuf/actions/deployment.go
@@ -6,16 +6,15 @@ import (
 	"maps"
 	"slices"
 
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
+	tufConstants "github.com/securesign/operator/internal/controller/tuf/constants"
 	"github.com/securesign/operator/internal/images"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure/deployment"
-
-	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
-	tufConstants "github.com/securesign/operator/internal/controller/tuf/constants"
 	v1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -48,6 +47,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tuf) *
 		result controllerutil.OperationResult
 		err    error
 	)
+
 	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client,
 		&v1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -60,6 +60,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tuf) *
 		ensure.Labels[*v1.Deployment](slices.Collect(maps.Keys(labels)), labels),
 		deployment.Proxy(),
 		deployment.PodRequirements(instance.Spec.PodRequirements, tufConstants.ContainerName),
+		deployment.PodSecurityContext(),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create TUF: %w", err), instance)
 	}

--- a/internal/controller/tuf/actions/tuf_init_job.go
+++ b/internal/controller/tuf/actions/tuf_init_job.go
@@ -86,7 +86,6 @@ func (i initJobAction) jobPresent(ctx context.Context, job *v2.Job, instance *rh
 }
 
 func (i initJobAction) ensureInitJob(ctx context.Context, labels map[string]string, instance *rhtasv1alpha1.Tuf) *action.Result {
-
 	if _, err := kubernetes.CreateOrUpdate(ctx, i.Client,
 		&v2.Job{
 			ObjectMeta: metav1.ObjectMeta{
@@ -100,6 +99,9 @@ func (i initJobAction) ensureInitJob(ctx context.Context, labels map[string]stri
 		func(object *v2.Job) error {
 			ensure.SetProxyEnvs(object.Spec.Template.Spec.Containers)
 			return nil
+		},
+		func(object *v2.Job) error {
+			return ensure.PodSecurityContext(&object.Spec.Template.Spec)
 		},
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create TUF init job: %w", err), instance)

--- a/internal/utils/kubernetes/ensure/deployment/deployment.go
+++ b/internal/utils/kubernetes/ensure/deployment/deployment.go
@@ -54,3 +54,9 @@ func PodRequirements(requirements v1alpha1.PodRequirements, containerName string
 		return nil
 	}
 }
+
+func PodSecurityContext() func(deployment *v1.Deployment) error {
+	return func(dp *v1.Deployment) error {
+		return ensure.PodSecurityContext(&dp.Spec.Template.Spec)
+	}
+}

--- a/internal/utils/kubernetes/ensure/pod_spec.go
+++ b/internal/utils/kubernetes/ensure/pod_spec.go
@@ -1,0 +1,67 @@
+package ensure
+
+import (
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	core "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	runAsUser  int64 = 1001
+	runAsGroup int64 = 1001
+)
+
+func PodSecurityContext(spec *core.PodSpec) error {
+	if spec.SecurityContext == nil {
+		spec.SecurityContext = &core.PodSecurityContext{}
+	}
+	spec.SecurityContext.RunAsNonRoot = ptr.To(true)
+	spec.SecurityContext.FSGroupChangePolicy = ptr.To(core.FSGroupChangeOnRootMismatch)
+
+	if spec.SecurityContext.SeccompProfile == nil {
+		spec.SecurityContext.SeccompProfile = &core.SeccompProfile{}
+	}
+	spec.SecurityContext.SeccompProfile.Type = core.SeccompProfileTypeRuntimeDefault
+
+	if !kubernetes.IsOpenShift() && spec.SecurityContext.FSGroup == nil {
+		spec.SecurityContext.FSGroup = ptr.To(runAsGroup)
+	}
+
+	for i := range spec.InitContainers {
+		container := &spec.InitContainers[i]
+
+		if container.SecurityContext == nil {
+			container.SecurityContext = &core.SecurityContext{}
+		}
+
+		if container.SecurityContext.RunAsNonRoot == nil {
+			container.SecurityContext.RunAsNonRoot = ptr.To(true)
+		}
+		if container.SecurityContext.AllowPrivilegeEscalation == nil {
+			container.SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
+		}
+		if !kubernetes.IsOpenShift() && container.SecurityContext.RunAsUser == nil {
+			container.SecurityContext.RunAsUser = ptr.To(runAsUser)
+		}
+	}
+
+	for i := range spec.Containers {
+		container := &spec.Containers[i]
+
+		if container.SecurityContext == nil {
+			container.SecurityContext = &core.SecurityContext{}
+		}
+
+		if container.SecurityContext.RunAsNonRoot == nil {
+			container.SecurityContext.RunAsNonRoot = ptr.To(true)
+		}
+		if container.SecurityContext.AllowPrivilegeEscalation == nil {
+			container.SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
+		}
+		if !kubernetes.IsOpenShift() && container.SecurityContext.RunAsUser == nil {
+			container.SecurityContext.RunAsUser = ptr.To(runAsUser)
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/support/tas/tuf/tuf.go
+++ b/test/e2e/support/tas/tuf/tuf.go
@@ -13,6 +13,7 @@ import (
 	utils2 "github.com/securesign/operator/internal/controller/tuf/utils"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
+	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	"github.com/securesign/operator/internal/utils/kubernetes/job"
 	"github.com/securesign/operator/test/e2e/support/condition"
 	appsv1 "k8s.io/api/apps/v1"
@@ -109,6 +110,7 @@ func refreshTufJob(instance *v1alpha1.Tuf) *v12.Job {
 	l := maps.Clone(instance.Labels)
 	l[labels.LabelAppComponent] = "test"
 	Expect(utils2.EnsureTufInitJob(instance, constants.RBACInitJobName, instance.Labels)(j)).To(Succeed())
+	Expect(ensure.PodSecurityContext(&j.Spec.Template.Spec)).To(Succeed())
 	c := kubernetes.FindContainerByNameOrCreate(&j.Spec.Template.Spec, "tuf-init")
 	args := c.Args
 	c.Args = []string{"rm -rf /var/run/target/* && " + strings.Join(args, " ")}

--- a/test/e2e/update/suite_test.go
+++ b/test/e2e/update/suite_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	_ "github.com/securesign/operator/test/e2e/support/kubernetes"
 	"github.com/securesign/operator/test/e2e/support/tas/securesign"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"


### PR DESCRIPTION
## Summary by Sourcery

Standardize security contexts for operator-managed pods by introducing a generic PodSecurityContext ensure function, removing legacy OpenShift-specific SCC logic, and applying consistent security defaults across Trillian, TUF, and Rekor workloads.

Enhancements:
- Add ensure.PodSecurityContext to apply non-root, FSGroup, and seccomp defaults to any PodSpec
- Remove GetOpenshiftPodSecurityContextRestricted and related OpenShift-specific imports and fallbacks
- Apply the new PodSecurityContext mutator to Trillian DB deployments, TUF deployments and init jobs, and Rekor statefulsets and deployments

Tests:
- Update TUF e2e test to assert PodSecurityContext is set on the init job