### PR TITLE
ci: add common HA install test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -424,6 +424,7 @@ jobs:
 
       - name: Cleanup Cluster
         uses: ./.github/actions/kind-cluster-cleanup
+        if: always()
         with:
           nfs-csi: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -422,13 +422,10 @@ jobs:
         run: kubectl logs -n openshift-rhtas-operator deployment/rhtas-operator-controller-manager
         if: always()
 
-      - name: Uninstall NFS-CSI and cleanup volumes
-        if: always()
-        run: |
-          kubectl delete pvc --all -A --ignore-not-found --wait=false || true
-          kubectl delete pv --all --ignore-not-found --wait=false || true
-          kustomize build --enable-helm ./ci/nfs/overlay/ | kubectl delete -f - --ignore-not-found || true
-          sudo systemctl restart docker || sudo service docker restart || true
+      - name: Cleanup Cluster
+        uses: ./.github/actions/kind-cluster-cleanup
+        with:
+          nfs-csi: true
 
   test-custom-install:
     name: Test with custom operator installation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,6 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-
   test-kind:
     name: Test kind deployment
     runs-on: ubuntu-24.04
@@ -337,6 +336,99 @@ jobs:
           name: test-upgrade
           path: test/**/k8s-dump-*.tar.gz
           if-no-files-found: ignore
+
+  test-ha-install:
+    name: Test with High Availability
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    needs:
+    - build-operator
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Log in to GitHub Container Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          auth_file_path: /tmp/config.json
+
+      - name: Log in to registry.redhat.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: registry.redhat.io
+          auth_file_path: /tmp/config.json
+
+      - name: Install Cluster
+        uses: ./.github/actions/kind-cluster
+        with:
+          config: ./ci/config.yaml
+          prometheus: 'true'
+          keycloak: 'true'
+          olm: 'true'
+          nfs-csi: 'true'
+
+      - name: Pull Container image from GHCR
+        run: podman pull ${{ env.IMG }}
+
+      - name: Load Docker image into Kind cluster
+        run: |
+          podman save ${{ env.IMG }} -o operator-oci.tar
+          kind load image-archive operator-oci.tar
+
+      - name: Replace images
+        run: make dev-images && cat config/default/images.env
+
+      - name: Deploy operator container
+        env:
+          OPENSHIFT: false
+        run: make deploy
+
+      - name: Wait for operator to be ready
+        run: |
+          kubectl wait --for=condition=available deployment/rhtas-operator-controller-manager --timeout=120s -n openshift-rhtas-operator
+
+      - name: Add service hosts to /etc/hosts
+        run: |
+          sudo echo "127.0.0.1 fulcio-server.local tuf.local rekor-server.local keycloak-internal.keycloak-system.svc rekor-search-ui.local cli-server.local tsa-server.local" | sudo tee -a /etc/hosts
+
+      - name: Install cosign
+        run: go install github.com/sigstore/cosign/v2/cmd/cosign@v2.4.0
+
+      - name: Run tests
+        run: |
+          make generate && go test -p 1 ./test/e2e/... -tags=ha -timeout 20m
+
+      - name: Archive test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-ha-install
+          path: test/**/k8s-dump-*.tar.gz
+          if-no-files-found: ignore
+
+      - name: dump the logs of the operator
+        run: kubectl logs -n openshift-rhtas-operator deployment/rhtas-operator-controller-manager
+        if: always()
+
+      - name: Uninstall NFS-CSI and cleanup volumes
+        if: always()
+        run: |
+          kubectl delete pvc --all -A --ignore-not-found --wait=false || true
+          kubectl delete pv --all --ignore-not-found --wait=false || true
+          kustomize build --enable-helm ./ci/nfs/overlay/ | kubectl delete -f - --ignore-not-found || true
+          sudo systemctl restart docker || sudo service docker restart || true
 
   test-custom-install:
     name: Test with custom operator installation

