### PR TITLE
test: Add OLMv1 test support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/google/go-containerregistry v0.20.6
 	github.com/google/trillian v1.7.2
 	github.com/google/uuid v1.6.0
-	github.com/onsi/ginkgo/v2 v2.23.4
-	github.com/onsi/gomega v1.37.0
+	github.com/onsi/ginkgo/v2 v2.25.1
+	github.com/onsi/gomega v1.38.2
 	github.com/openshift/api v0.0.0-20251023193535-8691c3014652
 	github.com/operator-framework/api v0.35.0
 	github.com/operator-framework/operator-lib v0.19.0
@@ -30,11 +30,12 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/docker/cli v28.2.2+incompatible // indirect
+	github.com/docker/cli v28.3.3+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.4 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
@@ -95,7 +96,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.34.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -12,8 +14,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/cli v28.2.2+incompatible h1:qzx5BNUDFqlvyq4AHzdNB7gSyVTmU4cgsyN9SdInc1A=
-github.com/docker/cli v28.2.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v28.3.3+incompatible h1:fp9ZHAr1WWPGdIWBM1b3zLtgCF+83gRdVMTJsUeiyAo=
+github.com/docker/cli v28.3.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.9.4 h1:76ItO69/AP/V4yT9V4uuuItG0B1N8hvt0T0c0NN/DzI=
@@ -113,10 +115,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus=
-github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
-github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
-github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/onsi/ginkgo/v2 v2.25.1 h1:Fwp6crTREKM+oA6Cz4MsO8RhKQzs2/gOIVOUscMAfZY=
+github.com/onsi/ginkgo/v2 v2.25.1/go.mod h1:ppTWQ1dh9KM/F1XgpeRqelR+zHVwV81DGRSDnFxK7Sk=
+github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
+github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -29,8 +29,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
-	olm "github.com/operator-framework/api/pkg/operators/v1"
-	olmAlpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/securesign/operator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,8 +50,6 @@ func CreateClient() (client.Client, error) {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
-	utilruntime.Must(olmAlpha.AddToScheme(scheme))
-	utilruntime.Must(olm.AddToScheme(scheme))
 
 	cfg, err := config.GetConfig()
 	if err != nil {

--- a/test/e2e/support/kubernetes/olm/olm.go
+++ b/test/e2e/support/kubernetes/olm/olm.go
@@ -1,0 +1,134 @@
+package olm
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	olm "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// olm types
+type subscriptionExtension struct {
+	v1alpha1.Subscription
+}
+
+func (e *subscriptionExtension) Unwrap() client.Object {
+	return &e.Subscription
+}
+
+func (e *subscriptionExtension) IsReady(ctx context.Context, cli client.Client) bool {
+	s := e.getInstalledCSV(ctx, cli)
+	return s != nil
+}
+
+func (e *subscriptionExtension) GetVersion(ctx context.Context, cli client.Client) string {
+	s := e.getInstalledCSV(ctx, cli)
+	if s == nil {
+		return ""
+	}
+	return s.Spec.Version.String()
+
+}
+
+func (e *subscriptionExtension) getInstalledCSV(ctx context.Context, cli client.Client) *v1alpha1.ClusterServiceVersion {
+	lst := v1alpha1.ClusterServiceVersionList{}
+	if err := cli.List(ctx, &lst, client.InNamespace(e.Namespace)); err != nil {
+		return nil
+	}
+	for _, s := range lst.Items {
+		if strings.Contains(s.Name, e.Name) && s.Status.Phase == v1alpha1.CSVPhaseSucceeded {
+			return &s
+
+		}
+	}
+	return nil
+}
+
+type catalogSourceWrapper struct {
+	v1alpha1.CatalogSource
+}
+
+func (c *catalogSourceWrapper) Unwrap() client.Object {
+	return &c.CatalogSource
+}
+
+func (c *catalogSourceWrapper) IsReady(ctx context.Context, cli client.Client) bool {
+	if c.Status.GRPCConnectionState == nil {
+		return false
+	}
+	return c.Status.GRPCConnectionState.LastObservedState == "READY"
+}
+
+func (c *catalogSourceWrapper) UpdateSourceImage(s string) {
+	c.Spec.Image = s
+}
+
+func OlmInstaller(ctx context.Context, cli client.Client, catalogImage, ns, packageName, channel string, ocp bool) (Extension, ExtensionSource, error) {
+	scheme := cli.Scheme()
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(olm.AddToScheme(scheme))
+
+	og := &olm.OperatorGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      packageName,
+		},
+		Spec: olm.OperatorGroupSpec{
+			TargetNamespaces: []string{},
+		},
+	}
+
+	catalog := &catalogSourceWrapper{
+
+		v1alpha1.CatalogSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      fmt.Sprintf("%s-catalog", packageName),
+			},
+			Spec: v1alpha1.CatalogSourceSpec{
+				Image:       catalogImage,
+				SourceType:  "grpc",
+				DisplayName: "OLM upgrade test Catalog",
+				Publisher:   "grpc",
+			},
+		},
+	}
+
+	subscription := &subscriptionExtension{
+		v1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      packageName,
+				Namespace: ns,
+			},
+			Spec: &v1alpha1.SubscriptionSpec{
+				CatalogSource:          catalog.Name,
+				CatalogSourceNamespace: catalog.Namespace,
+				Package:                packageName,
+				Channel:                channel,
+				Config: &v1alpha1.SubscriptionConfig{
+					Env: []coreV1.EnvVar{
+						{
+							Name:  "OPENSHIFT",
+							Value: strconv.FormatBool(ocp),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, obj := range []client.Object{catalog.Unwrap(), subscription.Unwrap(), og} {
+		if err := cli.Create(ctx, obj); client.IgnoreAlreadyExists(err) != nil {
+			return nil, nil, err
+		}
+	}
+
+	return subscription, catalog, nil
+}

--- a/test/e2e/support/kubernetes/olm/olm_types.go
+++ b/test/e2e/support/kubernetes/olm/olm_types.go
@@ -1,0 +1,21 @@
+package olm
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ExtensionSource interface {
+	client.Object
+	IsReady(context.Context, client.Client) bool
+	UpdateSourceImage(string)
+	Unwrap() client.Object
+}
+
+type Extension interface {
+	client.Object
+	IsReady(context.Context, client.Client) bool
+	GetVersion(context.Context, client.Client) string
+	Unwrap() client.Object
+}

--- a/test/e2e/support/kubernetes/olm/olm_v1.go
+++ b/test/e2e/support/kubernetes/olm/olm_v1.go
@@ -1,0 +1,143 @@
+package olm
+
+import (
+	"context"
+	"fmt"
+
+	coreV1 "k8s.io/api/core/v1"
+	rbacV1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type clusterExtensionWrapper struct {
+	*unstructured.Unstructured
+}
+
+func (e *clusterExtensionWrapper) Unwrap() client.Object {
+	return e.Unstructured
+}
+
+func (e *clusterExtensionWrapper) IsReady(_ context.Context, _ client.Client) bool {
+	return meta.IsStatusConditionTrue(conditions(e.Object), "Installed")
+}
+
+func (e *clusterExtensionWrapper) GetVersion(_ context.Context, _ client.Client) string {
+	version, _, _ := unstructured.NestedString(e.Object, "status", "install", "bundle", "version")
+	return version
+}
+
+type clusterCatalogSource struct {
+	*unstructured.Unstructured
+}
+
+func (c *clusterCatalogSource) Unwrap() client.Object {
+	return c.Unstructured
+}
+
+func (c *clusterCatalogSource) IsReady(_ context.Context, _ client.Client) bool {
+	return meta.IsStatusConditionTrue(conditions(c.Object), "Serving")
+}
+
+func (c *clusterCatalogSource) UpdateSourceImage(s string) {
+	_ = unstructured.SetNestedField(c.Object, s, "spec", "source", "image", "ref")
+}
+
+func OlmV1Installer(ctx context.Context, cli client.Client, catalogImage, ns, packageName string) (Extension, ExtensionSource, error) {
+	sa := &coreV1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-installer", packageName),
+			Namespace: ns,
+		},
+	}
+
+	crb := &rbacV1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-installer-%s", packageName, ns),
+		},
+		RoleRef: rbacV1.RoleRef{
+			APIGroup: coreV1.SchemeGroupVersion.Group,
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+		Subjects: []rbacV1.Subject{{Kind: "ServiceAccount", Name: sa.Name, Namespace: ns}},
+	}
+
+	selector := map[string]string{"catalog": "test"}
+
+	cs := &clusterCatalogSource{
+		Unstructured: &unstructured.Unstructured{},
+	}
+	cs.SetKind("ClusterCatalog")
+	cs.SetAPIVersion("olm.operatorframework.io/v1")
+	cs.SetName(fmt.Sprintf("%s-catalog", packageName))
+	cs.SetLabels(selector)
+	if err := unstructured.SetNestedMap(cs.Object, map[string]interface{}{
+		"availabilityMode": "Available",
+		"priority":         int64(-300),
+		"source": map[string]interface{}{
+			"type": "Image",
+			"image": map[string]interface{}{
+				"ref": catalogImage,
+			},
+		},
+	}, "spec"); err != nil {
+		return nil, nil, err
+	}
+
+	es := &clusterExtensionWrapper{
+		Unstructured: &unstructured.Unstructured{},
+	}
+	es.SetKind("ClusterExtension")
+	es.SetAPIVersion("olm.operatorframework.io/v1")
+	es.SetName(packageName)
+
+	if err := unstructured.SetNestedMap(es.Object, map[string]interface{}{
+		"namespace":      ns,
+		"serviceAccount": map[string]interface{}{"name": sa.Name},
+		"source": map[string]interface{}{
+			"sourceType": "Catalog",
+			"catalog": map[string]interface{}{
+				"packageName": packageName,
+			},
+		},
+	}, "spec"); err != nil {
+		return nil, nil, err
+	}
+	if err := unstructured.SetNestedStringMap(cs.Object, selector, "spec", "source", "catalog", "selector", "matchLabels"); err != nil {
+		return nil, nil, err
+	}
+
+	for _, obj := range []client.Object{sa, crb, es.Unwrap(), cs.Unwrap()} {
+		if err := cli.Create(ctx, obj); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return es, cs, nil
+}
+
+func conditions(object map[string]interface{}) []metav1.Condition {
+	var (
+		conditionsSlice []interface{}
+		found           bool
+		err             error
+	)
+	if conditionsSlice, found, err = unstructured.NestedSlice(object, "status", "conditions"); !found || err != nil {
+		return nil
+	}
+
+	jsonBytes, err := json.Marshal(conditionsSlice)
+	if err != nil {
+		return nil
+	}
+
+	var typedConditions []metav1.Condition
+	if err := json.Unmarshal(jsonBytes, &typedConditions); err != nil {
+		return nil
+	}
+	return typedConditions
+}


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add OLMv1 support alongside existing OLMv1alpha support
  - New `olm_v1.go` module with `OlmV1Installer` for ClusterExtension/ClusterCatalog
  - New `olm_types.go` with common Extension and ExtensionSource interfaces
  - Refactored `olm.go` to use wrapper types implementing shared interfaces

- Simplify upgrade test by abstracting OLM installation logic
  - Replace inline OLM object creation with installer functions
  - Support both OLM versions via environment variable `OLM_V1`
  - Remove duplicate catalog source and subscription management code

- Update dependencies to support OLMv1 operator-controller
  - Add `github.com/operator-framework/operator-controller v1.5.1`
  - Bump ginkgo and gomega to latest versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OLM Test Support"] --> B["OLMv1alpha Installer"]
  A --> C["OLMv1 Installer"]
  B --> D["Extension Interface"]
  C --> D
  B --> E["ExtensionSource Interface"]
  C --> E
  D --> F["Upgrade Test"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>olm_types.go</strong><dd><code>Define common OLM extension interfaces</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/e2e/support/kubernetes/olm/olm_types.go

<ul><li>Define <code>Extension</code> interface with methods for readiness, version <br>retrieval, and unwrapping<br> <li> Define <code>ExtensionSource</code> interface with methods for readiness, image <br>updates, and unwrapping<br> <li> Provide common abstraction for both OLMv1alpha and OLMv1 <br>implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1438/files#diff-d3bcf82d120f1ed91143e4a23faca62c35e1bf2853d97cbd1e1dbdf05f62df80">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>olm.go</strong><dd><code>Implement OLMv1alpha installer with interface wrappers</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/e2e/support/kubernetes/olm/olm.go

<ul><li>Implement <code>subscriptionExtension</code> wrapper for v1alpha1.Subscription with <br>IsReady and GetVersion methods<br> <li> Implement <code>catalogSourceWrapper</code> for v1alpha1.CatalogSource with IsReady <br>and UpdateSourceImage methods<br> <li> Create <code>OlmInstaller</code> function to set up OLMv1alpha resources <br>(OperatorGroup, CatalogSource, Subscription)<br> <li> Both wrappers implement the common Extension and ExtensionSource <br>interfaces</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1438/files#diff-efd958cc3f145fca3d14847c635f99a6710797f5f90fb93e8c9eb087c54ec40b">+134/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>olm_v1.go</strong><dd><code>Implement OLMv1 installer with interface wrappers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/e2e/support/kubernetes/olm/olm_v1.go

<ul><li>Implement <code>clusterExtensionWrapper</code> for olmV1.ClusterExtension with <br>readiness and version checks<br> <li> Implement <code>clusterCatalogSource</code> for olmV1.ClusterCatalog with readiness <br>and image update methods<br> <li> Create <code>OlmV1Installer</code> function to set up OLMv1 resources <br>(ServiceAccount, ClusterRoleBinding, ClusterCatalog, ClusterExtension)<br> <li> Both wrappers implement the common Extension and ExtensionSource <br>interfaces</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1438/files#diff-7c16b1e3b1ee77559a05a91cc34a0647939a80e067198a43077d9de84b334852">+116/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>common.go</strong><dd><code>Remove OLM imports and scheme registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/e2e/support/common.go

<ul><li>Remove unused imports for OLMv1 and OLMv1alpha types<br> <li> Remove scheme registration for olmAlpha and olm packages from <br>CreateClient function<br> <li> Simplify client creation by removing OLM-specific setup</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1438/files#diff-bfbbcad105ab41cf0304712c64bf1cc51061f82f9f042e835b162001d0d70f8d">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>upgrade_test.go</strong><dd><code>Refactor upgrade test to use OLM installers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/e2e/upgrade_test.go

<ul><li>Replace inline OLM object creation with abstracted installer functions<br> <li> Add support for OLMv1 via <code>OLM_V1</code> environment variable check<br> <li> Simplify catalog source and subscription management using wrapper <br>interfaces<br> <li> Remove helper function <code>findClusterServiceVersion</code> and related <br>CSV-specific logic<br> <li> Use generic Extension and ExtensionSource interfaces for version <br>tracking and readiness checks<br> <li> Refactor upgrade verification to use semver comparison on version <br>strings</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1438/files#diff-fc8ea8c7c1a732fd9a425771cb3463d1cd143e5527acec751f32ba88f2df697a">+51/-111</a></td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Add OLMv1 operator-controller dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

<ul><li>Add <code>github.com/operator-framework/operator-controller v1.5.1</code> for OLMv1 <br>support<br> <li> Upgrade <code>github.com/onsi/ginkgo/v2</code> from v2.23.4 to v2.25.1<br> <li> Upgrade <code>github.com/onsi/gomega</code> from v1.37.0 to v1.38.2</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1438/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Update dependency checksums</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.sum

<ul><li>Add checksums for new dependencies including operator-controller, <br>cel-go, and related packages<br> <li> Update checksums for upgraded ginkgo and gomega versions<br> <li> Add checksums for transitive dependencies (semver, antlr, cobra, <br>opentelemetry)</ul>


</details>


  </td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1438/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+39/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

