### PR TITLE
use target branch in rhtas-operator-pull-request.yaml

### DIFF
--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/securesign/rhtas-operator:on-pr-{{revision}}
+    value: quay.io/securesign/rhtas-operator-1-3-1:on-pr-{{revision}}
   - name: dockerfile
     value: Dockerfile.rhtas-operator.rh
   - name: path-context
@@ -49,7 +49,7 @@ spec:
     - name: url
       value: https://github.com/securesign/pipelines.git
     - name: revision
-      value: '{{target_branch}}'
+      value: main
     - name: pathInRepo
       value: pipelines/docker-build-multi-platform-oci-ta.yaml
     resolver: git


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Parameterize the revision field in .tekton/rhtas-operator-pull-request.yaml to use {{target_branch}} instead of “main”