### PR TITLE
Add RHBK kustomise resources and update deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ ts_chain.pem
 
 # HELM Charts
 ci/**/charts
+
+# RHBK Resources
+ci/rhbk/resources/base/hostname.env

--- a/ci/rhbk/operator/base/kustomization.yaml
+++ b/ci/rhbk/operator/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- subscription.yaml
+
+namespace: keycloak-system

--- a/ci/rhbk/operator/base/namespace.yaml
+++ b/ci/rhbk/operator/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: keycloak-system

--- a/ci/rhbk/operator/base/subscription.yaml
+++ b/ci/rhbk/operator/base/subscription.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhbk-operator-operator-group
+spec:
+  targetNamespaces:
+  - keycloak-system
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhbk-operator
+spec:
+  channel: stable-v26.2
+  installPlanApproval: Automatic
+  name: rhbk-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ci/rhbk/resources/base/keycloak.yaml
+++ b/ci/rhbk/resources/base/keycloak.yaml
@@ -1,0 +1,23 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: keycloak
+spec:
+  db:
+    host: postgresql-db
+    passwordSecret:
+      key: password
+      name: postgresql-db
+    usernameSecret:
+      key: username
+      name: postgresql-db
+    vendor: postgres
+  hostname:
+    hostname: https://keycloak-keycloak-system.apps.${BASE_DOMAIN}
+  ingress:
+    enabled: true
+  proxy:
+    headers: xforwarded
+  http:
+    httpEnabled: true
+  instances: 1

--- a/ci/rhbk/resources/base/keycloak_realm_import.yaml
+++ b/ci/rhbk/resources/base/keycloak_realm_import.yaml
@@ -1,0 +1,66 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: trusted-artifact-signer-realm
+spec:
+  keycloakCRName: keycloak
+  realm:
+    id: trusted-artifact-signer
+    realm: trusted-artifact-signer
+    displayName: Red-Hat-Trusted-Artifact-Signer
+    enabled: true
+    sslRequired: none
+    clients:
+      - clientId: trusted-artifact-signer
+        name: trusted-artifact-signer
+        description: Client for Red Hat Trusted Artifact Signer authentication
+        protocol: openid-connect
+        publicClient: true
+        standardFlowEnabled: true
+        directAccessGrantsEnabled: true
+        implicitFlowEnabled: false
+        defaultClientScopes: ["profile","email"]
+        redirectUris:
+          - "*"
+          - "urn:ietf:wg:oauth:2.0:oob"
+        attributes:
+          "request.object.signature.alg": "RS256"
+          "user.info.response.signature.alg": "RS256"
+        protocolMappers:
+          - name: email
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            config:
+              "user.attribute": "email"
+              "claim.name": "email"
+              "jsonType.label": "String"
+              "id.token.claim": "true"
+              "userinfo.token.claim": "true"
+          - name: email-verified
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            config:
+              "user.attribute": "emailVerified"
+              "claim.name": "email-verified"
+              "id.token.claim": "true"
+              "userinfo.token.claim": "true"
+          - name: audience
+            protocol: openid-connect
+            protocolMapper: oidc-hardcoded-claim-mapper
+            config:
+              "claim.name": "aud"
+              "claim.value": "trusted-artifact-signer"
+              "id.token.claim": "true"
+              "access.token.claim": "true"
+              "userinfo.token.claim": "true"
+    users:
+      - username: jdoe
+        enabled: true
+        emailVerified: true
+        email: jdoe@redhat.com
+        firstName: Jane
+        lastName: Doe
+        credentials:
+          - type: password
+            value: secure
+            temporary: false

--- a/ci/rhbk/resources/base/kustomization.yaml
+++ b/ci/rhbk/resources/base/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- postgresql_db_secret.yaml
+- postgresql_db_service.yaml
+- postgresql_db.yaml
+- keycloak.yaml
+- keycloak_realm_import.yaml
+
+namespace: keycloak-system
+
+configMapGenerator:
+  - name: base-hostname
+    envs:
+      - hostname.env
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: base-hostname
+      version: v1
+      fieldPath: data.HOSTNAME
+    targets:
+      - select:
+          kind: Keycloak
+          name: keycloak
+        fieldPaths:
+          - spec.hostname.hostname

--- a/ci/rhbk/resources/base/postgresql_db.yaml
+++ b/ci/rhbk/resources/base/postgresql_db.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgresql-db
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql-db
+  serviceName: postgresql-db
+  template:
+    metadata:
+      labels:
+        app: postgresql-db
+    spec:
+      containers:
+      - env:
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: postgresql-db
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: postgresql-db
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              key: database
+              name: postgresql-db
+        image: registry.redhat.io/rhel9/postgresql-15:latest
+        livenessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+            - --live
+          failureThreshold: 3
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: postgresql-db
+        readinessProbe:
+          exec:
+            command:
+            - /usr/libexec/check-container
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /var/lib/pgsql/data
+          name: data
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests:
+          storage: 5Gi

--- a/ci/rhbk/resources/base/postgresql_db_secret.yaml
+++ b/ci/rhbk/resources/base/postgresql_db_secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-db
+stringData:
+  database: keycloak
+  username: keycloak
+  password: keycloak

--- a/ci/rhbk/resources/base/postgresql_db_service.yaml
+++ b/ci/rhbk/resources/base/postgresql_db_service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql-db
+spec:
+  ports:
+  - port: 5432
+  selector:
+    app: postgresql-db


### PR DESCRIPTION
## Summary by Sourcery

Add Kustomize configurations for Red Hat backed Keycloak deployment and update the OpenShift deploy script to optionally install RHBK or the existing SSO setup.

New Features:
- Add Kustomize-based resources for RHBK deployment including PostgreSQL StatefulSet, Keycloak CR, realm import, secrets, service, operator subscription, and kustomization manifests under ci/rhbk

Enhancements:
- Enhance tas-keycloak-install.sh to support installing Red Hat Backed Keycloak via install_rhbk_sso_keycloak function with usage help and parameterized choice between rhbk and sso