### PR TITLE
test: wrap a testing.T by gomega.WithT

### DIFF
--- a/internal/utils/kubernetes/config_map_test.go
+++ b/internal/utils/kubernetes/config_map_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestEnsureImmutableConfigMap(t *testing.T) {
+	data := map[string]string{"test": "data"}
 	tests := []struct {
 		name      string
 		objects   []client.Object
@@ -105,7 +106,7 @@ func TestEnsureImmutableConfigMap(t *testing.T) {
 
 			result, err := CreateOrUpdate(ctx, c,
 				&v1.ConfigMap{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
-				EnsureConfigMapData(tt.immutable, map[string]string{"test": "data"}))
+				EnsureConfigMapData(tt.immutable, data))
 
 			g.Expect(result).To(gomega.Equal(tt.result))
 
@@ -118,8 +119,8 @@ func TestEnsureImmutableConfigMap(t *testing.T) {
 
 			existing := &v1.ConfigMap{}
 			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			g.Expect(existing.Data).To(gomega.Equal(existing.Data))
 			g.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
+			g.Expect(existing.Data).To(gomega.Equal(data))
 		})
 	}
 }

--- a/internal/utils/kubernetes/config_map_test.go
+++ b/internal/utils/kubernetes/config_map_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestEnsureImmutableConfigMap(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name      string
 		objects   []client.Object
@@ -99,6 +98,7 @@ func TestEnsureImmutableConfigMap(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -107,19 +107,19 @@ func TestEnsureImmutableConfigMap(t *testing.T) {
 				&v1.ConfigMap{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureConfigMapData(tt.immutable, map[string]string{"test": "data"}))
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			if tt.errorMsg == "" {
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 			} else {
-				gomega.Expect(err.Error()).To(gomega.Equal(tt.errorMsg))
+				g.Expect(err.Error()).To(gomega.Equal(tt.errorMsg))
 				return
 			}
 
 			existing := &v1.ConfigMap{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Data).To(gomega.Equal(existing.Data))
-			gomega.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Data).To(gomega.Equal(existing.Data))
+			g.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
 		})
 	}
 }

