### PR TITLE
Fix vendor and maintainer label

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -35,8 +35,8 @@ LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 LABEL operators.openshift.io/valid-subscription="Red Hat Trusted Artifact Signer"
 
-LABEL maintainer="Red Hat, Inc."
-LABEL vendor="Red Hat, Inc."
+LABEL maintainer="Red Hat, Inc"
+LABEL vendor="Red Hat, Inc"
 LABEL url="https://www.redhat.com"
 LABEL distribution-scope="public"
 LABEL version=$VERSION


### PR DESCRIPTION
EC is failing with

```
The "vendor" label has an unexpected "Red Hat, Inc" value. Must be one of: Red Hat, Inc.
```

## Summary by Sourcery

Fix the maintainer and vendor labels in bundle.Dockerfile to remove trailing periods and satisfy expected values

Bug Fixes:
- Remove trailing period from "maintainer" label value
- Remove trailing period from "vendor" label value