### PR TITLE
ci: pin tough build from a released tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "securesign/tough"
+          ref: rhtas-v1.3.0
           path: tough
 
       - uses: actions/cache@v4


### PR DESCRIPTION
The CI was previously building the tough dependency from its 'development' branch. This practice is unstable, and a recent change on that branch introduced breaking changes, causing our pipeline to fail.

This commit updates the CI configuration to build tough from a specific, pinned tag. This ensures a stable, non-breaking version is always used, restoring the build's reliability.

## Summary by Sourcery

CI:
- Update GitHub Actions checkout for tough to use ref rhtas-v1.3.0 instead of the development branch