--- a/internal/utils/kubernetes/ensure/deployment/deployment_test.go
+++ b/internal/utils/kubernetes/ensure/deployment/deployment_test.go
@@ -21,10 +21,9 @@ import (
 const name = "dp"
 
 func TestEnsureTrustedCA(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	t.Run("update existing object", func(t *testing.T) {
-
 		ctx := context.TODO()
+		g := gomega.NewWithT(t)
 		c := testAction.FakeClientBuilder().
 			WithObjects(&v1.Deployment{
 				ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
@@ -60,40 +59,38 @@ func TestEnsureTrustedCA(t *testing.T) {
 			&v1.Deployment{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 			TrustedCA(&v1alpha1.LocalObjectReference{Name: "test"}, name),
 		)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(err).ToNot(gomega.HaveOccurred())
 
-		gomega.Expect(result).To(gomega.Equal(controllerutil.OperationResultUpdated))
+		g.Expect(result).To(gomega.Equal(controllerutil.OperationResultUpdated))
 
 		existing := &v1.Deployment{}
-		gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env).To(gomega.HaveLen(2))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env[0].Name).To(gomega.Equal("NAME"))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env[0].Value).To(gomega.Equal("VALUE"))
+		g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env).To(gomega.HaveLen(2))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env[0].Name).To(gomega.Equal("NAME"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env[0].Value).To(gomega.Equal("VALUE"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env[1].Name).To(gomega.Equal("SSL_CERT_DIR"))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env[1].Value).To(gomega.Equal("/var/run/configs/tas/ca-trust:/var/run/secrets/kubernetes.io/serviceaccount"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env[1].Name).To(gomega.Equal("SSL_CERT_DIR"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env[1].Value).To(gomega.Equal("/var/run/configs/tas/ca-trust:/var/run/secrets/kubernetes.io/serviceaccount"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts).To(gomega.HaveLen(2))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(gomega.Equal("mount"))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(gomega.Equal("path"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts).To(gomega.HaveLen(2))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(gomega.Equal("mount"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(gomega.Equal("path"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(gomega.Equal("ca-trust"))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(gomega.Equal("/var/run/configs/tas/ca-trust"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(gomega.Equal("ca-trust"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(gomega.Equal("/var/run/configs/tas/ca-trust"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Volumes).To(gomega.HaveLen(2))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal("mount"))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[1].Name).To(gomega.Equal("ca-trust"))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[1].Projected.Sources).To(gomega.HaveLen(1))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[1].Projected.Sources[0].ConfigMap.Name).To(gomega.Equal("test"))
-
+		g.Expect(existing.Spec.Template.Spec.Volumes).To(gomega.HaveLen(2))
+		g.Expect(existing.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal("mount"))
+		g.Expect(existing.Spec.Template.Spec.Volumes[1].Name).To(gomega.Equal("ca-trust"))
+		g.Expect(existing.Spec.Template.Spec.Volumes[1].Projected.Sources).To(gomega.HaveLen(1))
+		g.Expect(existing.Spec.Template.Spec.Volumes[1].Projected.Sources[0].ConfigMap.Name).To(gomega.Equal("test"))
 	})
 }
 
 func TestEnsureTLS(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	t.Run("update existing object", func(t *testing.T) {
-
 		ctx := context.TODO()
+		g := gomega.NewWithT(t)
 		c := testAction.FakeClientBuilder().
 			WithObjects(&v1.Deployment{
 				ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
@@ -127,23 +124,23 @@ func TestEnsureTLS(t *testing.T) {
 				},
 			}, name),
 		)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(err).ToNot(gomega.HaveOccurred())
 
-		gomega.Expect(result).To(gomega.Equal(controllerutil.OperationResultUpdated))
+		g.Expect(result).To(gomega.Equal(controllerutil.OperationResultUpdated))
 
 		existing := &v1.Deployment{}
-		gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
+		g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts).To(gomega.HaveLen(1))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(gomega.Equal(tls.TLSVolumeName))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(gomega.Equal("/var/run/secrets/tas"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts).To(gomega.HaveLen(1))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(gomega.Equal(tls.TLSVolumeName))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(gomega.Equal("/var/run/secrets/tas"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[1].VolumeMounts).To(gomega.BeEmpty())
+		g.Expect(existing.Spec.Template.Spec.Containers[1].VolumeMounts).To(gomega.BeEmpty())
 
-		gomega.Expect(existing.Spec.Template.Spec.Volumes).To(gomega.HaveLen(1))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal(tls.TLSVolumeName))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[0].Projected.Sources).To(gomega.HaveLen(2))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[0].Projected.Sources).To(gomega.ContainElements(
+		g.Expect(existing.Spec.Template.Spec.Volumes).To(gomega.HaveLen(1))
+		g.Expect(existing.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal(tls.TLSVolumeName))
+		g.Expect(existing.Spec.Template.Spec.Volumes[0].Projected.Sources).To(gomega.HaveLen(2))
+		g.Expect(existing.Spec.Template.Spec.Volumes[0].Projected.Sources).To(gomega.ContainElements(
 			gomega.And(
 				gomega.WithTransform(func(s core.VolumeProjection) string {
 					return s.Secret.Name

--- a/internal/utils/kubernetes/ingress_test.go
+++ b/internal/utils/kubernetes/ingress_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestEnsureIngressSpec(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -100,6 +99,7 @@ func TestEnsureIngressSpec(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -113,18 +113,17 @@ func TestEnsureIngressSpec(t *testing.T) {
 					},
 					name),
 			)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &networkingv1.Ingress{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Spec.Rules).To(gomega.HaveLen(1))
-			gomega.Expect(existing.Spec.Rules[0].Host).To(gomega.Equal("host"))
-			gomega.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths).To(gomega.HaveLen(1))
-			gomega.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name).To(gomega.Equal(name))
-			gomega.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).To(gomega.Equal(name))
-
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Spec.Rules).To(gomega.HaveLen(1))
+			g.Expect(existing.Spec.Rules[0].Host).To(gomega.Equal("host"))
+			g.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths).To(gomega.HaveLen(1))
+			g.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name).To(gomega.Equal(name))
+			g.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).To(gomega.Equal(name))
 		})
 	}
 }

--- a/internal/utils/kubernetes/pvc_test.go
+++ b/internal/utils/kubernetes/pvc_test.go
@@ -36,8 +36,6 @@ func TestEnsurePVCSpec(t *testing.T) {
 		g.Expect(existing.Spec.Resources.Requests.Storage()).To(gomega.Equal(pvc.Size))
 		g.Expect(existing.Spec.StorageClassName).To(gstruct.PointTo(gomega.Equal(pvc.StorageClass)))
 	}
-
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -146,7 +144,7 @@ func TestEnsurePVCSpec(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
-			g := gomega.NewGomegaWithT(t)
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()

--- a/internal/utils/kubernetes/role_binding_test.go
+++ b/internal/utils/kubernetes/role_binding_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestEnsureRoleBinding(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -63,6 +62,7 @@ func TestEnsureRoleBinding(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -77,20 +77,19 @@ func TestEnsureRoleBinding(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&rbacv1.RoleBinding{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureRoleBinding(role, subject))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &rbacv1.RoleBinding{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.RoleRef).To(gomega.Equal(role))
-			gomega.Expect(existing.Subjects).To(gomega.Equal([]rbacv1.Subject{subject}))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.RoleRef).To(gomega.Equal(role))
+			g.Expect(existing.Subjects).To(gomega.Equal([]rbacv1.Subject{subject}))
 		})
 	}
 }
 
 func TestEnsureClusterRoleBinding(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -138,6 +137,7 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -152,14 +152,14 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&rbacv1.ClusterRoleBinding{ObjectMeta: v2.ObjectMeta{Name: name}},
 				EnsureClusterRoleBinding(role, subject))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &rbacv1.ClusterRoleBinding{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.RoleRef).To(gomega.Equal(role))
-			gomega.Expect(existing.Subjects).To(gomega.Equal([]rbacv1.Subject{subject}))
+			g.Expect(c.Get(ctx, client.ObjectKey{Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.RoleRef).To(gomega.Equal(role))
+			g.Expect(existing.Subjects).To(gomega.Equal([]rbacv1.Subject{subject}))
 		})
 	}
 }

--- a/internal/utils/kubernetes/role_test.go
+++ b/internal/utils/kubernetes/role_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestEnsureRoleRules(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -66,6 +65,7 @@ func TestEnsureRoleRules(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -86,19 +86,18 @@ func TestEnsureRoleRules(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&rbacv1.Role{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureRoleRules(rules...))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &rbacv1.Role{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Rules).To(gomega.Equal(rules))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Rules).To(gomega.Equal(rules))
 		})
 	}
 }
 
 func TestEnsureClusterRoleRules(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -151,6 +150,7 @@ func TestEnsureClusterRoleRules(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -171,13 +171,13 @@ func TestEnsureClusterRoleRules(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&rbacv1.ClusterRole{ObjectMeta: v2.ObjectMeta{Name: name}},
 				EnsureClusterRoleRules(rules...))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &rbacv1.ClusterRole{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Rules).To(gomega.Equal(rules))
+			g.Expect(c.Get(ctx, client.ObjectKey{Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Rules).To(gomega.Equal(rules))
 		})
 	}
 }