--- a/test/e2e/high_avalability/common_ha_install_test.go
+++ b/test/e2e/high_avalability/common_ha_install_test.go
@@ -1,0 +1,148 @@
+//go:build ha
+
+package ha
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/test/e2e/support"
+	"github.com/securesign/operator/test/e2e/support/kubernetes"
+	"github.com/securesign/operator/test/e2e/support/steps"
+	"github.com/securesign/operator/test/e2e/support/tas"
+	"github.com/securesign/operator/test/e2e/support/tas/ctlog"
+	"github.com/securesign/operator/test/e2e/support/tas/fulcio"
+	"github.com/securesign/operator/test/e2e/support/tas/rekor"
+	"github.com/securesign/operator/test/e2e/support/tas/securesign"
+	"github.com/securesign/operator/test/e2e/support/tas/trillian"
+	"github.com/securesign/operator/test/e2e/support/tas/tsa"
+	"github.com/securesign/operator/test/e2e/support/tas/tuf"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("HA Securesign install", Ordered, func() {
+	cli, _ := support.CreateClient()
+
+	var targetImageName string
+	var namespace *v1.Namespace
+	var s *v1alpha1.Securesign
+	var replicas *int32
+
+	BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+		namespace = new
+	}))
+
+	BeforeAll(func(ctx SpecContext) {
+		replicas = ptr.To(int32(2))
+		s = securesign.Create(namespace.Name, "test",
+			securesign.WithDefaults(),
+			securesign.WithSearchUI(),
+			securesign.WithReplicas(replicas),
+			securesign.WithNFSPVC(),
+		)
+	})
+
+	BeforeAll(func(ctx SpecContext) {
+		targetImageName = support.PrepareImage(ctx)
+	})
+
+	Describe("Install with HA configured", func() {
+		BeforeAll(func(ctx SpecContext) {
+			Expect(cli.Create(ctx, s)).To(Succeed())
+		})
+
+		It("All other components are running", func(ctx SpecContext) {
+			tas.VerifyAllComponents(ctx, cli, s, true)
+		})
+
+		It("has the correct number of replicas configured for HA", func(ctx SpecContext) {
+			Expect(ptr.Deref(fulcio.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
+				To(BeNumerically(">=", *replicas), "fulcio should have more than one replica")
+			Expect(ptr.Deref(rekor.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
+				To(BeNumerically(">=", *replicas), "rekor should have more than one replica")
+			Expect(ptr.Deref(rekor.Get(ctx, cli, namespace.Name, s.Name).Spec.RekorSearchUI.Replicas, 0)).
+				To(BeNumerically(">=", *replicas), "rekor search ui should have more than one replica")
+			Expect(ptr.Deref(ctlog.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
+				To(BeNumerically(">=", *replicas), "ctlog should have more than one replica")
+			Expect(ptr.Deref(tsa.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
+				To(BeNumerically(">=", *replicas), "tsa should have more than one replica")
+			Expect(ptr.Deref(tuf.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
+				To(BeNumerically(">=", *replicas), "tuf should have more than one replica")
+			Expect(ptr.Deref(trillian.Get(ctx, cli, namespace.Name, s.Name).Spec.LogServer.Replicas, 0)).
+				To(BeNumerically(">=", *replicas), "log server should have more than one replica")
+			Expect(ptr.Deref(trillian.Get(ctx, cli, namespace.Name, s.Name).Spec.LogSigner.Replicas, 0)).
+				To(BeNumerically(">=", *replicas), "log signer should have more than one replica")
+		})
+
+		It("Services have ready endpoints", func(ctx SpecContext) {
+			endpointNames := []string{"ctlog", "fulcio-server", "rekor-search-ui", "rekor-server", "trillian-logserver", "trillian-logsigner", "tsa-server", "tuf"}
+			for _, endpointName := range endpointNames {
+				err := kubernetes.ExpectServiceHasAtLeastNReadyEndpoints(ctx, cli, namespace.Name, endpointName, 2)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		})
+
+		It("Use cosign cli", func(ctx SpecContext) {
+			tas.VerifyByCosign(ctx, cli, s, targetImageName)
+		})
+
+		It("ctlog remains functional when a pod is deleted", func(ctx SpecContext) {
+			kubernetes.RemainsFunctionalWhenOnePodDeleted(ctx, cli, namespace.Name, "ctlog", func() {
+				tas.VerifyByCosign(ctx, cli, s, targetImageName)
+			})
+		})
+		It("fulcio remains functional when a pod is deleted", func(ctx SpecContext) {
+			kubernetes.RemainsFunctionalWhenOnePodDeleted(ctx, cli, namespace.Name, "fulcio-server", func() {
+				tas.VerifyByCosign(ctx, cli, s, targetImageName)
+			})
+		})
+		It("rekor remains functional when a pod is deleted", func(ctx SpecContext) {
+			kubernetes.RemainsFunctionalWhenOnePodDeleted(ctx, cli, namespace.Name, "rekor-server", func() {
+				tas.VerifyByCosign(ctx, cli, s, targetImageName)
+			})
+		})
+		It("rekor-search-ui remains functional when a pod is deleted", func(ctx SpecContext) {
+			kubernetes.RemainsFunctionalWhenOnePodDeleted(ctx, cli, namespace.Name, "rekor-search-ui", func() {
+				r := rekor.Get(ctx, cli, namespace.Name, s.Name)
+				Expect(r).ToNot(BeNil())
+				Expect(r.Status.RekorSearchUIUrl).NotTo(BeEmpty())
+
+				httpClient := http.Client{
+					Timeout: time.Second * 10,
+				}
+				Eventually(func() bool {
+					resp, err := httpClient.Get(r.Status.RekorSearchUIUrl)
+					if err != nil {
+						return false
+					}
+					defer func() { _ = resp.Body.Close() }()
+					return resp.StatusCode == http.StatusOK
+				}, "30s", "1s").Should(BeTrue(), "Rekor UI should be accessible and return a status code of 200")
+			})
+		})
+		It("trillian-logserver remains functional when a pod is deleted", func(ctx SpecContext) {
+			kubernetes.RemainsFunctionalWhenOnePodDeleted(ctx, cli, namespace.Name, "trillian-logserver", func() {
+				tas.VerifyByCosign(ctx, cli, s, targetImageName)
+			})
+		})
+		It("trillian-signer remains functional when a pod is deleted", func(ctx SpecContext) {
+			kubernetes.RemainsFunctionalWhenOnePodDeleted(ctx, cli, namespace.Name, "trillian-logsigner", func() {
+				tas.VerifyByCosign(ctx, cli, s, targetImageName)
+			})
+		})
+		It("Tsa remains functional when a pod is deleted", func(ctx SpecContext) {
+			kubernetes.RemainsFunctionalWhenOnePodDeleted(ctx, cli, namespace.Name, "tsa-server", func() {
+				tas.VerifyByCosign(ctx, cli, s, targetImageName)
+			})
+		})
+		It("TUF remains functional when a pod is deleted", func(ctx SpecContext) {
+			kubernetes.RemainsFunctionalWhenOnePodDeleted(ctx, cli, namespace.Name, "tuf", func() {
+				tas.VerifyByCosign(ctx, cli, s, targetImageName)
+			})
+		})
+	})
+})

--- a/test/e2e/high_avalability/common_ha_install_test.go
+++ b/test/e2e/high_avalability/common_ha_install_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	"github.com/securesign/operator/api/v1alpha1"
 	ctlogactions "github.com/securesign/operator/internal/controller/ctlog/actions"
 	fulcioactions "github.com/securesign/operator/internal/controller/fulcio/actions"
@@ -66,22 +67,22 @@ var _ = Describe("HA Securesign install", Ordered, func() {
 		})
 
 		It("has the correct number of replicas configured for HA", func(ctx SpecContext) {
-			Expect(ptr.Deref(fulcio.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
-				To(BeNumerically(">=", *replicas), "fulcio should have more than one replica")
-			Expect(ptr.Deref(rekor.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
-				To(BeNumerically(">=", *replicas), "rekor should have more than one replica")
-			Expect(ptr.Deref(rekor.Get(ctx, cli, namespace.Name, s.Name).Spec.RekorSearchUI.Replicas, 0)).
-				To(BeNumerically(">=", *replicas), "rekor search ui should have more than one replica")
-			Expect(ptr.Deref(ctlog.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
-				To(BeNumerically(">=", *replicas), "ctlog should have more than one replica")
-			Expect(ptr.Deref(tsa.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
-				To(BeNumerically(">=", *replicas), "tsa should have more than one replica")
-			Expect(ptr.Deref(tuf.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas, 0)).
-				To(BeNumerically(">=", *replicas), "tuf should have more than one replica")
-			Expect(ptr.Deref(trillian.Get(ctx, cli, namespace.Name, s.Name).Spec.LogServer.Replicas, 0)).
-				To(BeNumerically(">=", *replicas), "log server should have more than one replica")
-			Expect(ptr.Deref(trillian.Get(ctx, cli, namespace.Name, s.Name).Spec.LogSigner.Replicas, 0)).
-				To(BeNumerically(">=", *replicas), "log signer should have more than one replica")
+			Expect(fulcio.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas).
+				To(gstruct.PointTo(BeNumerically(">=", *replicas)), "fulcio should have more than one replica")
+			Expect(rekor.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas).
+				To(gstruct.PointTo(BeNumerically(">=", *replicas)), "rekor should have more than one replica")
+			Expect(rekor.Get(ctx, cli, namespace.Name, s.Name).Spec.RekorSearchUI.Replicas).
+				To(gstruct.PointTo(BeNumerically(">=", *replicas)), "rekor search ui should have more than one replica")
+			Expect(ctlog.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas).
+				To(gstruct.PointTo(BeNumerically(">=", *replicas)), "ctlog should have more than one replica")
+			Expect(tsa.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas).
+				To(gstruct.PointTo(BeNumerically(">=", *replicas)), "tsa should have more than one replica")
+			Expect(tuf.Get(ctx, cli, namespace.Name, s.Name).Spec.Replicas).
+				To(gstruct.PointTo(BeNumerically(">=", *replicas)), "tuf should have more than one replica")
+			Expect(trillian.Get(ctx, cli, namespace.Name, s.Name).Spec.LogServer.Replicas).
+				To(gstruct.PointTo(BeNumerically(">=", *replicas)), "log server should have more than one replica")
+			Expect(trillian.Get(ctx, cli, namespace.Name, s.Name).Spec.LogSigner.Replicas).
+				To(gstruct.PointTo(BeNumerically(">=", *replicas)), "log signer should have more than one replica")
 		})
 
 		It("Services have ready endpoints", func(ctx SpecContext) {

--- a/test/e2e/high_avalability/ha_suite_test.go
+++ b/test/e2e/high_avalability/ha_suite_test.go
@@ -14,6 +14,7 @@ func TestHA(t *testing.T) {
 	RegisterFailHandler(Fail)
 	log.SetLogger(GinkgoLogr)
 	SetDefaultEventuallyTimeout(time.Duration(3) * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "With HA install")
 
 	// print whole stack in case of failure

--- a/test/e2e/high_avalability/ha_suite_test.go
+++ b/test/e2e/high_avalability/ha_suite_test.go
@@ -1,0 +1,21 @@
+package ha
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestHA(t *testing.T) {
+	RegisterFailHandler(Fail)
+	log.SetLogger(GinkgoLogr)
+	SetDefaultEventuallyTimeout(time.Duration(3) * time.Minute)
+	RunSpecs(t, "With HA install")
+
+	// print whole stack in case of failure
+	format.MaxLength = 0
+}

--- a/test/e2e/support/kubernetes/endpoint.go
+++ b/test/e2e/support/kubernetes/endpoint.go
@@ -1,0 +1,31 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ExpectServiceHasAtLeastNReadyEndpoints(ctx context.Context, cli client.Client, namespace, endPointName string, endpointCount int) error {
+	count := 0
+	var slices discoveryv1.EndpointSliceList
+	if err := cli.List(ctx, &slices, client.InNamespace(namespace), client.MatchingLabels{"app.kubernetes.io/name": endPointName}); err != nil {
+		return fmt.Errorf("get endpoints for service %s/%s: %w", namespace, endPointName, err)
+	}
+
+	for _, slice := range slices.Items {
+		for _, endpoint := range slice.Endpoints {
+			if endpoint.Conditions.Ready != nil && *endpoint.Conditions.Ready {
+				count++
+			}
+		}
+	}
+
+	if count < endpointCount {
+		return fmt.Errorf("endpoint count for endpoint: %s should equal :%v, got: %v", endPointName, endpointCount, count)
+	}
+
+	return nil
+}

--- a/test/e2e/support/kubernetes/endpoint.go
+++ b/test/e2e/support/kubernetes/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/securesign/operator/internal/labels"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -11,7 +12,7 @@ import (
 func ExpectServiceHasAtLeastNReadyEndpoints(ctx context.Context, cli client.Client, namespace, endPointName string, endpointCount int) error {
 	count := 0
 	var slices discoveryv1.EndpointSliceList
-	if err := cli.List(ctx, &slices, client.InNamespace(namespace), client.MatchingLabels{"app.kubernetes.io/name": endPointName}); err != nil {
+	if err := cli.List(ctx, &slices, client.InNamespace(namespace), client.MatchingLabels{labels.LabelAppName: endPointName}); err != nil {
 		return fmt.Errorf("get endpoints for service %s/%s: %w", namespace, endPointName, err)
 	}
 

--- a/test/e2e/support/kubernetes/ha.go
+++ b/test/e2e/support/kubernetes/ha.go
@@ -6,16 +6,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func RemainsFunctionalWhenOnePodDeleted(ctx SpecContext, cli client.Client, namespace, serviceName string, verify func()) {
-	Expect(DeleteOnePodByAppLabel(ctx, cli, namespace, serviceName)).To(Succeed(), "failed to delete one pod for service %s", serviceName)
+func RemainsFunctionalWhenOnePodDeleted(ctx SpecContext, cli client.Client, namespace, componentName string, verify func()) {
+	Expect(DeleteOnePodByAppLabel(ctx, cli, namespace, componentName)).To(Succeed(), "failed to delete one pod for service %s", componentName)
 
-	Eventually(func() error {
-		return ExpectServiceHasAtLeastNReadyEndpoints(ctx, cli, namespace, serviceName, 1)
-	}).Should(Succeed(), "service lost all ready endpoints after a single pod deletion")
+	Eventually(ExpectServiceHasAtLeastNReadyEndpoints).WithContext(ctx).
+		WithArguments(cli, namespace, componentName, 1).
+		Should(Succeed(), "service lost all ready endpoints after a single pod deletion")
 
 	verify()
 
-	Eventually(func() error {
-		return ExpectServiceHasAtLeastNReadyEndpoints(ctx, cli, namespace, serviceName, 2)
-	}).Should(Succeed(), "expected service to recover to 2 ready endpoints")
+	Eventually(ExpectServiceHasAtLeastNReadyEndpoints).WithContext(ctx).
+		WithArguments(cli, namespace, componentName, 2).
+		Should(Succeed(), "expected service to recover to 2 ready endpoints")
 }

--- a/test/e2e/support/kubernetes/ha.go
+++ b/test/e2e/support/kubernetes/ha.go
@@ -1,0 +1,21 @@
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func RemainsFunctionalWhenOnePodDeleted(ctx SpecContext, cli client.Client, namespace, serviceName string, verify func()) {
+	Expect(DeleteOnePodByAppLabel(ctx, cli, namespace, serviceName)).To(Succeed(), "failed to delete one pod for service %s", serviceName)
+
+	Eventually(func() error {
+		return ExpectServiceHasAtLeastNReadyEndpoints(ctx, cli, namespace, serviceName, 1)
+	}).Should(Succeed(), "service lost all ready endpoints after a single pod deletion")
+
+	verify()
+
+	Eventually(func() error {
+		return ExpectServiceHasAtLeastNReadyEndpoints(ctx, cli, namespace, serviceName, 2)
+	}).Should(Succeed(), "expected service to recover to 2 ready endpoints")
+}

--- a/test/e2e/support/kubernetes/leader.go
+++ b/test/e2e/support/kubernetes/leader.go
@@ -1,0 +1,25 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	coordv1 "k8s.io/api/coordination/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetLeaseHolderIdentity(ctx context.Context, cli client.Client, namespace string, nameContains string) (string, error) {
+	var leaseList coordv1.LeaseList
+	if err := cli.List(ctx, &leaseList, client.InNamespace(namespace)); err != nil {
+		return "", fmt.Errorf("listing leases failed: %w", err)
+	}
+
+	for _, l := range leaseList.Items {
+		if strings.Contains(*l.Spec.HolderIdentity, nameContains) && l.Spec.HolderIdentity != nil {
+			return *l.Spec.HolderIdentity, nil
+		}
+	}
+
+	return "", fmt.Errorf("no leader found for component containing %q in namespace %q", nameContains, namespace)
+}

--- a/test/e2e/support/tas/securesign/securesign.go
+++ b/test/e2e/support/tas/securesign/securesign.go
@@ -271,6 +271,19 @@ func WithNTPMonitoring() Opts {
 	}
 }
 
+func WithReplicas(replicas *int32) Opts {
+	return func(s *v1alpha1.Securesign) {
+		s.Spec.Fulcio.Replicas = replicas
+		s.Spec.Rekor.Replicas = replicas
+		s.Spec.Rekor.RekorSearchUI.Replicas = replicas
+		s.Spec.Ctlog.Replicas = replicas
+		s.Spec.TimestampAuthority.Replicas = replicas
+		s.Spec.Tuf.Replicas = replicas
+		s.Spec.Trillian.LogServer.Replicas = replicas
+		s.Spec.Trillian.LogSigner.Replicas = replicas
+	}
+}
+
 func WithNFSPVC() Opts {
 	return func(s *v1alpha1.Securesign) {
 		pvcConf := v1alpha1.Pvc{


### PR DESCRIPTION
## Summary by Sourcery

Add high-availability installation testing by extending CI and end-to-end test suite with HA-specific scenarios and utilities.

New Features:
- Add a GitHub Actions job 'test-ha-install' to perform high-availability operator installation tests
- Introduce end-to-end HA tests verifying operator deployment, replica scaling, service readiness, resiliency under pod failure, and leader election

Enhancements:
- Add WithReplicas option to configure component replica counts in Securesign tests

CI:
- Integrate kind cluster setup, image loading, cosign validation, and artifact archival into the new HA test job

Tests:
- Add Ginkgo HA test suite and common_ha_install_test.go for multi-replica installation scenarios
- Add test utilities: DeleteOnePodByAppLabel, ExpectServiceHasAtLeastNReadyEndpoints, GetLeaseHolderIdentity, and RemainsFunctionalWhenOnePodDeleted