### PR TITLE
test: replace context.TODO() in tests

### DIFF
--- a/internal/action/rbac/action_test.go
+++ b/internal/action/rbac/action_test.go
@@ -600,7 +600,7 @@ func TestRbac_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})

--- a/internal/action/tree/action_test.go
+++ b/internal/action/tree/action_test.go
@@ -672,7 +672,7 @@ func TestResolveTree_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})

--- a/internal/controller/ctlog/actions/handle_fulcio_root_test.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -180,7 +179,7 @@ func TestCertCan_Handle(t *testing.T) {
 				Reason: tt.env.phase,
 			})
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.want.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.want.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.want.canHandle)
 			}
 		})
@@ -452,7 +451,7 @@ func TestCert_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &v1alpha1.CTlog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "instance",

--- a/internal/controller/ctlog/actions/handle_keys_test.go
+++ b/internal/controller/ctlog/actions/handle_keys_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -186,7 +185,7 @@ func TestKeysCan_Handle(t *testing.T) {
 				Reason: tt.env.phase,
 			})
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.want.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.want.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.want.canHandle)
 			}
 		})
@@ -528,7 +527,7 @@ func TestKeys_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &v1alpha1.CTlog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "instance",

--- a/internal/controller/ctlog/actions/server_config_test.go
+++ b/internal/controller/ctlog/actions/server_config_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	_ "embed"
 	"reflect"
 	"testing"
@@ -148,7 +147,7 @@ func TestServerConfig_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -376,7 +375,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(Not(BeNil()))
 
-					g.Expect(k8sErrors.IsNotFound(cli.Get(context.TODO(), client.ObjectKey{Name: "config", Namespace: "default"}, &v1.Secret{}))).To(BeTrue())
+					g.Expect(k8sErrors.IsNotFound(cli.Get(t.Context(), client.ObjectKey{Name: "config", Namespace: "default"}, &v1.Secret{}))).To(BeTrue())
 
 					secret, err := kubernetes.GetSecret(cli, "default", instance.Status.ServerConfigRef.Name)
 					g.Expect(err).ShouldNot(HaveOccurred())
@@ -451,7 +450,7 @@ func TestServerConfig_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1alpha1.CTlog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "ctlog",
@@ -639,7 +638,7 @@ func TestServerConfig_Update(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(&tt.env.instance).
 				WithStatusSubresource(&tt.env.instance).

--- a/internal/controller/ctlog/ctlog_controller_test.go
+++ b/internal/controller/ctlog/ctlog_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ctlog
 
 import (
-	"context"
 	"time"
 
 	"github.com/securesign/operator/api/v1alpha1"
@@ -47,8 +46,6 @@ var _ = Describe("CTlog controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -59,20 +56,20 @@ var _ = Describe("CTlog controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &v1alpha1.CTlog{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind CTlog")
 			found := &v1alpha1.CTlog{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -82,7 +79,7 @@ var _ = Describe("CTlog controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for CTlog", func() {
+		It("should successfully reconcile a custom resource for CTlog", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind CTlog")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/ctlog/ctlog_hot_update_test.go
+++ b/internal/controller/ctlog/ctlog_hot_update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ctlog
 
 import (
-	"context"
 	"maps"
 	"time"
 
@@ -52,8 +51,6 @@ var _ = Describe("CTlog update test", func() {
 			Namespace = "update"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Namespace,
@@ -63,20 +60,20 @@ var _ = Describe("CTlog update test", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &v1alpha1.CTlog{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind CTlog")
 			found := &v1alpha1.CTlog{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 3*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -86,7 +83,7 @@ var _ = Describe("CTlog update test", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for CTlog", func() {
+		It("should successfully reconcile a custom resource for CTlog", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind CTlog")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/ctlog/suite_test.go
+++ b/internal/controller/ctlog/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/fulcio/actions/generate_cert_test.go
+++ b/internal/controller/fulcio/actions/generate_cert_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestGenerateCert_Handle(t *testing.T) {
-	ctx := context.TODO()
 	g := NewWithT(t)
 	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	g.Expect(err).ToNot(HaveOccurred())
@@ -40,7 +39,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 		canHandle     bool
 		result        *action.Result
 		certCondition metav1.ConditionStatus
-		verify        func(Gomega, rhtasv1alpha1.FulcioStatus, client.WithWatch)
+		verify        func(context.Context, Gomega, rhtasv1alpha1.FulcioStatus, client.WithWatch)
 	}
 	tests := []struct {
 		name string
@@ -60,7 +59,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 				canHandle:     true,
 				result:        testAction.StatusUpdate(),
 				certCondition: metav1.ConditionTrue,
-				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.OrganizationEmail).To(Equal("jdoe@redhat.com"))
 					g.Expect(fulcio.Certificate.OrganizationName).To(Equal("RH"))
@@ -93,7 +92,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 				canHandle:     true,
 				result:        testAction.Requeue(),
 				certCondition: metav1.ConditionFalse,
-				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.OrganizationEmail).To(Equal("jdoe@redhat.com"))
 					g.Expect(fulcio.Certificate.OrganizationName).To(Equal("RH"))
@@ -130,7 +129,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 				canHandle:     true,
 				result:        testAction.StatusUpdate(),
 				certCondition: metav1.ConditionTrue,
-				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.OrganizationEmail).To(Equal("jdoe@redhat.com"))
 					g.Expect(fulcio.Certificate.OrganizationName).To(Equal("RH"))
@@ -172,7 +171,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 				canHandle:     true,
 				result:        testAction.StatusUpdate(),
 				certCondition: metav1.ConditionTrue,
-				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.OrganizationEmail).To(Equal("jdoe1@redhat.com"))
 					g.Expect(fulcio.Certificate.OrganizationName).To(Equal("RH"))
@@ -233,7 +232,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 				canHandle:     true,
 				result:        testAction.StatusUpdate(),
 				certCondition: metav1.ConditionTrue,
-				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.OrganizationEmail).To(Equal("jdoe@redhat.com"))
 					g.Expect(fulcio.Certificate.OrganizationName).To(Equal("RH"))
@@ -295,7 +294,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 				canHandle:     true,
 				result:        testAction.StatusUpdate(),
 				certCondition: metav1.ConditionTrue,
-				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.OrganizationEmail).To(Equal("jdoe@redhat.com"))
 					g.Expect(fulcio.Certificate.OrganizationName).To(Equal("RH"))
@@ -350,7 +349,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 				canHandle:     true,
 				result:        testAction.StatusUpdate(),
 				certCondition: metav1.ConditionTrue,
-				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).To(Equal("fulcio.local"))
 					g.Expect(fulcio.Certificate.CARef.Name).To(Equal("fulcio-cert"))
 
@@ -409,7 +408,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
+			ctx := t.Context()
 			instance := &rhtasv1alpha1.Fulcio{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "instance",
@@ -442,7 +441,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 
 				found := &rhtasv1alpha1.Fulcio{}
 				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(instance), found)).To(Succeed())
-				tt.want.verify(g, found.Status, c)
+				tt.want.verify(ctx, g, found.Status, c)
 			}
 		})
 	}

--- a/internal/controller/fulcio/actions/ingress_test.go
+++ b/internal/controller/fulcio/actions/ingress_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -12,7 +11,6 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -53,7 +51,7 @@ func TestIngress_CanHandle(t *testing.T) {
 				},
 			}
 			action := NewIngressAction()
-			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+			g.Expect(tt.expected).To(Equal(action.CanHandle(t.Context(), &instance)))
 		})
 	}
 }

