### PR TITLE
ci: use stage branch for securesign/fbc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,6 +124,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "securesign/fbc"
+          ref: stage
           path: fbc
 
       - name: Build catalog


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use stage branch when checking out securesign/fbc in GitHub Actions