--- a/internal/utils/kubernetes/secret_test.go
+++ b/internal/utils/kubernetes/secret_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestEnsureSecret(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name      string
 		objects   []client.Object
@@ -99,6 +98,7 @@ func TestEnsureSecret(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -107,19 +107,19 @@ func TestEnsureSecret(t *testing.T) {
 				&v1.Secret{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureSecretData(tt.immutable, map[string][]byte{"test": []byte("data")}))
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			if tt.errorMsg == "" {
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 			} else {
-				gomega.Expect(err.Error()).To(gomega.Equal(tt.errorMsg))
+				g.Expect(err.Error()).To(gomega.Equal(tt.errorMsg))
 				return
 			}
 
 			existing := &v1.Secret{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Data).To(gomega.Equal(existing.Data))
-			gomega.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Data).To(gomega.Equal(existing.Data))
+			g.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
 		})
 	}
 }

--- a/internal/utils/kubernetes/secret_test.go
+++ b/internal/utils/kubernetes/secret_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestEnsureSecret(t *testing.T) {
+	data := map[string][]byte{"test": []byte("data")}
 	tests := []struct {
 		name      string
 		objects   []client.Object
@@ -105,7 +106,7 @@ func TestEnsureSecret(t *testing.T) {
 
 			result, err := CreateOrUpdate(ctx, c,
 				&v1.Secret{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
-				EnsureSecretData(tt.immutable, map[string][]byte{"test": []byte("data")}))
+				EnsureSecretData(tt.immutable, data))
 
 			g.Expect(result).To(gomega.Equal(tt.result))
 
@@ -118,8 +119,8 @@ func TestEnsureSecret(t *testing.T) {
 
 			existing := &v1.Secret{}
 			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			g.Expect(existing.Data).To(gomega.Equal(existing.Data))
 			g.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
+			g.Expect(existing.Data).To(gomega.Equal(data))
 		})
 	}
 }