--- a/internal/controller/fulcio/fulcio_controller_test.go
+++ b/internal/controller/fulcio/fulcio_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fulcio
 
 import (
-	"context"
 	"time"
 
 	"github.com/securesign/operator/internal/constants"
@@ -47,8 +46,6 @@ var _ = Describe("Fulcio controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -59,20 +56,20 @@ var _ = Describe("Fulcio controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &v1alpha1.Fulcio{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Fulcio")
 			found := &v1alpha1.Fulcio{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -82,7 +79,7 @@ var _ = Describe("Fulcio controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Fulcio", func() {
+		It("should successfully reconcile a custom resource for Fulcio", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Fulcio")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/fulcio/fulcio_hot_update_test.go
+++ b/internal/controller/fulcio/fulcio_hot_update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fulcio
 
 import (
-	"context"
 	"time"
 
 	"github.com/securesign/operator/internal/constants"
@@ -46,8 +45,6 @@ var _ = Describe("Fulcio hot update", func() {
 			Namespace = "update"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Namespace,
@@ -57,20 +54,20 @@ var _ = Describe("Fulcio hot update", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &v1alpha1.Fulcio{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Fulcio")
 			found := &v1alpha1.Fulcio{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -80,7 +77,7 @@ var _ = Describe("Fulcio hot update", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Fulcio", func() {
+		It("should successfully reconcile a custom resource for Fulcio", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Fulcio")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/fulcio/suite_test.go
+++ b/internal/controller/fulcio/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/rekor/actions/server/generate_signer_test.go
+++ b/internal/controller/rekor/actions/server/generate_signer_test.go
@@ -235,7 +235,7 @@ func TestGenerateSigner_CanHandle(t *testing.T) {
 				meta.SetStatusCondition(&instance.Status.Conditions, status)
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -417,7 +417,7 @@ func TestGenerateSigner_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1alpha1.Rekor{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rekor",
@@ -469,7 +469,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, client.WithWatch, <-chan watch.Event)
+		verify func(context.Context, Gomega, client.WithWatch, <-chan watch.Event)
 	}
 	tests := []struct {
 		name string
@@ -494,9 +494,9 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					rekor := &rhtasv1alpha1.Rekor{}
-					g.Expect(cli.Get(context.TODO(), rekorNN, rekor)).Should(Succeed())
+					g.Expect(cli.Get(ctx, rekorNN, rekor)).Should(Succeed())
 					g.Expect(rekor.Status.Signer.KeyRef).ShouldNot(BeNil())
 					g.Expect(rekor.Status.Signer.KeyRef.Name).Should(Equal("unassigned-secret"))
 
@@ -523,9 +523,9 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					rekor := &rhtasv1alpha1.Rekor{}
-					g.Expect(cli.Get(context.TODO(), rekorNN, rekor)).Should(Succeed())
+					g.Expect(cli.Get(ctx, rekorNN, rekor)).Should(Succeed())
 					g.Expect(rekor.Status.Signer.KeyRef).ShouldNot(BeNil())
 					g.Expect(rekor.Status.Signer.KeyRef.Name).ShouldNot(Equal("unassigned-secret"))
 
@@ -541,7 +541,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1alpha1.Rekor{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rekor",
@@ -585,7 +585,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 
 			watchSecrets.Stop()
 			if tt.want.verify != nil {
-				tt.want.verify(g, c, watchSecrets.ResultChan())
+				tt.want.verify(ctx, g, c, watchSecrets.ResultChan())
 			}
 		})
 	}

--- a/internal/controller/rekor/actions/server/ingress_test.go
+++ b/internal/controller/rekor/actions/server/ingress_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -12,7 +11,6 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -53,7 +51,7 @@ func TestIngress_CanHandle(t *testing.T) {
 				},
 			}
 			action := NewIngressAction()
-			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+			g.Expect(tt.expected).To(Equal(action.CanHandle(t.Context(), &instance)))
 		})
 	}
 }

--- a/internal/controller/rekor/actions/server/resolve_pub_key_test.go
+++ b/internal/controller/rekor/actions/server/resolve_pub_key_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -77,7 +76,7 @@ func TestResolvePubKey_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -211,7 +210,7 @@ func TestResolvePubKey_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &v1alpha1.Rekor{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rekor",

--- a/internal/controller/rekor/actions/server/sharding_config_test.go
+++ b/internal/controller/rekor/actions/server/sharding_config_test.go
@@ -80,7 +80,7 @@ func TestShardingConfig_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -100,7 +100,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, client.WithWatch, <-chan watch.Event)
+		verify func(context.Context, Gomega, client.WithWatch, <-chan watch.Event)
 	}
 	tests := []struct {
 		name string
@@ -116,14 +116,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKeyWithValue(shardingConfigName, ""))
 
 					g.Expect(events).To(HaveLen(1))
@@ -155,14 +155,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKey(shardingConfigName))
 
 					rlr := make([]rhtasv1alpha1.RekorLogRange, 0)
@@ -213,15 +213,15 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 					g.Expect(r.Status.ServerConfigRef.Name).ShouldNot(Equal(cmName + "old"))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKey(shardingConfigName))
 
 					rlr := make([]rhtasv1alpha1.RekorLogRange, 0)
@@ -268,15 +268,15 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 					g.Expect(r.Status.ServerConfigRef.Name).ShouldNot(Equal(cmName + "old"))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKey(shardingConfigName))
 
 					rlr := make([]rhtasv1alpha1.RekorLogRange, 0)
@@ -316,14 +316,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(Equal(cmName + "old"))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKeyWithValue(shardingConfigName, ""))
 
 					rlr := make([]rhtasv1alpha1.RekorLogRange, 0)
@@ -363,14 +363,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(Equal(cmName + "old"))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKey(shardingConfigName))
 
 					rlr := make([]rhtasv1alpha1.RekorLogRange, 0)
@@ -391,15 +391,15 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).ShouldNot(Equal(cmName + "deleted"))
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKeyWithValue(shardingConfigName, ""))
 
 					g.Expect(events).To(HaveLen(1))
@@ -429,9 +429,9 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).ShouldNot(Equal(cmName + "old"))
 
