### PR TITLE
fix(tsa): handle nil pointer when NTP monitoring config is not set

### DIFF
--- a/internal/controller/tsa/actions/deployment.go
+++ b/internal/controller/tsa/actions/deployment.go
@@ -50,14 +50,11 @@ func (i deployAction) Name() string {
 }
 
 func (i deployAction) CanHandle(ctx context.Context, instance *rhtasv1alpha1.TimestampAuthority) bool {
-	c := meta.FindStatusCondition(instance.GetConditions(), constants.Ready)
-	if instance.Spec.Signer.CertificateChain.CertificateChainRef == nil &&
-		(instance.Spec.Signer.CertificateChain.RootCA == nil ||
-			instance.Spec.Signer.CertificateChain.LeafCA == nil) {
+	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
+	if c == nil {
 		return false
 	}
-
-	return (c.Reason == constants.Ready || c.Reason == constants.Creating)
+	return c.Reason == constants.Creating || c.Reason == constants.Ready
 }
 
 func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.TimestampAuthority) *action.Result {


### PR DESCRIPTION
- Fix panic when tsa.ntpMonitoring.enabled=true but config is not provided
- Add proper nil checks in ntpMonitoringAction.Handle method
- Ensure operator gracefully handles missing NTP monitoring configuration
- Add test coverage for nil config scenarios to prevent regression

The operator was crashing with "invalid memory address or nil pointer dereference" when NTP monitoring was enabled without providing a config.

Refs: SECURESIGN-2966

## Summary by Sourcery

Handle missing NTP monitoring configuration to prevent nil pointer panics, add necessary nil checks and status updates in the NTP monitoring action, enrich unit tests for nil-config scenarios, fix deploy action's readiness logic, and regenerate CRD schemas with updated descriptions for affinity weights and EnvFiles support.

Bug Fixes:
- Prevent panic when NTP monitoring is enabled without a provided config by adding nil checks and early return in the Handle method.
- Fix deployAction.CanHandle to handle missing Ready condition properly and avoid unintended false results.

Enhancements:
- Refactor NTP config marshaling and status alignment methods to accept nil inputs.
- Update CRD schema descriptions: change affinity weight behavior wording, adjust feature gate phrasing, and add EnvFiles fileKeyRef support across CRDs.

Tests:
- Add unit tests to cover scenarios where NTP monitoring config is nil to validate graceful handling and status conditions.