### PR TITLE
Simple script to recreate TLS certificates

### DIFF
--- a/hack/restoreTls.sh
+++ b/hack/restoreTls.sh
@@ -3,12 +3,20 @@
 # Delete TLS secrets (will be recreated by operator) and restart deployments in correct order.
 # Switch to the namespace you want to delete the TLS secrets from.
 
+# Discover the Securesign instance name
+INSTANCE_NAME=$(oc get Securesign -o jsonpath='{.items[0].metadata.name}')
+
+if [[ -z "$INSTANCE_NAME" ]]; then
+    echo "No Securesign instance found in current namespace"
+    exit 1
+fi
+
 echo "Deleting TLS secrets..."
-oc delete secret securesign-sample-rekor-redis-tls --ignore-not-found=true
-oc delete secret securesign-sample-ctlog-tls --ignore-not-found=true
-oc delete secret securesign-sample-trillian-logserver-tls --ignore-not-found=true
-oc delete secret securesign-sample-trillian-logsigner-tls --ignore-not-found=true
-oc delete secret securesign-sample-trillian-db-tls --ignore-not-found=true
+oc delete secret ${INSTANCE_NAME}-rekor-redis-tls --ignore-not-found=true
+oc delete secret ${INSTANCE_NAME}-ctlog-tls --ignore-not-found=true
+oc delete secret ${INSTANCE_NAME}-trillian-logserver-tls --ignore-not-found=true
+oc delete secret ${INSTANCE_NAME}-trillian-logsigner-tls --ignore-not-found=true
+oc delete secret ${INSTANCE_NAME}-trillian-db-tls --ignore-not-found=true
 
 echo "Restarting Trillian components ..."
 oc rollout restart deployment trillian-db


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Script to delete and recreate TLS certificates

- Restarts deployments in proper dependency order

- Automates TLS certificate restoration process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Delete TLS secrets"] --> B["Restart Trillian DB"]
  B --> C["Restart Trillian components"]
  C --> D["Restart Redis"]
  D --> E["Restart CTlog"]
  E --> F["Display new TLS secrets"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>restoreTls.sh</strong><dd><code>TLS certificate restoration automation script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hack/restoreTls.sh

<ul><li>Creates bash script to delete TLS secrets for Securesign components<br> <li> Implements ordered restart of deployments (Trillian, Redis, CTlog)<br> <li> Adds verification step to display recreated TLS secrets</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1379/files#diff-5edf0c393ef5f7c6c70ec71f4ceff947e6a694ddc8b605c4c621c5603213e98b">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