@@ -475,14 +475,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(Not(Equal(cmName + "old")))
 
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: cmName + "old", Namespace: rekorNN.Namespace}, &v1.ConfigMap{})).To(HaveOccurred())
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: "keep", Namespace: rekorNN.Namespace}, &v1.ConfigMap{})).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: cmName + "old", Namespace: rekorNN.Namespace}, &v1.ConfigMap{})).To(HaveOccurred())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: "keep", Namespace: rekorNN.Namespace}, &v1.ConfigMap{})).To(Succeed())
 
 					g.Expect(events).To(HaveLen(2))
 					g.Expect(events).To(Receive(
@@ -502,7 +502,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1alpha1.Rekor{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rekor",
@@ -532,7 +532,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 			}
 			watchCm.Stop()
 			if tt.want.verify != nil {
-				tt.want.verify(g, c, watchCm.ResultChan())
+				tt.want.verify(ctx, g, c, watchCm.ResultChan())
 			}
 		})
 	}

--- a/internal/controller/rekor/actions/ui/ingress_test.go
+++ b/internal/controller/rekor/actions/ui/ingress_test.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -12,7 +11,6 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -67,7 +65,7 @@ func TestIngress_CanHandle(t *testing.T) {
 				},
 			}
 			action := NewIngressAction()
-			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+			g.Expect(tt.expected).To(Equal(action.CanHandle(t.Context(), &instance)))
 		})
 	}
 }

--- a/internal/controller/rekor/rekor_attestation_test.go
+++ b/internal/controller/rekor/rekor_attestation_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Rekor controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			By("Deleting the Namespace to perform the tests")

