### PR TITLE
Sealight2.0 [TESTING]

### DIFF
--- a/.tekton/rhtas-operator-bundle-pull-request.yaml
+++ b/.tekton/rhtas-operator-bundle-pull-request.yaml
@@ -1,6 +1,6 @@
 apiVersion: tekton.dev/v1
 kind: PipelineRun
-metadata:
+metadata: #
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/securesign/secure-sign-operator?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -41,6 +41,20 @@ spec:
     value: Dockerfile.rhtas-operator.rh
   - name: path-context
     value: .
+  - name: component
+    value: '{{ repo_name }}'
+  - name: branch
+    value: '{{ source_branch }}'
+  - name: revision
+    value: '{{ revision }}'
+  - name: repository-url
+    value: '{{ repo_url }}'
+  - name: test-event
+    value: '{{ event_type }}'
+  - name: pull-request-number
+    value: '{{ pull_request_number }}'
+  - name: target-branch
+    value: '{{ target_branch }}'
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -30,6 +30,13 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/securesign/rhtas-operator:on-pr-{{revision}}
+  # Add these parameters
+  - name: sealights-output-image
+    value: quay.io/redhat-user-workloads/rhtas-tenant/operator/rhtas-operator-sealights:{{revision}}
+  - name: sealights-dockerfile
+    value: Dockerfile.sealights
+  - name: sealights-image-expires-after
+    value: '5d'
   - name: dockerfile
     value: Dockerfile.rhtas-operator.rh
   - name: path-context
@@ -50,7 +57,7 @@ spec:
     - name: url
       value: https://github.com/securesign/pipelines.git
     - name: revision
-      value: main
+      value: SealightsExperimental
     - name: pathInRepo
       value: pipelines/docker-build-multi-platform-oci-ta.yaml
     resolver: git

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -41,19 +41,19 @@ spec:
   - name: path-context
     value: .
   - name: component
-    value: '{{ repo_name }}'
+    value: '{{repo_name}}'
   - name: branch
-    value: '{{ source_branch }}'
+    value: '{{source_branch}}'
   - name: revision
-    value: '{{ revision }}'
+    value: '{{revision}}'
   - name: repository-url
-    value: '{{ repo_url }}'
+    value: '{{repo_url}}'
   - name: test-event
-    value: '{{ event_type }}'
+    value: '{{event_type}}'
   - name: pull-request-number
-    value: '{{ pull_request_number }}'
+    value: '{{pull_request_number}}'
   - name: target-branch
-    value: '{{ target_branch }}'
+    value: '{{target_branch}}'
   - name: build-platforms
     value:
     - linux/x86_64

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -30,7 +30,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/securesign/rhtas-operator:on-pr-{{revision}}
-  # Add these parameters
   - name: sealights-output-image
     value: quay.io/redhat-user-workloads/rhtas-tenant/operator/rhtas-operator-sealights:{{revision}}
   - name: sealights-dockerfile


### PR DESCRIPTION
## Summary by Sourcery

Enable Sealights support in the Tekton pull-request pipelines by adding related parameters, exposing key context variables, and switching to the experimental pipeline branch

Enhancements:
- Add Sealights-specific parameters to the PR pipeline (output image, Dockerfile, and image expiration)
- Expose common context variables (component, branch, repository URL, event type, PR number, and target branch) to pipeline tasks
- Switch the external pipelines git resource to use the SealightsExperimental branch

Build:
- Add a placeholder comment to the metadata line in the bundle pull-request pipeline manifest