### PR TITLE
fix: SECURESIGN-3246: restrict SBJ to OpenShift environments

### DIFF
--- a/internal/controller/securesign/actions/segment_backup_cronjob.go
+++ b/internal/controller/securesign/actions/segment_backup_cronjob.go
@@ -36,6 +36,10 @@ func (i segmentBackupCronJob) Name() string {
 	return "segment-backup-nightly-metrics"
 }
 func (i segmentBackupCronJob) CanHandle(_ context.Context, instance *rhtasv1alpha1.Securesign) bool {
+	if !kubernetes.IsOpenShift() {
+		return false
+	}
+
 	c := meta.FindStatusCondition(instance.Status.Conditions, MetricsCondition)
 	if c == nil || c.Reason == constants.Ready {
 		return false

--- a/internal/controller/securesign/actions/segment_backup_job.go
+++ b/internal/controller/securesign/actions/segment_backup_job.go
@@ -35,6 +35,10 @@ func (i segmentBackupJob) Name() string {
 }
 
 func (i segmentBackupJob) CanHandle(_ context.Context, instance *rhtasv1alpha1.Securesign) bool {
+	if !kubernetes.IsOpenShift() {
+		return false
+	}
+
 	c := meta.FindStatusCondition(instance.Status.Conditions, MetricsCondition)
 	if c == nil || c.Reason == constants.Ready {
 		return false

--- a/internal/controller/securesign/actions/segment_rbac.go
+++ b/internal/controller/securesign/actions/segment_rbac.go
@@ -41,6 +41,10 @@ func (i rbacAction) Name() string {
 }
 
 func (i rbacAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Securesign) bool {
+	if !kubernetes.IsOpenShift() {
+		return false
+	}
+
 	c := meta.FindStatusCondition(instance.Status.Conditions, MetricsCondition)
 	if c == nil || c.Reason == constants.Ready {
 		return false

--- a/internal/controller/securesign/securesign_controller.go
+++ b/internal/controller/securesign/securesign_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/controller"
 	"github.com/securesign/operator/internal/labels"
+	"github.com/securesign/operator/internal/utils/kubernetes"
 	v12 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
@@ -99,11 +100,13 @@ func (r *securesignReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := r.DeleteAllOf(ctx, &v1.ClusterRole{}, client.MatchingLabels(instanceLabels)); err != nil {
 			log.Error(err, "problem with removing ClusterRole resource")
 		}
-		if err := r.DeleteAllOf(ctx, &v1.Role{}, client.InNamespace(actions.OpenshiftMonitoringNS), client.MatchingLabels(instanceLabels)); err != nil {
-			log.Error(err, "problem with removing Role resource in %s", actions.OpenshiftMonitoringNS)
-		}
-		if err := r.DeleteAllOf(ctx, &v1.RoleBinding{}, client.InNamespace(actions.OpenshiftMonitoringNS), client.MatchingLabels(instanceLabels)); err != nil {
-			log.Error(err, "problem with removing RoleBinding resource in %s", actions.OpenshiftMonitoringNS)
+		if kubernetes.IsOpenShift() {
+			if err := r.DeleteAllOf(ctx, &v1.Role{}, client.InNamespace(actions.OpenshiftMonitoringNS), client.MatchingLabels(instanceLabels)); err != nil {
+				log.Error(err, "problem with removing Role resource in %s", actions.OpenshiftMonitoringNS)
+			}
+			if err := r.DeleteAllOf(ctx, &v1.RoleBinding{}, client.InNamespace(actions.OpenshiftMonitoringNS), client.MatchingLabels(instanceLabels)); err != nil {
+				log.Error(err, "problem with removing RoleBinding resource in %s", actions.OpenshiftMonitoringNS)
+			}
 		}
 
 		controllerutil.RemoveFinalizer(target, finalizer)


### PR DESCRIPTION
This PR adds guards around the SBJ integration, since this requires resources within the `openshift-monitoring` namespace

## Summary by Sourcery

Guard SBJ integration to only operate in OpenShift environments and disable related actions on non-OpenShift clusters

Enhancements:
- Add kubernetes.IsOpenShift guard around Role and RoleBinding cleanup in openshift-monitoring namespace
- Restrict segment backup CronJob, backup Job, and RBAC actions to OpenShift clusters only