### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for rhtas-operator-v1-2

### DIFF
--- a/Dockerfile.rhtas-operator.rh
+++ b/Dockerfile.rhtas-operator.rh
@@ -39,7 +39,8 @@ LABEL io.k8s.display-name="RHTAS operator container image for Red Hat Trusted Ar
 LABEL io.openshift.tags="rhtas-operator, Red Hat Trusted Artifact Signer."
 LABEL summary="Operator for the rhtas-operator."
 LABEL com.redhat.component="rhtas-operator"
-LABEL name="rhtas-operator"
+LABEL name="rhtas/rhtas-rhel9-operator"
+LABEL cpe="cpe:/a:redhat:trusted_artifact_signer:1.2::el9"
 
 LABEL features.operators.openshift.io/cni="false"
 LABEL features.operators.openshift.io/disconnected="false"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
