### PR TITLE
fix: Unblock logsigner service upgrade on OpenShift

### DIFF
--- a/internal/controller/trillian/actions/logsigner/service.go
+++ b/internal/controller/trillian/actions/logsigner/service.go
@@ -36,7 +36,7 @@ func (i createServiceAction) Name() string {
 
 func (i createServiceAction) CanHandle(ctx context.Context, instance *rhtasv1alpha1.Trillian) bool {
 	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return c.Reason == constants.Creating || c.Reason == constants.Ready && instance.Spec.Monitoring.Enabled
+	return c.Reason == constants.Creating || c.Reason == constants.Ready
 }
 
 func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian) *action.Result {


### PR DESCRIPTION
A restrictive monitoring condition prevented the logsigner service from being reconciled during an upgrade. This meant the new pod would fail to start because its required TLS secret was missing.

By removing the condition, the service and its secrets are now correctly managed, allowing for seamless upgrades.

## Summary by Sourcery

Bug Fixes:
- Unblock logsigner service upgrade by removing restrictive monitoring-enabled check in CanHandle, allowing the service and its secrets to be managed correctly.