### PR TITLE
ci: use release-1.3 branch for sigstore-e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -534,6 +534,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "securesign/sigstore-e2e"
+          ref: release-1.3
           path: e2e
 
       - name: Install Go


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure sigstore-e2e checkout to use the release-1.3 branch