--- a/internal/utils/kubernetes/service_test.go
+++ b/internal/utils/kubernetes/service_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestService(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -60,6 +59,7 @@ func TestService(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -70,14 +70,14 @@ func TestService(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&v1.Service{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureServiceSpec(l, ports...))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &v1.Service{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Spec.Ports).To(gomega.Equal(ports))
-			gomega.Expect(existing.Spec.Selector).To(gomega.Equal(l))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Spec.Ports).To(gomega.Equal(ports))
+			g.Expect(existing.Spec.Selector).To(gomega.Equal(l))
 		})
 	}
 }

--- a/internal/utils/tls/tls_test.go
+++ b/internal/utils/tls/tls_test.go
@@ -27,7 +27,6 @@ func (f fakeTlsClient) GetTrustedCA() *v1alpha1.LocalObjectReference {
 }
 
 func TestCAPath(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name     string
 		objects  []client.Object
@@ -109,18 +108,18 @@ func TestCAPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.TODO()
-
+			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
 
 			result, err := CAPath(ctx, c, tt.instance)
 			if tt.err {
-				gomega.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(err).To(gomega.HaveOccurred())
 			} else {
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 			}
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 		})
 	}
 }


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Replace global gomega registration with per-test instances

- Fix assertion logic in config map tests

- Improve test isolation and thread safety


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gomega.RegisterTestingT(t)"] --> B["gomega.NewWithT(t)"]
  B --> C["g.Expect() calls"]
  D["Global gomega"] --> E["Per-test gomega"]
  F["Fixed assertions"] --> G["Better test isolation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>config_map_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-151cbd1cdc1bd999265b0ad75ea2deb35a752a21acaf3e1f0a16a08095c526e6">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deployment_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-d52a2a37bbbf0b60e72714f2acb88859453007b67ed84979101c54465f856a9a">+31/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-5bb4219f11205abb3fcf436196c8fa4b766557508425b3127b97e1e5c24d480a">+9/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pvc_test.go</strong><dd><code>Fix gomega initialization method call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-6a1fbed29b9f640d9ac97caed5a1bac3d53b39641d1e5c47b9cd16a6502869f7">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>role_binding_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-8c3e3a6793523ccd3f91f2969592aeafd7d2dcc5c7f4ab23d0c08c070501360b">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>role_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-44d5e2c996d73edff1317e18609e4f3c52381c1e51f42caa5f56ea06b3b6a452">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>secret_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-9e5c8cd8ef0cd4958e8cbbd1b1f7ef0d58072c83114e2b2e9260b06870936bd1">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-16671386b998515d5b758ebdb5c97ba1884ccfb9617f0851ecc069b465e14f8a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tls_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-4ac7fd7fe6eb6d2623b5fe52087c358894cfde2f25386bef8db06038623d36c2">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>install_test.go</strong><dd><code>Replace global gomega with per-test instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1309/files#diff-26e0dc76aadea0ffe8bdc6070c14f6bd5164fd78a9a2a8dfbcb2232000b166eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

