### PR TITLE
test: fix proxy deployment service

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -410,6 +410,7 @@ jobs:
 
       - name: Cleanup Cluster
         uses: ./.github/actions/kind-cluster-cleanup
+        if: always()
         with:
           nfs-csi: true
 

--- a/test/e2e/custom_install/proxy_test.go
+++ b/test/e2e/custom_install/proxy_test.go
@@ -152,10 +152,6 @@ func withProxy(hostname string) func(pod *v1.Pod) {
 		".cluster.local",
 		".svc",
 		"localhost",
-		"10.0.0.0/16",
-		"10.96.0.0/16",
-		"172.30.0.0/16",
-		"10.128.0.0/14",
 		"127.0.0.1",
 	}
 

--- a/test/e2e/custom_install/testdata/proxy.yaml
+++ b/test/e2e/custom_install/testdata/proxy.yaml
@@ -6,7 +6,7 @@ metadata:
   name: proxy
   namespace: "{{.Namespace}}"
   labels:
-    name: proxy
+    app: proxy
 spec:
   securityContext:
     runAsNonRoot: true
@@ -23,7 +23,6 @@ spec:
   - name: httpd
     image: mirror.gcr.io/httpd:2.4.46
     securityContext:
-      runAsGroup: 1001
       runAsUser: 1001
     command:
      - httpd
@@ -49,7 +48,7 @@ metadata:
   namespace: "{{.Namespace}}"
 spec:
   selector:
-    name: proxy
+    app: proxy
   ports:
     - port: 80
       name: http


### PR DESCRIPTION
## Summary by Sourcery

Fix proxy service deployment test configuration, update proxy e2e test host resolution logic, and ensure workflow cluster cleanup always runs

CI:
- Ensure cluster cleanup step runs on every workflow outcome by adding "if: always()"

Tests:
- Update proxy testdata: change service labels and selectors to use "app: proxy" and remove runAsGroup setting
- Simplify proxy e2e test by removing internal cluster CIDR host entries from host resolution list