--- a/internal/controller/rekor/rekor_controller_test.go
+++ b/internal/controller/rekor/rekor_controller_test.go
@@ -18,7 +18,6 @@ package rekor
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"time"
@@ -54,8 +53,6 @@ var _ = Describe("Rekor controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -66,13 +63,13 @@ var _ = Describe("Rekor controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &v1alpha1.Rekor{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			DeferCleanup(func() {
 				// Ensure that we reset the DefaultClient's transport after the test
 				httpmock.RestoreDefaultTransport(http.DefaultClient)
@@ -84,7 +81,7 @@ var _ = Describe("Rekor controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -94,7 +91,7 @@ var _ = Describe("Rekor controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Rekor", func() {
+		It("should successfully reconcile a custom resource for Rekor", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Rekor")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/rekor/rekor_hot_update_test.go
+++ b/internal/controller/rekor/rekor_hot_update_test.go
@@ -18,7 +18,6 @@ package rekor
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"time"
@@ -55,8 +54,6 @@ var _ = Describe("Rekor hot update test", func() {
 			Namespace = "update"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Namespace,
@@ -66,13 +63,13 @@ var _ = Describe("Rekor hot update test", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &v1alpha1.Rekor{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			DeferCleanup(func() {
 				// Ensure that we reset the DefaultClient's transport after the test
 				httpmock.RestoreDefaultTransport(http.DefaultClient)
@@ -84,7 +81,7 @@ var _ = Describe("Rekor hot update test", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -94,7 +91,7 @@ var _ = Describe("Rekor hot update test", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Rekor", func() {
+		It("should successfully reconcile a custom resource for Rekor", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Rekor")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/rekor/suite_test.go
+++ b/internal/controller/rekor/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/testonly/suite.go
+++ b/internal/controller/testonly/suite.go
@@ -58,7 +58,7 @@ func ControllerSuite(supplier controller.Constructor) controllerSuite {
 }
 
 func (t *controllerSuite) BeforeSuite() {
-	t.ctx, t.cancel = context.WithCancel(context.TODO())
+	t.ctx, t.cancel = context.WithCancel(context.Background())
 
 	By("bootstrapping test environment")
 	t.testEnv = &envtest.Environment{
@@ -113,7 +113,7 @@ func (t *controllerSuite) BeforeSuite() {
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
-		elog := logf.FromContext(context.TODO()).WithName("Event")
+		elog := logf.FromContext(t.ctx).WithName("Event")
 		for msg := range recorder.Events {
 			elog.Info(msg)
 		}

--- a/internal/controller/trillian/actions/db/handle_secret_test.go
+++ b/internal/controller/trillian/actions/db/handle_secret_test.go
@@ -125,7 +125,7 @@ func TestHandleSecret_CanHandle(t *testing.T) {
 				Status: tt.condition,
 			})
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -141,7 +141,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, client.WithWatch, <-chan watch.Event)
+		verify func(context.Context, Gomega, client.WithWatch, <-chan watch.Event)
 	}
 	tests := []struct {
 		name string
@@ -160,9 +160,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Error(reconcile.TerminalError(ErrMissingDBConfiguration)),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -184,9 +184,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionTrue))
@@ -217,9 +217,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionTrue))
@@ -250,9 +250,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("connection"))
@@ -273,9 +273,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -300,9 +300,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -336,9 +336,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -369,9 +369,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -401,9 +401,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -454,9 +454,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -521,9 +521,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -608,9 +608,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -635,7 +635,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1alpha1.Trillian{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "trillian",
@@ -668,7 +668,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 
 			watchSecrets.Stop()
 			if tt.want.verify != nil {
-				tt.want.verify(g, c, watchSecrets.ResultChan())
+				tt.want.verify(ctx, g, c, watchSecrets.ResultChan())
 			}
 		})
 	}

--- a/internal/controller/trillian/actions/logserver/tls_test.go
+++ b/internal/controller/trillian/actions/logserver/tls_test.go
@@ -1,7 +1,6 @@
 package logserver
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,9 +13,6 @@ import (
 )
 
 func TestTlsAction_CanHandle(t *testing.T) {
-	ctx := context.TODO()
-	g := NewWithT(t)
-
 	type env struct {
 		conditions  []metav1.Condition
 		specTLS     rhtasv1alpha1.TLS
@@ -207,6 +203,8 @@ func TestTlsAction_CanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
 			instance := &rhtasv1alpha1.Trillian{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-trillian",

--- a/internal/controller/trillian/actions/logsigner/tls_test.go
+++ b/internal/controller/trillian/actions/logsigner/tls_test.go
@@ -1,7 +1,6 @@
 package logsigner
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,9 +13,6 @@ import (
 )
 
 func TestTlsAction_CanHandle(t *testing.T) {
-	ctx := context.TODO()
-	g := NewWithT(t)
-
 	type env struct {
 		conditions  []metav1.Condition
 		specTLS     rhtasv1alpha1.TLS
@@ -207,6 +203,8 @@ func TestTlsAction_CanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			g := NewWithT(t)
 			instance := &rhtasv1alpha1.Trillian{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-trillian",

--- a/internal/controller/trillian/suite_test.go
+++ b/internal/controller/trillian/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/trillian/trillian_controller_test.go
+++ b/internal/controller/trillian/trillian_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package trillian
 
 import (
-	"context"
 	"time"
 
 	"github.com/securesign/operator/internal/constants"
@@ -46,8 +45,6 @@ var _ = Describe("Trillian controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -58,20 +55,20 @@ var _ = Describe("Trillian controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		trillian := &v1alpha1.Trillian{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Trillian")
 			found := &v1alpha1.Trillian{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -81,7 +78,7 @@ var _ = Describe("Trillian controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Trillian", func() {
+		It("should successfully reconcile a custom resource for Trillian", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Trillian")
 			err := suite.Client().Get(ctx, typeNamespaceName, trillian)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/tsa/actions/generate_signer_test.go
+++ b/internal/controller/tsa/actions/generate_signer_test.go
@@ -35,8 +35,6 @@ func Test_SignerName(t *testing.T) {
 }
 
 func Test_SignerCanHandle(t *testing.T) {
-	g := NewWithT(t)
-
 	tests := []struct {
 		name     string
 		testCase func(*rhtasv1alpha1.TimestampAuthority)
@@ -93,10 +91,11 @@ func Test_SignerCanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			action := NewGenerateSignerAction()
 			instance := common.GenerateTSAInstance()
 			tt.testCase(instance)
-			g.Expect(action.CanHandle(context.TODO(), instance)).To(Equal(tt.expected))
+			g.Expect(action.CanHandle(t.Context(), instance)).To(Equal(tt.expected))
 		})
 	}
 

--- a/internal/controller/tsa/actions/ingress_test.go
+++ b/internal/controller/tsa/actions/ingress_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -12,7 +11,6 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -53,7 +51,7 @@ func TestIngress_CanHandle(t *testing.T) {
 				},
 			}
 			action := NewIngressAction()
-			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+			g.Expect(tt.expected).To(Equal(action.CanHandle(t.Context(), &instance)))
 		})
 	}
 }

--- a/internal/controller/tsa/actions/ntpMonitoring_test.go
+++ b/internal/controller/tsa/actions/ntpMonitoring_test.go
@@ -90,7 +90,7 @@ func Test_NTPCanHandle(t *testing.T) {
 			action := NewNtpMonitoringAction()
 			instance := common.GenerateTSAInstance()
 			tt.testCase(instance)
-			g.Expect(action.CanHandle(context.TODO(), instance)).To(Equal(tt.expected))
+			g.Expect(action.CanHandle(t.Context(), instance)).To(Equal(tt.expected))
 		})
 	}
 }

--- a/internal/controller/tsa/suite_test.go
+++ b/internal/controller/tsa/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/tsa/timestampauthority_controller_test.go
+++ b/internal/controller/tsa/timestampauthority_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tsa
 
 import (
-	"context"
 	"time"
 
 	"github.com/securesign/operator/internal/constants"
@@ -46,8 +45,6 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -62,19 +59,19 @@ var _ = Describe("TimestampAuthority Controller", func() {
 		service := &corev1.Service{}
 		ingress := &v1.Ingress{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Timestamp Authority")
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -84,7 +81,7 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for the Timestamp Authority", func() {
+		It("should successfully reconcile a custom resource for the Timestamp Authority", func(ctx SpecContext) {
 			By("creating the custom resource for the Timestamp Authority")
 			err := suite.Client().Get(ctx, typeNamespaceName, timestampAuthority)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/tsa/tsa_hot_update_test.go
+++ b/internal/controller/tsa/tsa_hot_update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 import (
-	"context"
 	"time"
 
 	"github.com/securesign/operator/internal/constants"
@@ -46,8 +45,6 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			Namespace = "update"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Namespace,
@@ -58,19 +55,19 @@ var _ = Describe("Timestamp Authority hot update", func() {
 		timestampAuthority := &rhtasv1alpha1.TimestampAuthority{}
 		found := &rhtasv1alpha1.TimestampAuthority{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Timestamp Authority")
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -80,7 +77,7 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for the Timestamp Authority", func() {
+		It("should successfully reconcile a custom resource for the Timestamp Authority", func(ctx SpecContext) {
 			By("creating the custom resource for the Timestamp Authority")
 			err := suite.Client().Get(ctx, typeNamespaceName, timestampAuthority)
 			if err != nil && errors.IsNotFound(err) {
@@ -188,7 +185,7 @@ var _ = Describe("Timestamp Authority hot update", func() {
 
 			By("Creating new certificate chain and signer keys")
 			secret := tsa.CreateSecrets(Namespace, "tsa-test-secret")
-			Expect(suite.Client().Create(context.TODO(), secret)).NotTo(HaveOccurred())
+			Expect(suite.Client().Create(ctx, secret)).NotTo(HaveOccurred())
 
 			By("Status field changed for cert chain")
 			Eventually(func(g Gomega) string {

--- a/internal/controller/tuf/actions/ingress_test.go
+++ b/internal/controller/tuf/actions/ingress_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -12,7 +11,6 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -53,7 +51,7 @@ func TestIngress_CanHandle(t *testing.T) {
 				},
 			}
 			action := NewIngressAction()
-			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+			g.Expect(tt.expected).To(Equal(action.CanHandle(t.Context(), &instance)))
 		})
 	}
 }

--- a/internal/controller/tuf/suite_test.go
+++ b/internal/controller/tuf/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/tuf/tuf_controller_test.go
+++ b/internal/controller/tuf/tuf_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tuf
 
 import (
-	"context"
 	"maps"
 	"time"
 
@@ -51,8 +50,6 @@ var _ = Describe("TUF controller", func() {
 			TufNamespace = "controller"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: TufNamespace,
@@ -62,20 +59,20 @@ var _ = Describe("TUF controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: TufName, Namespace: TufNamespace}
 		tuf := &v1alpha1.Tuf{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Tuf")
 			found := &v1alpha1.Tuf{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -85,7 +82,7 @@ var _ = Describe("TUF controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Tuf", func() {
+		It("should successfully reconcile a custom resource for Tuf", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Tuf")
 			err := suite.Client().Get(ctx, typeNamespaceName, tuf)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/testing/common/tsa/tsa.go
+++ b/internal/testing/common/tsa/tsa.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"context"
 	"testing"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
@@ -62,26 +61,27 @@ func GenerateTSAInstance() *rhtasv1alpha1.TimestampAuthority {
 }
 
 func TsaTestSetup(instance *rhtasv1alpha1.TimestampAuthority, t *testing.T, client client.WithWatch, action action.Action[*rhtasv1alpha1.TimestampAuthority], initObjs ...client.Object) (client.WithWatch, action.Action[*rhtasv1alpha1.TimestampAuthority]) {
+	ctx := t.Context()
 	if client == nil {
 		client = testAction.FakeClientBuilder().WithObjects(instance).WithStatusSubresource(instance).Build()
 	}
-	if err := client.Get(context.TODO(), types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}, instance); err != nil {
+	if err := client.Get(ctx, types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}, instance); err != nil {
 		t.Error(err)
 		return nil, nil
 	}
 
 	for _, obj := range initObjs {
-		if err := client.Create(context.TODO(), obj); err != nil {
+		if err := client.Create(ctx, obj); err != nil {
 			t.Error(err)
 			return nil, nil
 		}
 	}
 
 	a := testAction.PrepareAction(client, action)
-	if !a.CanHandle(context.TODO(), instance) {
+	if !a.CanHandle(ctx, instance) {
 		return nil, nil
 	}
 
-	_ = a.Handle(context.TODO(), instance)
+	_ = a.Handle(ctx, instance)
 	return client, a
 }

--- a/internal/utils/kubernetes/config_map_test.go
+++ b/internal/utils/kubernetes/config_map_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -14,7 +13,6 @@ import (
 )
 
 func TestEnsureImmutableConfigMap(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name      string
 		objects   []client.Object
@@ -98,7 +96,8 @@ func TestEnsureImmutableConfigMap(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -107,19 +106,19 @@ func TestEnsureImmutableConfigMap(t *testing.T) {
 				&v1.ConfigMap{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureConfigMapData(tt.immutable, map[string]string{"test": "data"}))
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			if tt.errorMsg == "" {
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 			} else {
-				gomega.Expect(err.Error()).To(gomega.Equal(tt.errorMsg))
+				g.Expect(err.Error()).To(gomega.Equal(tt.errorMsg))
 				return
 			}
 
 			existing := &v1.ConfigMap{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Data).To(gomega.Equal(existing.Data))
-			gomega.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Data).To(gomega.Equal(existing.Data))
+			g.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
 		})
 	}
 }

--- a/internal/utils/kubernetes/ensure/deployment/deployment_test.go
+++ b/internal/utils/kubernetes/ensure/deployment/deployment_test.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -21,10 +20,9 @@ import (
 const name = "dp"
 
 func TestEnsureTrustedCA(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	t.Run("update existing object", func(t *testing.T) {
-
-		ctx := context.TODO()
+		g := gomega.NewWithT(t)
+		ctx := t.Context()
 		c := testAction.FakeClientBuilder().
 			WithObjects(&v1.Deployment{
 				ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
@@ -60,40 +58,39 @@ func TestEnsureTrustedCA(t *testing.T) {
 			&v1.Deployment{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 			TrustedCA(&v1alpha1.LocalObjectReference{Name: "test"}, name),
 		)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(err).ToNot(gomega.HaveOccurred())
 
-		gomega.Expect(result).To(gomega.Equal(controllerutil.OperationResultUpdated))
+		g.Expect(result).To(gomega.Equal(controllerutil.OperationResultUpdated))
 
 		existing := &v1.Deployment{}
-		gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env).To(gomega.HaveLen(2))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env[0].Name).To(gomega.Equal("NAME"))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env[0].Value).To(gomega.Equal("VALUE"))
+		g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env).To(gomega.HaveLen(2))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env[0].Name).To(gomega.Equal("NAME"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env[0].Value).To(gomega.Equal("VALUE"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env[1].Name).To(gomega.Equal("SSL_CERT_DIR"))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].Env[1].Value).To(gomega.Equal("/var/run/configs/tas/ca-trust:/var/run/secrets/kubernetes.io/serviceaccount"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env[1].Name).To(gomega.Equal("SSL_CERT_DIR"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].Env[1].Value).To(gomega.Equal("/var/run/configs/tas/ca-trust:/var/run/secrets/kubernetes.io/serviceaccount"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts).To(gomega.HaveLen(2))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(gomega.Equal("mount"))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(gomega.Equal("path"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts).To(gomega.HaveLen(2))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(gomega.Equal("mount"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(gomega.Equal("path"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(gomega.Equal("ca-trust"))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(gomega.Equal("/var/run/configs/tas/ca-trust"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[1].Name).To(gomega.Equal("ca-trust"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[1].MountPath).To(gomega.Equal("/var/run/configs/tas/ca-trust"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Volumes).To(gomega.HaveLen(2))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal("mount"))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[1].Name).To(gomega.Equal("ca-trust"))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[1].Projected.Sources).To(gomega.HaveLen(1))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[1].Projected.Sources[0].ConfigMap.Name).To(gomega.Equal("test"))
+		g.Expect(existing.Spec.Template.Spec.Volumes).To(gomega.HaveLen(2))
+		g.Expect(existing.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal("mount"))
+		g.Expect(existing.Spec.Template.Spec.Volumes[1].Name).To(gomega.Equal("ca-trust"))
+		g.Expect(existing.Spec.Template.Spec.Volumes[1].Projected.Sources).To(gomega.HaveLen(1))
+		g.Expect(existing.Spec.Template.Spec.Volumes[1].Projected.Sources[0].ConfigMap.Name).To(gomega.Equal("test"))
 
 	})
 }
 
 func TestEnsureTLS(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	t.Run("update existing object", func(t *testing.T) {
-
-		ctx := context.TODO()
+		g := gomega.NewWithT(t)
+		ctx := t.Context()
 		c := testAction.FakeClientBuilder().
 			WithObjects(&v1.Deployment{
 				ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
@@ -127,23 +124,23 @@ func TestEnsureTLS(t *testing.T) {
 				},
 			}, name),
 		)
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(err).ToNot(gomega.HaveOccurred())
 
-		gomega.Expect(result).To(gomega.Equal(controllerutil.OperationResultUpdated))
+		g.Expect(result).To(gomega.Equal(controllerutil.OperationResultUpdated))
 
 		existing := &v1.Deployment{}
-		gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
+		g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts).To(gomega.HaveLen(1))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(gomega.Equal(tls.TLSVolumeName))
-		gomega.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(gomega.Equal("/var/run/secrets/tas"))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts).To(gomega.HaveLen(1))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].Name).To(gomega.Equal(tls.TLSVolumeName))
+		g.Expect(existing.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath).To(gomega.Equal("/var/run/secrets/tas"))
 
-		gomega.Expect(existing.Spec.Template.Spec.Containers[1].VolumeMounts).To(gomega.BeEmpty())
+		g.Expect(existing.Spec.Template.Spec.Containers[1].VolumeMounts).To(gomega.BeEmpty())
 
-		gomega.Expect(existing.Spec.Template.Spec.Volumes).To(gomega.HaveLen(1))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal(tls.TLSVolumeName))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[0].Projected.Sources).To(gomega.HaveLen(2))
-		gomega.Expect(existing.Spec.Template.Spec.Volumes[0].Projected.Sources).To(gomega.ContainElements(
+		g.Expect(existing.Spec.Template.Spec.Volumes).To(gomega.HaveLen(1))
+		g.Expect(existing.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal(tls.TLSVolumeName))
+		g.Expect(existing.Spec.Template.Spec.Volumes[0].Projected.Sources).To(gomega.HaveLen(2))
+		g.Expect(existing.Spec.Template.Spec.Volumes[0].Projected.Sources).To(gomega.ContainElements(
 			gomega.And(
 				gomega.WithTransform(func(s core.VolumeProjection) string {
 					return s.Secret.Name

--- a/internal/utils/kubernetes/ingress_test.go
+++ b/internal/utils/kubernetes/ingress_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -16,7 +15,6 @@ import (
 )
 
 func TestEnsureIngressSpec(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -99,7 +97,8 @@ func TestEnsureIngressSpec(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -113,17 +112,17 @@ func TestEnsureIngressSpec(t *testing.T) {
 					},
 					name),
 			)
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &networkingv1.Ingress{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Spec.Rules).To(gomega.HaveLen(1))
-			gomega.Expect(existing.Spec.Rules[0].Host).To(gomega.Equal("host"))
-			gomega.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths).To(gomega.HaveLen(1))
-			gomega.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name).To(gomega.Equal(name))
-			gomega.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).To(gomega.Equal(name))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Spec.Rules).To(gomega.HaveLen(1))
+			g.Expect(existing.Spec.Rules[0].Host).To(gomega.Equal("host"))
+			g.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths).To(gomega.HaveLen(1))
+			g.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name).To(gomega.Equal(name))
+			g.Expect(existing.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).To(gomega.Equal(name))
 
 		})
 	}

--- a/internal/utils/kubernetes/role_binding_test.go
+++ b/internal/utils/kubernetes/role_binding_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -15,7 +14,6 @@ import (
 )
 
 func TestEnsureRoleBinding(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -62,7 +60,8 @@ func TestEnsureRoleBinding(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -77,20 +76,19 @@ func TestEnsureRoleBinding(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&rbacv1.RoleBinding{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureRoleBinding(role, subject))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &rbacv1.RoleBinding{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.RoleRef).To(gomega.Equal(role))
-			gomega.Expect(existing.Subjects).To(gomega.Equal([]rbacv1.Subject{subject}))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.RoleRef).To(gomega.Equal(role))
+			g.Expect(existing.Subjects).To(gomega.Equal([]rbacv1.Subject{subject}))
 		})
 	}
 }
 
 func TestEnsureClusterRoleBinding(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -137,7 +135,8 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -152,14 +151,14 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&rbacv1.ClusterRoleBinding{ObjectMeta: v2.ObjectMeta{Name: name}},
 				EnsureClusterRoleBinding(role, subject))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &rbacv1.ClusterRoleBinding{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.RoleRef).To(gomega.Equal(role))
-			gomega.Expect(existing.Subjects).To(gomega.Equal([]rbacv1.Subject{subject}))
+			g.Expect(c.Get(ctx, client.ObjectKey{Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.RoleRef).To(gomega.Equal(role))
+			g.Expect(existing.Subjects).To(gomega.Equal([]rbacv1.Subject{subject}))
 		})
 	}
 }

--- a/internal/utils/kubernetes/role_test.go
+++ b/internal/utils/kubernetes/role_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -13,7 +12,6 @@ import (
 )
 
 func TestEnsureRoleRules(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -65,7 +63,8 @@ func TestEnsureRoleRules(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -86,19 +85,18 @@ func TestEnsureRoleRules(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&rbacv1.Role{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureRoleRules(rules...))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &rbacv1.Role{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Rules).To(gomega.Equal(rules))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Rules).To(gomega.Equal(rules))
 		})
 	}
 }
 
 func TestEnsureClusterRoleRules(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -150,7 +148,8 @@ func TestEnsureClusterRoleRules(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -171,13 +170,13 @@ func TestEnsureClusterRoleRules(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&rbacv1.ClusterRole{ObjectMeta: v2.ObjectMeta{Name: name}},
 				EnsureClusterRoleRules(rules...))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &rbacv1.ClusterRole{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Rules).To(gomega.Equal(rules))
+			g.Expect(c.Get(ctx, client.ObjectKey{Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Rules).To(gomega.Equal(rules))
 		})
 	}
 }

--- a/internal/utils/kubernetes/secret_test.go
+++ b/internal/utils/kubernetes/secret_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -14,7 +13,6 @@ import (
 )
 
 func TestEnsureSecret(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name      string
 		objects   []client.Object
@@ -98,7 +96,8 @@ func TestEnsureSecret(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -107,19 +106,19 @@ func TestEnsureSecret(t *testing.T) {
 				&v1.Secret{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureSecretData(tt.immutable, map[string][]byte{"test": []byte("data")}))
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			if tt.errorMsg == "" {
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 			} else {
-				gomega.Expect(err.Error()).To(gomega.Equal(tt.errorMsg))
+				g.Expect(err.Error()).To(gomega.Equal(tt.errorMsg))
 				return
 			}
 
 			existing := &v1.Secret{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Data).To(gomega.Equal(existing.Data))
-			gomega.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Data).To(gomega.Equal(existing.Data))
+			g.Expect(utils.OptionalBool(existing.Immutable)).To(gomega.Equal(tt.immutable))
 		})
 	}
 }

--- a/internal/utils/kubernetes/service_test.go
+++ b/internal/utils/kubernetes/service_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -59,7 +58,8 @@ func TestService(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				Build()
@@ -70,14 +70,14 @@ func TestService(t *testing.T) {
 			result, err := CreateOrUpdate(ctx, c,
 				&v1.Service{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
 				EnsureServiceSpec(l, ports...))
-			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(err).ToNot(gomega.HaveOccurred())
 
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 
 			existing := &v1.Service{}
-			gomega.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
-			gomega.Expect(existing.Spec.Ports).To(gomega.Equal(ports))
-			gomega.Expect(existing.Spec.Selector).To(gomega.Equal(l))
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test"}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Spec.Ports).To(gomega.Equal(ports))
+			g.Expect(existing.Spec.Selector).To(gomega.Equal(l))
 		})
 	}
 }

--- a/internal/utils/tls/tls_test.go
+++ b/internal/utils/tls/tls_test.go
@@ -1,7 +1,6 @@
 package tls
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -27,7 +26,6 @@ func (f fakeTlsClient) GetTrustedCA() *v1alpha1.LocalObjectReference {
 }
 
 func TestCAPath(t *testing.T) {
-	gomega.RegisterTestingT(t)
 	tests := []struct {
 		name     string
 		objects  []client.Object
@@ -108,7 +106,8 @@ func TestCAPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
+			g := gomega.NewWithT(t)
 
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
@@ -116,11 +115,11 @@ func TestCAPath(t *testing.T) {
 
 			result, err := CAPath(ctx, c, tt.instance)
 			if tt.err {
-				gomega.Expect(err).To(gomega.HaveOccurred())
+				g.Expect(err).To(gomega.HaveOccurred())
 			} else {
-				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 			}
-			gomega.Expect(result).To(gomega.Equal(tt.result))
+			g.Expect(result).To(gomega.Equal(tt.result))
 		})
 	}
 }


### PR DESCRIPTION
### **PR Type**
Tests


___

### **Description**
- Replace context.TODO() with t.Context() in test files

- Update test function signatures to use SpecContext

- Add EnforceDefaultTimeoutsWhenUsingContexts() to test suites

- Modernize Gomega usage patterns in tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["context.TODO()"] -- "replace with" --> B["t.Context()"]
  C["BeforeEach/AfterEach"] -- "add" --> D["SpecContext parameter"]
  E["Test suites"] -- "add" --> F["EnforceDefaultTimeoutsWhenUsingContexts()"]
  G["gomega.RegisterTestingT(t)"] -- "replace with" --> H["gomega.NewWithT(t)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>48 files</summary><table>
<tr>
  <td><strong>sharding_config_test.go</strong><dd><code>Replace context.TODO() with t.Context() in sharding config tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-cd4d4d3e036036f1bf68c2b41853ea8420e40d6ba07596aaf4b1ae36ff5e46e6">+31/-31</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>handle_secret_test.go</strong><dd><code>Replace context.TODO() with t.Context() in database secret tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-c7289c1665d1051221fc73d256bc78cbe60683178643bb1b4ab3dfab315beb66">+28/-28</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>deployment_test.go</strong><dd><code>Modernize context usage and Gomega patterns in deployment tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-d52a2a37bbbf0b60e72714f2acb88859453007b67ed84979101c54465f856a9a">+33/-36</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>generate_cert_test.go</strong><dd><code>Replace context.TODO() with t.Context() in certificate generation </code><br><code>tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-0e5179147120188002c85f9dadb2d5ff68fa99b3ba1179b3bdf0108eb9167fd9">+10/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>server_config_test.go</strong><dd><code>Replace context.TODO() with t.Context() in server config tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-752925ca2f9e35fc7443a35532d3c609df3bd771830745462a69cbfea9d36c63">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>resolve_keys_test.go</strong><dd><code>Replace context.TODO() with t.Context() in key resolution tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-0ee4e9b0281354065aa2dbaf98f4b34e3dce245182bfb403c8efb4421924551f">+10/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate_signer_test.go</strong><dd><code>Replace context.TODO() with t.Context() in signer generation tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-daf88814d39453e1bf5a2b9134de7729e1ef01b9c6e4804edfa7a24f4996b334">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>role_binding_test.go</strong><dd><code>Modernize context usage and Gomega patterns in role binding tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-8c3e3a6793523ccd3f91f2969592aeafd7d2dcc5c7f4ab23d0c08c070501360b">+14/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>role_test.go</strong><dd><code>Modernize context usage and Gomega patterns in role tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-44d5e2c996d73edff1317e18609e4f3c52381c1e51f42caa5f56ea06b3b6a452">+12/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tsa_hot_update_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-6b6cae9ec920dec84cb902ef79888cb87466572b0a682e62cb15c7372f779858">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Modernize context usage and Gomega patterns in ingress tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-5bb4219f11205abb3fcf436196c8fa4b766557508425b3127b97e1e5c24d480a">+10/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>server_config_test.go</strong><dd><code>Replace context.TODO() with t.Context() in CTlog server config tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-1d8ec2c0c48f20ca47848914885dbdc7fa72511fef64970039f15b9bcd560596">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rekor_hot_update_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-35f1b274058875f37109013c744105ca45dbf35f4effeea59bd335b2941e0de9">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rekor_controller_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-5a2b3dce012145d9f4a80de0cc903ddaea86a370036eb8c3b8b73c8aee270043">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>timestampauthority_controller_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-f6978882ad6f72df2400a23d9a8ae9b05ae0af70bc706dafcdc21d37652141ad">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config_map_test.go</strong><dd><code>Modernize context usage and Gomega patterns in config map tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-151cbd1cdc1bd999265b0ad75ea2deb35a752a21acaf3e1f0a16a08095c526e6">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>secret_test.go</strong><dd><code>Modernize context usage and Gomega patterns in secret tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-9e5c8cd8ef0cd4958e8cbbd1b1f7ef0d58072c83114e2b2e9260b06870936bd1">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fulcio_hot_update_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-348257071047c22eefbe39de9617605390dce156ed453002c97f5757dc9bf4a6">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fulcio_controller_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-2a65389cfa1b9cafe8c18f9bde992f06b8d907fbef2976e131c5ff7e41db38eb">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>trillian_controller_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-afe64b4331578c0c78169f7ca5ad65210dd6a94f8e90f0d7e64745e9e90929a5">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ctlog_controller_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-94cc5390112a55702f2e35d5f6e2fb25782c82fb105354a13ec8e759d92d64e5">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tuf_controller_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-08a539432b76b1c8f7e5c747af5475f7c0918eb4dd444134c53128227df33b4b">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ctlog_hot_update_test.go</strong><dd><code>Update test function signatures to use SpecContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-40f5b5c97f19db5dd8d343604d72ea75a95ac4d1095c27fa742943b05b6e293e">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service_test.go</strong><dd><code>Modernize context usage and Gomega patterns in service tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-16671386b998515d5b758ebdb5c97ba1884ccfb9617f0851ecc069b465e14f8a">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tsa.go</strong><dd><code>Replace context.TODO() with t.Context() in TSA test utilities</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-8e79a0d17b855f6fe7006b063065b282f720aca077f4137bf7540c54259649d7">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tls_test.go</strong><dd><code>Modernize context usage and Gomega patterns in TLS tests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-4ac7fd7fe6eb6d2623b5fe52087c358894cfde2f25386bef8db06038623d36c2">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resolve_pub_key_test.go</strong><dd><code>Replace context.TODO() with t.Context() in public key resolution tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-68468a9521416e05b9ee98ef269ed9c455633b7add41e1b4bcb4fdf3c6f35cde">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tls_test.go</strong><dd><code>Replace context.TODO() with t.Context() in log signer TLS tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-568956400f5cc19d65a4b92bc0df919ad5acd5617da2967141a56ca1ec709d03">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tls_test.go</strong><dd><code>Replace context.TODO() with t.Context() in log server TLS tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-c7491055757689026482b035269be21ac98f649a8132fe8194395ab21db6f5c7">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handle_keys_test.go</strong><dd><code>Replace context.TODO() with t.Context() in CTlog key handling tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-b93ee587efe39d429c4c2b7a26c7188265468b306e72256fee89e2174f64ed09">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handle_fulcio_root_test.go</strong><dd><code>Replace context.TODO() with t.Context() in Fulcio root handling tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-f27511e5f6f2fcc1a557c65f08dcad4707fcdbbd7ad918ceba89f81fedbfb70a">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Replace context.TODO() with t.Context() in Fulcio ingress tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-a603aee9f4f65e6a515f2614067ffb10527cc9d3821e530dec7f200b79d5e465">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Replace context.TODO() with t.Context() in Rekor server ingress tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-6320153ec82faec4ff45371dfe48e223d56609cb8d6dfccba39dbaf0a620ce10">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Replace context.TODO() with t.Context() in TSA ingress tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-8eb2f6bc50ad3fdb77068a54e8731e2eb5cc0919309fc9eb6c2f72d0da9fa780">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Replace context.TODO() with t.Context() in TUF ingress tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-b4514ff75edd767ef3336928f8ae85817522a6f05dbfa535e4f5e9d9e090efaa">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ingress_test.go</strong><dd><code>Replace context.TODO() with t.Context() in Rekor UI ingress tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-927c6d40c2b0da23f930820dcf95b566dbaa59d65fa1e86ad95f9e893284e112">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>suite.go</strong><dd><code>Replace context.TODO() with context.Background() in test suite</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-416fd6dc9277ceda3593c3d04dbac11f59ac0362af23b91c1f0ba0f3b3564850">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate_signer_test.go</strong><dd><code>Replace context.TODO() with t.Context() in TSA signer generation tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-3a54e6dfc14f29d050e2692333a0f64abc1d0e1c4980506fe08d18e4c654526b">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rekor_attestation_test.go</strong><dd><code>Replace context.TODO() with ctx in Rekor attestation tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-5708f749512de0d9a129a5e673f5a8e21edbb892f2412a16c320c20a5e7af661">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>action_test.go</strong><dd><code>Replace context.TODO() with t.Context() in RBAC action tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-4eca0eca368d67ba067b9225fd7f1b2650b5d9fffe5b9e587dd0ac797b396baf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>action_test.go</strong><dd><code>Replace context.TODO() with t.Context() in tree action tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-58b3d724754f97767e86ea9f64b381e6c02ffb77c91a49ccdac66309f1eb0a5d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ntpMonitoring_test.go</strong><dd><code>Replace context.TODO() with t.Context() in NTP monitoring tests</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-90ef605ccfd5b34d30b7413ec2dacf137c4ff859434c7eaae306fc81db9ce5ff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>suite_test.go</strong><dd><code>Add EnforceDefaultTimeoutsWhenUsingContexts to CTlog test suite</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-d3b9ce021963bc4530cb1ed706c2e42a30d43fcbf3ff6b34d45ddc3dad3d375f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>suite_test.go</strong><dd><code>Add EnforceDefaultTimeoutsWhenUsingContexts to Fulcio test suite</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-85861102c5027ac288b47c4ae5716266bfbc979af6d0daea6a0de360d4e60c00">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>suite_test.go</strong><dd><code>Add EnforceDefaultTimeoutsWhenUsingContexts to Rekor test suite</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-14e550cd23dcd13a1f9256b2ab0c163e291beadf05be1d567332c93e2e85a2f8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>suite_test.go</strong><dd><code>Add EnforceDefaultTimeoutsWhenUsingContexts to Trillian test suite</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-80d6c00571b63c2f0219886f53692fcf7fbb986392cc2287071f39a43f32dcd4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>suite_test.go</strong><dd><code>Add EnforceDefaultTimeoutsWhenUsingContexts to TSA test suite</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-e9d2dbcfabf939a46c22eb999cc5aced6fb45a8a4d53140854ffc46c690c2c8b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>suite_test.go</strong><dd><code>Add EnforceDefaultTimeoutsWhenUsingContexts to TUF test suite</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1314/files#diff-16413ea58831bf17b18084cea1bc6ddd4bd794408699db348874778823e358c5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

