### PR TITLE
fix(build): Make docker-buildx target compatible with podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,10 @@ docker-push: ## Push docker image with the manager.
 PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for the manager for cross-platform support
+ifeq ($(CONTAINER_TOOL),podman)
+	$(CONTAINER_TOOL) build --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile .
+	$(CONTAINER_TOOL) push ${IMG}
+else
 	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
 	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
 	- $(CONTAINER_TOOL) buildx create --name project-v3-builder
@@ -196,6 +200,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm project-v3-builder
 	rm Dockerfile.cross
+endif
 
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.


### PR DESCRIPTION
The docker-buildx target was using Docker-specific 'buildx' commands,
which failed when CONTAINER_TOOL was set to 'podman'

## Summary by Sourcery

Support Podman for cross-platform image builds by conditionally using standard Podman build and push commands in the docker-buildx Makefile target while retaining Docker buildx for other container tools.

Bug Fixes:
- Make the Makefile docker-buildx target compatible with Podman by using `podman build` and `podman push` when CONTAINER_TOOL is set to podman

Enhancements:
- Add conditional logic in the Makefile to choose between Docker buildx and Podman build commands