### PR TITLE
feat: SECURESIGN-3184: ensure ServiceMonitors are only created when s…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/controller/ctlog"
 	"github.com/securesign/operator/internal/controller/fulcio"
 	"github.com/securesign/operator/internal/controller/rekor"
@@ -61,6 +62,7 @@ import (
 	"github.com/securesign/operator/internal/controller/trillian"
 	"github.com/securesign/operator/internal/controller/tsa"
 	"github.com/securesign/operator/internal/controller/tuf"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -76,6 +78,7 @@ func init() {
 	utilruntime.Must(v1.AddToScheme(scheme))
 	utilruntime.Must(configv1.AddToScheme(scheme))
 	utilruntime.Must(consolev1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -207,14 +210,35 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupController("securesign", securesign.NewReconciler, mgr)
-	setupController("fulcio", fulcio.NewReconciler, mgr)
-	setupController("trillian", trillian.NewReconciler, mgr)
-	setupController("rekor", rekor.NewReconciler, mgr)
-	setupController("tuf", tuf.NewReconciler, mgr)
-	setupController("ctlog", ctlog.NewReconciler, mgr)
-	setupController("tsa", tsa.NewReconciler, mgr)
+	monitoringRegistry := monitoring.NewRegistry(
+		mgr.GetClient(),
+		mgr.GetEventRecorderFor("servicemmonitor-watcher"),
+		setupLog,
+	)
+
+	setupController("securesign", securesign.NewReconciler, mgr, monitoringRegistry)
+	setupController("fulcio", fulcio.NewReconciler, mgr, monitoringRegistry)
+	setupController("trillian", trillian.NewReconciler, mgr, monitoringRegistry)
+	setupController("rekor", rekor.NewReconciler, mgr, monitoringRegistry)
+	setupController("tuf", tuf.NewReconciler, mgr, monitoringRegistry)
+	setupController("ctlog", ctlog.NewReconciler, mgr, monitoringRegistry)
+	setupController("tsa", tsa.NewReconciler, mgr, monitoringRegistry)
 	//+kubebuilder:scaffold:builder
+
+	// Setup CRD watcher for ServiceMonitor availability
+	crdWatcher, err := monitoring.NewCRDWatcher(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		monitoringRegistry,
+	)
+	if err != nil {
+		setupLog.Error(err, "unable to create CRD watcher")
+		os.Exit(1)
+	}
+	if err := crdWatcher.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to setup CRD watcher")
+		os.Exit(1)
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
@@ -241,11 +265,12 @@ func main() {
 	}
 }
 
-func setupController(name string, constructor controller.Constructor, manager ctrl.Manager) {
+func setupController(name string, constructor controller.Constructor, manager ctrl.Manager, monitoringRegistry *monitoring.ServiceMonitorRegistry) {
 	if err := constructor(
 		manager.GetClient(),
 		manager.GetScheme(),
 		manager.GetEventRecorderFor(name+"-controller"),
+		monitoringRegistry,
 	).SetupWithManager(manager); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", name)
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -69,6 +69,14 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apiregistration.k8s.io
   resources:
   - apiservices

--- a/internal/action/monitoring/crd_watcher.go
+++ b/internal/action/monitoring/crd_watcher.go
@@ -1,0 +1,123 @@
+package monitoring
+
+import (
+	"context"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// ServiceMonitorCRDName is the name of the ServiceMonitor CRD
+	ServiceMonitorCRDName = "servicemonitors.monitoring.coreos.com"
+)
+
+// CRDWatcherReconciler watches CRD resources to detect
+// when the Prometheus Operator ServiceMonitor CRD is installed or removed
+type CRDWatcherReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Registry *ServiceMonitorRegistry
+}
+
+// NewCRDWatcher creates a new CRD watcher reconciler
+func NewCRDWatcher(c client.Client, scheme *runtime.Scheme, registry *ServiceMonitorRegistry) (*CRDWatcherReconciler, error) {
+	return &CRDWatcherReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Registry: registry,
+	}, nil
+}
+
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
+
+// Reconcile processes CRD changes for the ServiceMonitor CRD
+func (r *CRDWatcherReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if req.Name != ServiceMonitorCRDName {
+		return reconcile.Result{}, nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Detected ServiceMonitor CRD change")
+
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	err := r.Get(ctx, req.NamespacedName, crd)
+
+	available := false
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "Failed to get CRD")
+			return reconcile.Result{}, err
+		}
+		logger.Info("ServiceMonitor CRD not found - Prometheus Operator not installed")
+	} else {
+		available = isCRDEstablished(crd)
+		if !available {
+			logger.Info("ServiceMonitor CRD found but not established yet")
+		}
+	}
+
+	previouslyAvailable := r.Registry.IsAPIAvailable()
+	r.Registry.SetAPIAvailable(available)
+
+	if available != previouslyAvailable {
+		if available {
+			logger.Info("ServiceMonitor CRD is now available")
+			r.Registry.EmitEventToOwners(ctx, "Normal", "ServiceMonitorAPIAvailable", "ServiceMonitor API is now available")
+		} else {
+			logger.Info("ServiceMonitor CRD is no longer available")
+			r.Registry.EmitEventToOwners(ctx, "Warning", "ServiceMonitorAPIUnavailable", "ServiceMonitor API is no longer available")
+		}
+	}
+
+	if available {
+		logger.Info("ServiceMonitor CRD is established, reconciling all registered ServiceMonitors")
+		if err := r.Registry.ReconcileAll(ctx); err != nil {
+			logger.Error(err, "Failed to reconcile ServiceMonitors")
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// isCRDEstablished checks if a CRD is established and ready to use
+func isCRDEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	for _, condition := range crd.Status.Conditions {
+		if condition.Type == apiextensionsv1.Established {
+			return condition.Status == apiextensionsv1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// SetupWithManager sets up the controller with the Manager
+func (r *CRDWatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&apiextensionsv1.CustomResourceDefinition{}).
+		WithEventFilter(serviceMonitorCRDPredicate()).
+		Complete(r)
+}
+
+// serviceMonitorCRDPredicate filters events to only process the ServiceMonitor CRD
+func serviceMonitorCRDPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == ServiceMonitorCRDName
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == ServiceMonitorCRDName
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == ServiceMonitorCRDName
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return e.Object.GetName() == ServiceMonitorCRDName
+		},
+	}
+}

--- a/internal/action/monitoring/crd_watcher_test.go
+++ b/internal/action/monitoring/crd_watcher_test.go
@@ -1,0 +1,265 @@
+package monitoring
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+func TestNewCRDWatcher(t *testing.T) {
+	g := NewWithT(t)
+
+	c, _, _, registry, scheme := setupTest(t, false, apiextensionsv1.AddToScheme)
+
+	reconciler, err := NewCRDWatcher(c, scheme, registry)
+
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(reconciler).ToNot(BeNil())
+	g.Expect(reconciler.Client).To(Equal(c))
+	g.Expect(reconciler.Scheme).To(Equal(scheme))
+	g.Expect(reconciler.Registry).To(Equal(registry))
+}
+
+func TestReconcileServiceMonitorCRD(t *testing.T) {
+	tests := []struct {
+		name                 string
+		crdName              string
+		createCRD            bool
+		crdEstablished       bool
+		expectedAPIAvailable *bool // nil means don't check
+	}{
+		{
+			name:                 "non-ServiceMonitor CRD",
+			crdName:              "othercrd.example.com",
+			createCRD:            false,
+			expectedAPIAvailable: nil, // Don't check for non-ServiceMonitor CRDs
+		},
+		{
+			name:                 "ServiceMonitor CRD established",
+			crdName:              ServiceMonitorCRDName,
+			createCRD:            true,
+			crdEstablished:       true,
+			expectedAPIAvailable: boolPtr(true),
+		},
+		{
+			name:                 "ServiceMonitor CRD not established",
+			crdName:              ServiceMonitorCRDName,
+			createCRD:            true,
+			crdEstablished:       false,
+			expectedAPIAvailable: boolPtr(false),
+		},
+		{
+			name:                 "ServiceMonitor CRD not found",
+			crdName:              ServiceMonitorCRDName,
+			createCRD:            false,
+			expectedAPIAvailable: boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.TODO()
+
+			reconciler := setupCRDWatcherTest(t)
+
+			if tt.createCRD {
+				crd := createServiceMonitorCRD(tt.crdEstablished)
+				g.Expect(reconciler.Client.Create(ctx, crd)).To(Succeed())
+			}
+
+			req := ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name: tt.crdName,
+				},
+			}
+
+			result, err := reconciler.Reconcile(ctx, req)
+
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(ctrl.Result{}))
+
+			if tt.expectedAPIAvailable != nil {
+				g.Expect(reconciler.Registry.IsAPIAvailable()).To(Equal(*tt.expectedAPIAvailable))
+			}
+		})
+	}
+}
+
+func TestReconcileServiceMonitorCRDTransitions(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	reconciler := setupCRDWatcherTest(t)
+
+	req := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name: ServiceMonitorCRDName,
+		},
+	}
+
+	result, err := reconciler.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(reconciler.Registry.IsAPIAvailable()).To(BeFalse())
+
+	crd := createServiceMonitorCRD(true)
+	g.Expect(reconciler.Client.Create(ctx, crd)).To(Succeed())
+
+	result, err = reconciler.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(reconciler.Registry.IsAPIAvailable()).To(BeTrue())
+
+	g.Expect(reconciler.Client.Delete(ctx, crd)).To(Succeed())
+
+	result, err = reconciler.Reconcile(ctx, req)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+	g.Expect(reconciler.Registry.IsAPIAvailable()).To(BeFalse())
+}
+
+func TestIsCRDEstablished(t *testing.T) {
+	tests := []struct {
+		name        string
+		conditions  []apiextensionsv1.CustomResourceDefinitionCondition
+		established bool
+	}{
+		{
+			name: "established",
+			conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{
+					Type:   apiextensionsv1.Established,
+					Status: apiextensionsv1.ConditionTrue,
+				},
+			},
+			established: true,
+		},
+		{
+			name: "not established",
+			conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{
+					Type:   apiextensionsv1.Established,
+					Status: apiextensionsv1.ConditionFalse,
+				},
+			},
+			established: false,
+		},
+		{
+			name:        "no conditions",
+			conditions:  []apiextensionsv1.CustomResourceDefinitionCondition{},
+			established: false,
+		},
+		{
+			name: "other conditions only",
+			conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{
+					Type:   "NamesAccepted",
+					Status: apiextensionsv1.ConditionTrue,
+				},
+			},
+			established: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			crd := &apiextensionsv1.CustomResourceDefinition{
+				Status: apiextensionsv1.CustomResourceDefinitionStatus{
+					Conditions: tt.conditions,
+				},
+			}
+
+			result := isCRDEstablished(crd)
+			g.Expect(result).To(Equal(tt.established))
+		})
+	}
+}
+
+func TestServiceMonitorCRDPredicate(t *testing.T) {
+	pred := serviceMonitorCRDPredicate()
+
+	serviceMonitorCRD := createServiceMonitorCRD(true)
+	otherCRD := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "other-crd.example.com",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		testFunc func(predicate.Predicate) bool
+	}{
+		{
+			name: "CreateFunc - ServiceMonitor CRD",
+			testFunc: func(p predicate.Predicate) bool {
+				return p.Create(event.CreateEvent{Object: serviceMonitorCRD})
+			},
+		},
+		{
+			name: "CreateFunc - Other CRD",
+			testFunc: func(p predicate.Predicate) bool {
+				return !p.Create(event.CreateEvent{Object: otherCRD})
+			},
+		},
+		{
+			name: "UpdateFunc - ServiceMonitor CRD",
+			testFunc: func(p predicate.Predicate) bool {
+				return p.Update(event.UpdateEvent{ObjectNew: serviceMonitorCRD})
+			},
+		},
+		{
+			name: "UpdateFunc - Other CRD",
+			testFunc: func(p predicate.Predicate) bool {
+				return !p.Update(event.UpdateEvent{ObjectNew: otherCRD})
+			},
+		},
+		{
+			name: "DeleteFunc - ServiceMonitor CRD",
+			testFunc: func(p predicate.Predicate) bool {
+				return p.Delete(event.DeleteEvent{Object: serviceMonitorCRD})
+			},
+		},
+		{
+			name: "DeleteFunc - Other CRD",
+			testFunc: func(p predicate.Predicate) bool {
+				return !p.Delete(event.DeleteEvent{Object: otherCRD})
+			},
+		},
+		{
+			name: "GenericFunc - ServiceMonitor CRD",
+			testFunc: func(p predicate.Predicate) bool {
+				return p.Generic(event.GenericEvent{Object: serviceMonitorCRD})
+			},
+		},
+		{
+			name: "GenericFunc - Other CRD",
+			testFunc: func(p predicate.Predicate) bool {
+				return !p.Generic(event.GenericEvent{Object: otherCRD})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.testFunc(pred)
+			if !result {
+				t.Errorf("Predicate test failed for %s", tt.name)
+			}
+		})
+	}
+}
+
+// boolPtr helper for creating *bool values
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/action/monitoring/generic_action.go
+++ b/internal/action/monitoring/generic_action.go
@@ -1,0 +1,88 @@
+package monitoring
+
+import (
+	"context"
+	"maps"
+	"slices"
+
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/apis"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/labels"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MonitoringConfig holds configuration for creating a monitoring action
+type MonitoringConfig[T apis.ConditionsAwareObject] struct {
+	ComponentName         string
+	DeploymentName        string
+	MonitoringRoleName    string
+	MetricsPortName       string
+	IsMonitoringEnabled   func(T) bool
+	CustomEndpointBuilder func(instance T) []func(*unstructured.Unstructured) error
+	Registry              *ServiceMonitorRegistry
+}
+
+// NewMonitoringAction creates a generic monitoring action for any supported instance type
+func NewMonitoringAction[T apis.ConditionsAwareObject](config MonitoringConfig[T]) action.Action[T] {
+	return &genericMonitoringAction[T]{
+		config: config,
+	}
+}
+
+type genericMonitoringAction[T apis.ConditionsAwareObject] struct {
+	action.BaseAction
+	config MonitoringConfig[T]
+}
+
+func (i *genericMonitoringAction[T]) Name() string {
+	return "create monitoring"
+}
+
+func (i *genericMonitoringAction[T]) CanHandle(ctx context.Context, instance T) bool {
+	c := meta.FindStatusCondition(instance.GetConditions(), constants.Ready)
+	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && i.config.IsMonitoringEnabled(instance)
+}
+
+func (i *genericMonitoringAction[T]) Handle(ctx context.Context, instance T) *action.Result {
+	registry := i.config.Registry
+	key := client.ObjectKeyFromObject(instance)
+
+	monitoringLabels := labels.For(i.config.ComponentName, i.config.MonitoringRoleName, instance.GetName())
+
+	ensureFuncs := []func(*unstructured.Unstructured) error{
+		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
+		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
+	}
+
+	if i.config.CustomEndpointBuilder != nil {
+		ensureFuncs = append(ensureFuncs, i.config.CustomEndpointBuilder(instance)...)
+	} else {
+		ensureFuncs = append(ensureFuncs, kubernetes.EnsureServiceMonitorSpec(
+			labels.ForComponent(i.config.ComponentName, instance.GetName()),
+			kubernetes.ServiceMonitorEndpoint(i.config.MetricsPortName),
+		))
+	}
+
+	spec := &ServiceMonitorSpec{
+		OwnerKey:    key,
+		OwnerGVK:    instance.GetObjectKind().GroupVersionKind(),
+		Namespace:   instance.GetNamespace(),
+		Name:        i.config.DeploymentName,
+		EnsureFuncs: ensureFuncs,
+	}
+
+	registry.Register(ctx, spec, instance)
+
+	if err := registry.ReconcileOne(ctx, spec); err != nil {
+		i.Logger.V(1).Info("ServiceMonitor reconciliation deferred", "error", err.Error())
+	} else {
+		i.Logger.V(1).Info("ServiceMonitor reconciled successfully", "name", spec.Name)
+	}
+
+	return i.Continue()
+}

--- a/internal/action/monitoring/generic_action_test.go
+++ b/internal/action/monitoring/generic_action_test.go
@@ -1,0 +1,231 @@
+package monitoring
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestGenericMonitoringActionCanHandle(t *testing.T) {
+	tests := []struct {
+		name              string
+		reason            string
+		monitoringEnabled bool
+		expectedCanHandle bool
+	}{
+		{
+			name:              "can handle - Creating state with monitoring enabled",
+			reason:            constants.Creating,
+			monitoringEnabled: true,
+			expectedCanHandle: true,
+		},
+		{
+			name:              "can handle - Ready state with monitoring enabled",
+			reason:            constants.Ready,
+			monitoringEnabled: true,
+			expectedCanHandle: true,
+		},
+		{
+			name:              "cannot handle - Creating state with monitoring disabled",
+			reason:            constants.Creating,
+			monitoringEnabled: false,
+			expectedCanHandle: false,
+		},
+		{
+			name:              "cannot handle - Ready state with monitoring disabled",
+			reason:            constants.Ready,
+			monitoringEnabled: false,
+			expectedCanHandle: false,
+		},
+		{
+			name:              "cannot handle - other state",
+			reason:            constants.Failure,
+			monitoringEnabled: true,
+			expectedCanHandle: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.TODO()
+
+			c, recorder, logger, _, _ := setupTest(t, true)
+
+			action := createMonitoringAction(c, recorder, logger, nil, func(instance *mockInstance) bool {
+				return tt.monitoringEnabled
+			}, nil)
+
+			instance := newMockInstance("default", "test-instance")
+			instance.SetCondition(metav1.Condition{
+				Type:   constants.Ready,
+				Reason: tt.reason,
+				Status: metav1.ConditionTrue,
+			})
+
+			result := action.CanHandle(ctx, instance)
+			g.Expect(result).To(Equal(tt.expectedCanHandle))
+		})
+	}
+}
+
+func TestGenericMonitoringActionHandle(t *testing.T) {
+	tests := []struct {
+		name                         string
+		apiAvailable                 bool
+		customEndpointBuilder        func(*mockInstance) []func(*unstructured.Unstructured) error
+		instances                    []*mockInstance
+		expectedSpecCount            int
+		expectedContinue             bool
+		validateCustomEndpointCalled bool
+		customEndpointCalled         *bool
+		validateSpec                 func(*testing.T, *ServiceMonitorRegistry)
+	}{
+		{
+			name:         "basic handle",
+			apiAvailable: true,
+			instances: []*mockInstance{
+				createTestInstance("default", "test-instance"),
+			},
+			expectedSpecCount: 1,
+			expectedContinue:  true,
+			validateSpec: func(t *testing.T, registry *ServiceMonitorRegistry) {
+				g := NewWithT(t)
+				specs := registry.GetAll()
+				found := false
+				for _, spec := range specs {
+					if spec.Name == "test-deployment" && spec.Namespace == "default" {
+						found = true
+						g.Expect(spec.OwnerKey.Name).To(Equal("test-instance"))
+						g.Expect(spec.OwnerKey.Namespace).To(Equal("default"))
+						g.Expect(spec.EnsureFuncs).ToNot(BeEmpty())
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "ServiceMonitor spec should be registered")
+			},
+		},
+		{
+			name:         "handle with custom endpoint builder",
+			apiAvailable: true,
+			instances: []*mockInstance{
+				createTestInstance("default", "test-instance"),
+			},
+			customEndpointBuilder: func(instance *mockInstance) []func(*unstructured.Unstructured) error {
+				return []func(*unstructured.Unstructured) error{
+					func(u *unstructured.Unstructured) error {
+						return nil
+					},
+				}
+			},
+			expectedSpecCount:            1,
+			expectedContinue:             true,
+			validateCustomEndpointCalled: true,
+		},
+		{
+			name:         "handle with API unavailable",
+			apiAvailable: false,
+			instances: []*mockInstance{
+				createTestInstance("default", "test-instance"),
+			},
+			expectedSpecCount: 1,
+			expectedContinue:  true,
+		},
+		{
+			name:         "handle multiple instances",
+			apiAvailable: true,
+			instances: []*mockInstance{
+				createTestInstance("default", "test-instance-1"),
+				createTestInstance("other-ns", "test-instance-2"),
+			},
+			expectedSpecCount: 2,
+			expectedContinue:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.TODO()
+
+			c, recorder, logger, registry, _ := setupTest(t, tt.apiAvailable)
+
+			var monitoringAction *genericMonitoringAction[*mockInstance]
+			customEndpointBuilderCalled := false
+
+			if tt.customEndpointBuilder != nil {
+				wrappedBuilder := func(instance *mockInstance) []func(*unstructured.Unstructured) error {
+					customEndpointBuilderCalled = true
+					return tt.customEndpointBuilder(instance)
+				}
+				monitoringAction = createMonitoringAction(c, recorder, logger, registry, nil, wrappedBuilder)
+			} else {
+				monitoringAction = createMonitoringAction(c, recorder, logger, registry, nil, nil)
+			}
+
+			for _, instance := range tt.instances {
+				g.Expect(c.Create(ctx, instance.Unstructured)).To(Succeed())
+				result := monitoringAction.Handle(ctx, instance)
+				g.Expect(action.IsContinue(result)).To(Equal(tt.expectedContinue))
+			}
+
+			specs := registry.GetAll()
+			g.Expect(specs).To(HaveLen(tt.expectedSpecCount))
+
+			if tt.validateSpec != nil {
+				tt.validateSpec(t, registry)
+			}
+
+			if tt.validateCustomEndpointCalled {
+				g.Expect(customEndpointBuilderCalled).To(BeTrue())
+			}
+		})
+	}
+}
+
+func TestGenericMonitoringActionIntegration(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	c, _, _, registry, monitoringAction := setupMonitoringActionTest(t, true)
+
+	instance := newMockInstance("default", "test-instance")
+	instance.SetCondition(metav1.Condition{
+		Type:   constants.Ready,
+		Reason: constants.Creating,
+		Status: metav1.ConditionTrue,
+	})
+
+	g.Expect(c.Create(ctx, instance.Unstructured)).To(Succeed())
+
+	g.Expect(monitoringAction.CanHandle(ctx, instance)).To(BeTrue())
+
+	result := monitoringAction.Handle(ctx, instance)
+	g.Expect(action.IsContinue(result)).To(BeTrue())
+
+	specs := registry.GetAll()
+	g.Expect(specs).To(HaveLen(1))
+
+	spec := specs[0]
+	g.Expect(spec.Name).To(Equal("test-deployment"))
+	g.Expect(spec.Namespace).To(Equal("default"))
+	g.Expect(spec.OwnerKey.Name).To(Equal("test-instance"))
+	g.Expect(spec.OwnerKey.Namespace).To(Equal("default"))
+	g.Expect(spec.EnsureFuncs).ToNot(BeEmpty())
+}
+
+// createTestInstance is a helper to create a test instance with default conditions
+func createTestInstance(namespace, name string) *mockInstance {
+	instance := newMockInstance(namespace, name)
+	instance.SetCondition(metav1.Condition{
+		Type:   constants.Ready,
+		Reason: constants.Creating,
+		Status: metav1.ConditionTrue,
+	})
+	return instance
+}

--- a/internal/action/monitoring/registry.go
+++ b/internal/action/monitoring/registry.go
@@ -1,0 +1,243 @@
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// ServiceMonitorSpec holds the specification for creating a ServiceMonitor
+type ServiceMonitorSpec struct {
+	// Owner is the object that owns this ServiceMonitor
+	OwnerKey types.NamespacedName
+	// OwnerGVK is the GroupVersionKind of the owner
+	OwnerGVK schema.GroupVersionKind
+	// Namespace where the ServiceMonitor should be created
+	Namespace string
+	// Name of the ServiceMonitor
+	Name string
+	// EnsureFuncs are the functions to apply to the ServiceMonitor
+	EnsureFuncs []func(*unstructured.Unstructured) error
+}
+
+// ownerKey uniquely identifies an owner by namespace, name, and GVK
+type ownerKey struct {
+	types.NamespacedName
+	GVK schema.GroupVersionKind
+}
+
+// ServiceMonitorRegistry manages registered ServiceMonitor specifications
+type ServiceMonitorRegistry struct {
+	mutex          sync.RWMutex
+	specs          map[types.NamespacedName]*ServiceMonitorSpec
+	notifiedOwners map[ownerKey]*ServiceMonitorSpec
+	client         client.Client
+	recorder       record.EventRecorder
+	logger         logr.Logger
+	apiAvailable   bool
+}
+
+// NewRegistry creates a new ServiceMonitorRegistry instance
+func NewRegistry(client client.Client, recorder record.EventRecorder, logger logr.Logger) *ServiceMonitorRegistry {
+	return &ServiceMonitorRegistry{
+		specs:          make(map[types.NamespacedName]*ServiceMonitorSpec),
+		notifiedOwners: make(map[ownerKey]*ServiceMonitorSpec),
+		client:         client,
+		recorder:       recorder,
+		logger:         logger,
+	}
+}
+
+// Register adds or updates a ServiceMonitor specification in the registry
+func (r *ServiceMonitorRegistry) Register(ctx context.Context, spec *ServiceMonitorSpec, owner client.Object) {
+	isNewOwner, apiAvailable := r.registerSpec(spec)
+
+	if isNewOwner {
+		if apiAvailable {
+			r.recorder.Event(owner, "Normal", "ServiceMonitorAPIAvailable", "ServiceMonitor API is available")
+		} else {
+			r.recorder.Event(owner, "Warning", "ServiceMonitorAPIUnavailable", "ServiceMonitor API is not available")
+		}
+	}
+}
+
+// registerSpec adds or updates a ServiceMonitor specification in the registry (internal, holds lock)
+func (r *ServiceMonitorRegistry) registerSpec(spec *ServiceMonitorSpec) (isNewOwner bool, apiAvailable bool) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	key := types.NamespacedName{Namespace: spec.Namespace, Name: spec.Name}
+	existing, exists := r.specs[key]
+
+	newOwnerKey := ownerKey{NamespacedName: spec.OwnerKey, GVK: spec.OwnerGVK}
+	isNewOwner = r.notifiedOwners[newOwnerKey] == nil
+
+	r.specs[key] = spec
+
+	if !exists {
+		r.logger.Info("Registered ServiceMonitor spec", "owner", spec.OwnerKey, "ownerGVK", spec.OwnerGVK, "namespace", spec.Namespace, "name", spec.Name)
+	} else {
+		ownerChanged := existing.OwnerGVK.String() != spec.OwnerGVK.String() ||
+			existing.OwnerKey != spec.OwnerKey
+		changed := ownerChanged || len(existing.EnsureFuncs) != len(spec.EnsureFuncs)
+
+		if ownerChanged {
+			oldKey := ownerKey{NamespacedName: existing.OwnerKey, GVK: existing.OwnerGVK}
+			delete(r.notifiedOwners, oldKey)
+			r.logger.Info("Removed old owner from notification tracking", "oldOwner", existing.OwnerKey, "oldOwnerGVK", existing.OwnerGVK)
+
+			isNewOwner = true
+		}
+
+		if changed {
+			r.logger.Info("Updated ServiceMonitor spec", "owner", spec.OwnerKey, "ownerGVK", spec.OwnerGVK, "namespace", spec.Namespace, "name", spec.Name)
+		}
+	}
+
+	if isNewOwner {
+		r.notifiedOwners[newOwnerKey] = spec
+	}
+
+	apiAvailable = r.apiAvailable
+	return isNewOwner, apiAvailable
+}
+
+// cleanupOwner removes all specs for an owner and clears it from notifiedOwners
+func (r *ServiceMonitorRegistry) cleanupOwner(spec *ServiceMonitorSpec) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	specKey := types.NamespacedName{Namespace: spec.Namespace, Name: spec.Name}
+	delete(r.specs, specKey)
+	r.logger.V(1).Info("Removed ServiceMonitor spec for deleted owner", "owner", spec.OwnerKey, "ownerGVK", spec.OwnerGVK, "namespace", spec.Namespace, "name", spec.Name)
+
+	ownerKey := ownerKey{NamespacedName: spec.OwnerKey, GVK: spec.OwnerGVK}
+	delete(r.notifiedOwners, ownerKey)
+	r.logger.V(1).Info("Cleared notification tracking for deleted owner", "owner", spec.OwnerKey, "ownerGVK", spec.OwnerGVK)
+}
+
+// GetAll returns all registered ServiceMonitor specifications
+func (r *ServiceMonitorRegistry) GetAll() []*ServiceMonitorSpec {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	specs := make([]*ServiceMonitorSpec, 0, len(r.specs))
+	for _, spec := range r.specs {
+		specs = append(specs, spec)
+	}
+	return specs
+}
+
+// SetAPIAvailable sets whether the ServiceMonitor API is available
+func (r *ServiceMonitorRegistry) SetAPIAvailable(available bool) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.apiAvailable = available
+	r.logger.Info("ServiceMonitor API availability updated", "available", available)
+}
+
+// IsAPIAvailable returns whether we should attempt to reconcile ServiceMonitors
+func (r *ServiceMonitorRegistry) IsAPIAvailable() bool {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	return r.apiAvailable
+}
+
+// EmitEventToOwners emits an event to all unique owner objects that have registered ServiceMonitors
+func (r *ServiceMonitorRegistry) EmitEventToOwners(ctx context.Context, eventType, reason, message string) {
+	r.mutex.RLock()
+	specsToNotify := make([]*ServiceMonitorSpec, 0, len(r.notifiedOwners))
+	for _, spec := range r.notifiedOwners {
+		specsToNotify = append(specsToNotify, spec)
+	}
+	r.mutex.RUnlock()
+
+	for _, spec := range specsToNotify {
+		r.emitEventToOwner(ctx, spec, eventType, reason, message)
+	}
+}
+
+// ReconcileAll creates or updates all registered ServiceMonitors
+func (r *ServiceMonitorRegistry) ReconcileAll(ctx context.Context) error {
+	specs := r.GetAll()
+
+	r.logger.Info("Reconciling all ServiceMonitors", "count", len(specs))
+
+	if !r.IsAPIAvailable() {
+		return fmt.Errorf("ServiceMonitor API not available")
+	}
+
+	var errs []error
+	for _, spec := range specs {
+		if err := r.ReconcileOne(ctx, spec); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to reconcile %d ServiceMonitors: %v", len(errs), errs)
+	}
+
+	return nil
+}
+
+// getOwnerObject retrieves the owner object for a ServiceMonitor spec
+func (r *ServiceMonitorRegistry) getOwnerObject(ctx context.Context, spec *ServiceMonitorSpec) (client.Object, error) {
+	owner := &unstructured.Unstructured{}
+	owner.SetGroupVersionKind(spec.OwnerGVK)
+
+	if err := r.client.Get(ctx, spec.OwnerKey, owner); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			r.logger.Info("Owner not found, cleaning up registry", "owner", spec.OwnerKey)
+			r.cleanupOwner(spec)
+		}
+		return nil, fmt.Errorf("failed to get owner object: %w", err)
+	}
+
+	return owner, nil
+}
+
+// emitEventToOwner emits an event to the owner object of a ServiceMonitor spec
+func (r *ServiceMonitorRegistry) emitEventToOwner(ctx context.Context, spec *ServiceMonitorSpec, eventType, reason, message string) {
+	owner, err := r.getOwnerObject(ctx, spec)
+	if err == nil {
+		r.recorder.Event(owner, eventType, reason, message)
+	} else {
+		r.logger.Info("Failed to get owner for event emission", "owner", spec.OwnerKey, "ownerGVK", spec.OwnerGVK, "error", err.Error())
+	}
+}
+
+// ReconcileOne creates or updates a single ServiceMonitor
+func (r *ServiceMonitorRegistry) ReconcileOne(ctx context.Context, spec *ServiceMonitorSpec) error {
+	if !r.IsAPIAvailable() {
+		return fmt.Errorf("ServiceMonitor API not available")
+	}
+
+	serviceMonitor := kubernetes.CreateServiceMonitor(spec.Namespace, spec.Name)
+
+	result, err := kubernetes.CreateOrUpdate(ctx, r.client, serviceMonitor, spec.EnsureFuncs...)
+	if err != nil {
+		r.logger.Error(err, "Failed to reconcile ServiceMonitor", "namespace", spec.Namespace, "name", spec.Name)
+		r.emitEventToOwner(ctx, spec, "Warning", "ServiceMonitorReconcileFailed",
+			fmt.Sprintf("Failed to reconcile ServiceMonitor %s/%s: %v", spec.Namespace, spec.Name, err))
+		return fmt.Errorf("failed to reconcile ServiceMonitor: %w", err)
+	}
+
+	if result != controllerutil.OperationResultNone {
+		r.logger.Info("Reconciled ServiceMonitor", "namespace", spec.Namespace, "name", spec.Name, "operation", result)
+		r.emitEventToOwner(ctx, spec, "Normal", "ServiceMonitorReconciled",
+			fmt.Sprintf("ServiceMonitor %s/%s %s", spec.Namespace, spec.Name, result))
+	}
+
+	return nil
+}

--- a/internal/action/monitoring/registry_test.go
+++ b/internal/action/monitoring/registry_test.go
@@ -1,0 +1,472 @@
+package monitoring
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewRegistry(t *testing.T) {
+	g := NewWithT(t)
+
+	c, recorder, _, registry, _ := setupTest(t, false)
+
+	g.Expect(registry).ToNot(BeNil())
+	g.Expect(registry.specs).ToNot(BeNil())
+	g.Expect(registry.notifiedOwners).ToNot(BeNil())
+	g.Expect(registry.client).To(Equal(c))
+	g.Expect(registry.recorder).To(Equal(recorder))
+	g.Expect(registry.apiAvailable).To(BeFalse())
+}
+
+func TestRegister(t *testing.T) {
+	tests := []struct {
+		name          string
+		apiAvailable  bool
+		expectedEvent string
+		isNewOwner    bool
+	}{
+		{
+			name:          "register with API available",
+			apiAvailable:  true,
+			expectedEvent: "ServiceMonitorAPIAvailable",
+			isNewOwner:    true,
+		},
+		{
+			name:          "register with API unavailable",
+			apiAvailable:  false,
+			expectedEvent: "ServiceMonitorAPIUnavailable",
+			isNewOwner:    true,
+		},
+		{
+			name:          "register existing owner",
+			apiAvailable:  true,
+			expectedEvent: "",
+			isNewOwner:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.TODO()
+
+			c, registry := setupRegistryTest(t)
+			registry.SetAPIAvailable(tt.apiAvailable)
+
+			spec := createTestSpec("default", "test-monitor")
+
+			owner := createOwnerFromSpec(spec)
+
+			g.Expect(c.Create(ctx, owner)).To(Succeed())
+
+			registry.Register(ctx, spec, owner)
+
+			g.Expect(registry.specs).To(HaveKey(types.NamespacedName{
+				Namespace: spec.Namespace,
+				Name:      spec.Name,
+			}))
+
+			if !tt.isNewOwner {
+				registry.Register(ctx, spec, owner)
+			}
+		})
+	}
+}
+
+func TestRegisterSpec(t *testing.T) {
+	tests := []struct {
+		name                  string
+		apiAvailable          bool
+		registerTwice         bool
+		expectedIsNewOwner    bool
+		expectedAPIAvailable  bool
+		expectedSpecCount     int
+		expectedNotifiedCount int
+	}{
+		{
+			name:                  "new owner with API available",
+			apiAvailable:          true,
+			registerTwice:         false,
+			expectedIsNewOwner:    true,
+			expectedAPIAvailable:  true,
+			expectedSpecCount:     1,
+			expectedNotifiedCount: 1,
+		},
+		{
+			name:                  "new owner with API unavailable",
+			apiAvailable:          false,
+			registerTwice:         false,
+			expectedIsNewOwner:    true,
+			expectedAPIAvailable:  false,
+			expectedSpecCount:     1,
+			expectedNotifiedCount: 1,
+		},
+		{
+			name:                  "existing owner with API available",
+			apiAvailable:          true,
+			registerTwice:         true,
+			expectedIsNewOwner:    false,
+			expectedAPIAvailable:  true,
+			expectedSpecCount:     1,
+			expectedNotifiedCount: 1,
+		},
+		{
+			name:                  "existing owner with API unavailable",
+			apiAvailable:          false,
+			registerTwice:         true,
+			expectedIsNewOwner:    false,
+			expectedAPIAvailable:  false,
+			expectedSpecCount:     1,
+			expectedNotifiedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			_, registry := setupRegistryTest(t)
+			registry.SetAPIAvailable(tt.apiAvailable)
+
+			spec := createTestSpec("default", "test-monitor")
+
+			if tt.registerTwice {
+				registry.registerSpec(spec)
+			}
+
+			isNewOwner, apiAvailable := registry.registerSpec(spec)
+
+			g.Expect(isNewOwner).To(Equal(tt.expectedIsNewOwner))
+			g.Expect(apiAvailable).To(Equal(tt.expectedAPIAvailable))
+			g.Expect(registry.specs).To(HaveLen(tt.expectedSpecCount))
+			g.Expect(registry.notifiedOwners).To(HaveLen(tt.expectedNotifiedCount))
+		})
+	}
+}
+
+func TestRegisterSpecOwnerChange(t *testing.T) {
+	g := NewWithT(t)
+
+	_, registry := setupRegistryTest(t)
+
+	spec1 := createTestSpec("default", "test-monitor")
+
+	isNewOwner, _ := registry.registerSpec(spec1)
+	g.Expect(isNewOwner).To(BeTrue())
+	g.Expect(registry.notifiedOwners).To(HaveLen(1))
+
+	spec2 := createTestSpec("default", "test-monitor")
+	spec2.OwnerKey.Name = "differentowner"
+
+	isNewOwner, _ = registry.registerSpec(spec2)
+
+	g.Expect(isNewOwner).To(BeTrue())
+	g.Expect(registry.specs).To(HaveLen(1))
+	g.Expect(registry.notifiedOwners).To(HaveLen(1))
+}
+
+func TestGetAll(t *testing.T) {
+	g := NewWithT(t)
+
+	_, registry := setupRegistryTest(t)
+
+	spec1 := createTestSpec("default", "monitor-1")
+	spec2 := createTestSpec("default", "monitor-2")
+	spec3 := createTestSpec("other-ns", "monitor-3")
+
+	registry.registerSpec(spec1)
+	registry.registerSpec(spec2)
+	registry.registerSpec(spec3)
+
+	specs := registry.GetAll()
+
+	g.Expect(specs).To(HaveLen(3))
+}
+
+func TestSetAPIAvailable(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialState  bool
+		setValue      bool
+		expectedValue bool
+	}{
+		{
+			name:          "set to true from initial false",
+			initialState:  false,
+			setValue:      true,
+			expectedValue: true,
+		},
+		{
+			name:          "set to false from true",
+			initialState:  true,
+			setValue:      false,
+			expectedValue: false,
+		},
+		{
+			name:          "set to true when already true",
+			initialState:  true,
+			setValue:      true,
+			expectedValue: true,
+		},
+		{
+			name:          "set to false when already false",
+			initialState:  false,
+			setValue:      false,
+			expectedValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			_, registry := setupRegistryTest(t)
+
+			if tt.initialState {
+				registry.SetAPIAvailable(true)
+			}
+
+			registry.SetAPIAvailable(tt.setValue)
+			g.Expect(registry.IsAPIAvailable()).To(Equal(tt.expectedValue))
+		})
+	}
+}
+
+func TestReconcileAPIUnavailable(t *testing.T) {
+	tests := []struct {
+		name         string
+		reconcileAll bool
+		registerSpec bool
+	}{
+		{
+			name:         "ReconcileAll with API unavailable",
+			reconcileAll: true,
+			registerSpec: true,
+		},
+		{
+			name:         "ReconcileOne with API unavailable",
+			reconcileAll: false,
+			registerSpec: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.TODO()
+
+			_, registry := setupRegistryTest(t)
+			registry.SetAPIAvailable(false)
+
+			spec := createTestSpec("default", "test-monitor")
+
+			if tt.registerSpec {
+				registry.registerSpec(spec)
+			}
+
+			var err error
+			if tt.reconcileAll {
+				err = registry.ReconcileAll(ctx)
+			} else {
+				err = registry.ReconcileOne(ctx, spec)
+			}
+
+			g.Expect(err).To(HaveOccurred())
+			g.Expect(err.Error()).To(ContainSubstring("ServiceMonitor API not available"))
+		})
+	}
+}
+
+func TestGetOwnerObject(t *testing.T) {
+	tests := []struct {
+		name          string
+		createOwner   bool
+		registerSpec  bool
+		expectError   bool
+		expectCleanup bool
+	}{
+		{
+			name:          "owner exists",
+			createOwner:   true,
+			registerSpec:  false,
+			expectError:   false,
+			expectCleanup: false,
+		},
+		{
+			name:          "owner not found triggers cleanup",
+			createOwner:   false,
+			registerSpec:  true,
+			expectError:   true,
+			expectCleanup: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.TODO()
+
+			c, registry := setupRegistryTest(t)
+
+			spec := createTestSpec("default", "test-monitor")
+
+			if tt.createOwner {
+				owner := createOwnerFromSpec(spec)
+				g.Expect(c.Create(ctx, owner)).To(Succeed())
+			}
+
+			if tt.registerSpec {
+				registry.registerSpec(spec)
+			}
+
+			retrievedOwner, err := registry.getOwnerObject(ctx, spec)
+
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(retrievedOwner).To(BeNil())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(retrievedOwner).ToNot(BeNil())
+				g.Expect(retrievedOwner.GetName()).To(Equal(spec.OwnerKey.Name))
+				g.Expect(retrievedOwner.GetNamespace()).To(Equal(spec.OwnerKey.Namespace))
+			}
+
+			if tt.expectCleanup {
+				g.Expect(registry.specs).To(BeEmpty())
+				g.Expect(registry.notifiedOwners).To(BeEmpty())
+			}
+		})
+	}
+}
+
+func TestCleanupOwner(t *testing.T) {
+	g := NewWithT(t)
+
+	_, registry := setupRegistryTest(t)
+
+	spec := createTestSpec("default", "test-monitor")
+
+	registry.registerSpec(spec)
+
+	g.Expect(registry.specs).To(HaveLen(1))
+	g.Expect(registry.notifiedOwners).To(HaveLen(1))
+
+	registry.cleanupOwner(spec)
+
+	g.Expect(registry.specs).To(BeEmpty())
+	g.Expect(registry.notifiedOwners).To(BeEmpty())
+}
+
+func TestEmitEventToOwners(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	c, recorder, _, registry, _ := setupTest(t, false)
+
+	spec1 := createTestSpec("default", "monitor-1")
+	spec2 := createTestSpec("default", "monitor-2")
+	spec2.OwnerKey.Name = "test-owner-2"
+
+	owner1 := createOwnerFromSpec(spec1)
+
+	owner2 := createOwnerFromSpec(spec2)
+
+	g.Expect(c.Create(ctx, owner1)).To(Succeed())
+	g.Expect(c.Create(ctx, owner2)).To(Succeed())
+
+	registry.registerSpec(spec1)
+	registry.registerSpec(spec2)
+
+	registry.EmitEventToOwners(ctx, "Normal", "TestReason", "Test message")
+
+	events := recorder.Events
+	g.Expect(events).To(HaveLen(2), "Should emit events to both owners")
+
+	for range 2 {
+		event := <-events
+		g.Expect(event).To(ContainSubstring("TestReason"))
+		g.Expect(event).To(ContainSubstring("Test message"))
+	}
+}
+
+func TestReconcileAllWithServiceMonitors(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	c, registry := setupRegistryTest(t)
+	registry.SetAPIAvailable(true)
+
+	serviceMonitorGVK := schema.GroupVersionKind{
+		Group:   "monitoring.coreos.com",
+		Version: "v1",
+		Kind:    "ServiceMonitor",
+	}
+
+	sm := &unstructured.Unstructured{}
+	sm.SetGroupVersionKind(serviceMonitorGVK)
+	sm.SetNamespace("default")
+	sm.SetName("existing-monitor")
+
+	g.Expect(c.Create(ctx, sm)).To(Succeed())
+
+	spec := createTestSpec("default", "test-monitor")
+	owner := createOwnerFromSpec(spec)
+
+	g.Expect(c.Create(ctx, owner)).To(Succeed())
+
+	spec.EnsureFuncs = []func(*unstructured.Unstructured) error{
+		func(u *unstructured.Unstructured) error {
+			u.SetOwnerReferences([]metav1.OwnerReference{
+				{
+					APIVersion: spec.OwnerGVK.GroupVersion().String(),
+					Kind:       spec.OwnerGVK.Kind,
+					Name:       owner.GetName(),
+					UID:        owner.GetUID(),
+				},
+			})
+			return nil
+		},
+	}
+
+	registry.registerSpec(spec)
+
+	err := registry.ReconcileAll(ctx)
+
+	g.Expect(err).ToNot(HaveOccurred())
+
+	retrievedSM := &unstructured.Unstructured{}
+	retrievedSM.SetGroupVersionKind(serviceMonitorGVK)
+
+	err = c.Get(ctx, types.NamespacedName{
+		Namespace: spec.Namespace,
+		Name:      spec.Name,
+	}, retrievedSM)
+
+	g.Expect(err).ToNot(HaveOccurred(), "ServiceMonitor should be created")
+	g.Expect(retrievedSM.GetName()).To(Equal(spec.Name))
+	g.Expect(retrievedSM.GetNamespace()).To(Equal(spec.Namespace))
+
+	ownerRefs := retrievedSM.GetOwnerReferences()
+	g.Expect(ownerRefs).To(HaveLen(1), "ServiceMonitor should have one owner reference")
+	g.Expect(ownerRefs[0].APIVersion).To(Equal(spec.OwnerGVK.GroupVersion().String()))
+	g.Expect(ownerRefs[0].Kind).To(Equal(spec.OwnerGVK.Kind))
+	g.Expect(ownerRefs[0].Name).To(Equal(owner.GetName()))
+	g.Expect(ownerRefs[0].UID).To(Equal(owner.GetUID()))
+
+	existingSM := &unstructured.Unstructured{}
+	existingSM.SetGroupVersionKind(serviceMonitorGVK)
+	err = c.Get(ctx, types.NamespacedName{
+		Namespace: "default",
+		Name:      "existing-monitor",
+	}, existingSM)
+	g.Expect(err).ToNot(HaveOccurred(), "Existing ServiceMonitor should still exist")
+
+	g.Expect(registry.specs).To(HaveLen(1), "Registry should still contain the registered spec")
+}

--- a/internal/action/monitoring/test_helpers.go
+++ b/internal/action/monitoring/test_helpers.go
@@ -1,0 +1,202 @@
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// setupTest provides common test setup for all monitoring tests
+func setupTest(_ *testing.T, apiAvailable bool, schemeAdders ...func(*runtime.Scheme) error) (client.Client, *record.FakeRecorder, logr.Logger, *ServiceMonitorRegistry, *runtime.Scheme) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+
+	for _, adder := range schemeAdders {
+		utilruntime.Must(adder(scheme))
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	recorder := record.NewFakeRecorder(100)
+	logger := logr.Discard()
+
+	registry := NewRegistry(c, recorder, logger)
+	if apiAvailable {
+		registry.SetAPIAvailable(true)
+	}
+
+	return c, recorder, logger, registry, scheme
+}
+
+// createTestSpec creates a ServiceMonitorSpec for testing purposes
+func createTestSpec(namespace, name string) *ServiceMonitorSpec {
+	return &ServiceMonitorSpec{
+		OwnerKey: types.NamespacedName{
+			Namespace: namespace,
+			Name:      "test-owner",
+		},
+		OwnerGVK: schema.GroupVersionKind{
+			Group:   "test.io",
+			Version: "v1",
+			Kind:    "TestResource",
+		},
+		Namespace: namespace,
+		Name:      name,
+		EnsureFuncs: []func(*unstructured.Unstructured) error{
+			func(u *unstructured.Unstructured) error {
+				return nil
+			},
+		},
+	}
+}
+
+// createOwnerFromSpec creates a test owner object from a ServiceMonitorSpec
+func createOwnerFromSpec(spec *ServiceMonitorSpec) *unstructured.Unstructured {
+	owner := &unstructured.Unstructured{}
+	owner.SetGroupVersionKind(spec.OwnerGVK)
+	owner.SetNamespace(spec.OwnerKey.Namespace)
+	owner.SetName(spec.OwnerKey.Name)
+	owner.SetUID("test-uid")
+	return owner
+}
+
+// mockInstance is a test implementation of ConditionsAwareObject
+type mockInstance struct {
+	*unstructured.Unstructured
+	conditions []metav1.Condition
+}
+
+func (m *mockInstance) GetConditions() []metav1.Condition {
+	return m.conditions
+}
+
+func (m *mockInstance) SetCondition(condition metav1.Condition) {
+	meta.SetStatusCondition(&m.conditions, condition)
+}
+
+// newMockInstance creates a new mockInstance for testing
+func newMockInstance(namespace, name string) *mockInstance {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "test.io",
+		Version: "v1",
+		Kind:    "MockResource",
+	})
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	u.SetUID(types.UID("test-uid"))
+
+	return &mockInstance{
+		Unstructured: u,
+		conditions:   []metav1.Condition{},
+	}
+}
+
+// createMonitoringAction creates a configured monitoring action with dependencies injected
+func createMonitoringAction(
+	c client.Client,
+	recorder *record.FakeRecorder,
+	logger logr.Logger,
+	registry *ServiceMonitorRegistry,
+	isMonitoringEnabled func(*mockInstance) bool,
+	customEndpointBuilder func(*mockInstance) []func(*unstructured.Unstructured) error,
+) *genericMonitoringAction[*mockInstance] {
+	config := MonitoringConfig[*mockInstance]{
+		ComponentName:      "test-component",
+		DeploymentName:     "test-deployment",
+		MonitoringRoleName: "test-role",
+		MetricsPortName:    "metrics",
+		Registry:           registry,
+		IsMonitoringEnabled: func(instance *mockInstance) bool {
+			if isMonitoringEnabled != nil {
+				return isMonitoringEnabled(instance)
+			}
+			return true
+		},
+		CustomEndpointBuilder: customEndpointBuilder,
+	}
+
+	action := NewMonitoringAction(config).(*genericMonitoringAction[*mockInstance])
+	action.InjectClient(c)
+	action.InjectLogger(logger)
+	action.InjectRecorder(recorder)
+
+	return action
+}
+
+// setupRegistryTest provides simplified setup for registry tests
+func setupRegistryTest(t *testing.T) (client.Client, *ServiceMonitorRegistry) {
+	c, _, _, registry, _ := setupTest(t, false)
+	return c, registry
+}
+
+// createServiceMonitorCRD creates a test ServiceMonitor CRD for testing
+func createServiceMonitorCRD(established bool) *apiextensionsv1.CustomResourceDefinition {
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: ServiceMonitorCRDName,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "monitoring.coreos.com",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "ServiceMonitor",
+				ListKind: "ServiceMonitorList",
+				Plural:   "servicemonitors",
+				Singular: "servicemonitor",
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+
+	if established {
+		crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{
+			{
+				Type:   apiextensionsv1.Established,
+				Status: apiextensionsv1.ConditionTrue,
+			},
+		}
+	}
+
+	return crd
+}
+
+// setupCRDWatcherTest provides setup for CRD watcher tests
+func setupCRDWatcherTest(t *testing.T) *CRDWatcherReconciler {
+	g := NewWithT(t)
+
+	c, _, _, registry, scheme := setupTest(t, false, apiextensionsv1.AddToScheme)
+
+	reconciler, err := NewCRDWatcher(c, scheme, registry)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(reconciler).ToNot(BeNil())
+
+	return reconciler
+}
+
+// setupMonitoringActionTest combines setupTest and createMonitoringAction for common test setup
+func setupMonitoringActionTest(t *testing.T, apiAvailable bool) (client.Client, *record.FakeRecorder, logr.Logger, *ServiceMonitorRegistry, *genericMonitoringAction[*mockInstance]) {
+	c, recorder, logger, registry, _ := setupTest(t, apiAvailable)
+	action := createMonitoringAction(c, recorder, logger, registry, nil, nil)
+	return c, recorder, logger, registry, action
+}

--- a/internal/controller/ctlog/actions/monitoring.go
+++ b/internal/controller/ctlog/actions/monitoring.go
@@ -1,56 +1,20 @@
 package actions
 
 import (
-	"context"
-	"fmt"
-	"maps"
-	"slices"
-
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
-	"github.com/securesign/operator/internal/labels"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/securesign/operator/internal/action/monitoring"
 )
 
-func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.CTlog] {
-	return &monitoringAction{}
-}
-
-type monitoringAction struct {
-	action.BaseAction
-}
-
-func (i monitoringAction) Name() string {
-	return "create monitoring"
-}
-
-func (i monitoringAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.CTlog) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && instance.Spec.Monitoring.Enabled
-}
-
-func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *action.Result {
-	var (
-		err error
-	)
-
-	monitoringLabels := labels.For(ComponentName, MonitoringRoleName, instance.Name)
-
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
-		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
-		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(
-			labels.ForComponent(ComponentName, instance.Name),
-			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
-		),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
-	}
-
-	// monitors & RBAC are not watched - do not need to re-enqueue
-	return i.Continue()
+func NewCreateMonitorAction(registry *monitoring.ServiceMonitorRegistry) action.Action[*rhtasv1alpha1.CTlog] {
+	return monitoring.NewMonitoringAction(monitoring.MonitoringConfig[*rhtasv1alpha1.CTlog]{
+		ComponentName:      ComponentName,
+		DeploymentName:     DeploymentName,
+		MonitoringRoleName: MonitoringRoleName,
+		MetricsPortName:    MetricsPortName,
+		IsMonitoringEnabled: func(instance *rhtasv1alpha1.CTlog) bool {
+			return instance.Spec.Monitoring.Enabled
+		},
+		Registry: registry,
+	})
 }

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -21,6 +21,7 @@ import (
 
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
@@ -50,15 +51,17 @@ import (
 // ctlogReconciler reconciles a CTlog object
 type ctlogReconciler struct {
 	client.Client
-	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	scheme             *runtime.Scheme
+	recorder           record.EventRecorder
+	monitoringRegistry *monitoring.ServiceMonitorRegistry
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, monitoringRegistry *monitoring.ServiceMonitorRegistry) controller.Controller {
 	return &ctlogReconciler{
-		Client:   c,
-		scheme:   scheme,
-		recorder: recorder,
+		Client:             c,
+		scheme:             scheme,
+		recorder:           recorder,
+		monitoringRegistry: monitoringRegistry,
 	}
 }
 
@@ -114,7 +117,7 @@ func (r *ctlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		actions.NewRBACAction(),
 		actions.NewDeployAction(),
 		actions.NewServiceAction(),
-		actions.NewCreateMonitorAction(),
+		actions.NewCreateMonitorAction(r.monitoringRegistry),
 
 		transitions.NewToInitializePhaseAction[*rhtasv1alpha1.CTlog](),
 

--- a/internal/controller/fulcio/actions/monitoring.go
+++ b/internal/controller/fulcio/actions/monitoring.go
@@ -1,56 +1,20 @@
 package actions
 
 import (
-	"context"
-	"fmt"
-	"maps"
-	"slices"
-
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
-	"github.com/securesign/operator/internal/labels"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/securesign/operator/internal/action/monitoring"
 )
 
-func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Fulcio] {
-	return &monitoringAction{}
-}
-
-type monitoringAction struct {
-	action.BaseAction
-}
-
-func (i monitoringAction) Name() string {
-	return "create monitoring"
-}
-
-func (i monitoringAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Fulcio) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && instance.Spec.Monitoring.Enabled
-}
-
-func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulcio) *action.Result {
-	var (
-		err error
-	)
-
-	monitoringLabels := labels.For(ComponentName, MonitoringRoleName, instance.Name)
-
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
-		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
-		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(
-			labels.ForComponent(ComponentName, instance.Name),
-			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
-		),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
-	}
-
-	// monitors & RBAC are not watched - do not need to re-enqueue
-	return i.Continue()
+func NewCreateMonitorAction(registry *monitoring.ServiceMonitorRegistry) action.Action[*rhtasv1alpha1.Fulcio] {
+	return monitoring.NewMonitoringAction(monitoring.MonitoringConfig[*rhtasv1alpha1.Fulcio]{
+		ComponentName:      ComponentName,
+		DeploymentName:     DeploymentName,
+		MonitoringRoleName: MonitoringRoleName,
+		MetricsPortName:    MetricsPortName,
+		IsMonitoringEnabled: func(instance *rhtasv1alpha1.Fulcio) bool {
+			return instance.Spec.Monitoring.Enabled
+		},
+		Registry: registry,
+	})
 }

--- a/internal/controller/fulcio/fulcio_controller.go
+++ b/internal/controller/fulcio/fulcio_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
@@ -44,15 +45,17 @@ import (
 // fulcioReconciler reconciles a Fulcio object
 type fulcioReconciler struct {
 	client.Client
-	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	scheme             *runtime.Scheme
+	recorder           record.EventRecorder
+	monitoringRegistry *monitoring.ServiceMonitorRegistry
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, monitoringRegistry *monitoring.ServiceMonitorRegistry) controller.Controller {
 	return &fulcioReconciler{
-		Client:   c,
-		scheme:   scheme,
-		recorder: recorder,
+		Client:             c,
+		scheme:             scheme,
+		recorder:           recorder,
+		monitoringRegistry: monitoringRegistry,
 	}
 }
 
@@ -100,7 +103,7 @@ func (r *fulcioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		actions.NewRBACAction(),
 		actions.NewServerConfigAction(),
 		actions.NewDeployAction(),
-		actions.NewCreateMonitorAction(),
+		actions.NewCreateMonitorAction(r.monitoringRegistry),
 		actions.NewServiceAction(),
 		actions.NewIngressAction(),
 		actions.NewStatusUrlAction(),

--- a/internal/controller/rekor/actions/monitor/monitoring.go
+++ b/internal/controller/rekor/actions/monitor/monitoring.go
@@ -1,63 +1,19 @@
 package monitor
 
 import (
-	"context"
-	"fmt"
-	"maps"
-	"slices"
-
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/controller/rekor/actions"
-	"github.com/securesign/operator/internal/labels"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Rekor] {
-	return &monitoringAction{}
-}
-
-type monitoringAction struct {
-	action.BaseAction
-}
-
-func (i monitoringAction) Name() string {
-	return "create monitoring"
-}
-
-func (i monitoringAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Rekor) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && enabled(instance)
-}
-
-func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor) *action.Result {
-	var (
-		err error
-	)
-
-	monitoringLabels := labels.For(actions.MonitorComponentName, actions.MonitoringRoleName, instance.Name)
-
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.MonitorStatefulSetName),
-		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
-		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(
-			labels.ForComponent(actions.MonitorComponentName, instance.Name),
-			kubernetes.ServiceMonitorEndpoint(actions.MonitorMetricsPortName),
-		),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance, metav1.Condition{
-			Type:    actions.MonitorCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
-		})
-	}
-
-	// monitors & RBAC are not watched - do not need to re-enqueue
-	return i.Continue()
+func NewCreateMonitorAction(registry *monitoring.ServiceMonitorRegistry) action.Action[*rhtasv1alpha1.Rekor] {
+	return monitoring.NewMonitoringAction(monitoring.MonitoringConfig[*rhtasv1alpha1.Rekor]{
+		ComponentName:       actions.MonitorComponentName,
+		DeploymentName:      actions.MonitorStatefulSetName,
+		MonitoringRoleName:  actions.MonitoringRoleName,
+		MetricsPortName:     actions.MonitorMetricsPortName,
+		IsMonitoringEnabled: enabled,
+		Registry:            registry,
+	})
 }

--- a/internal/controller/rekor/actions/server/monitoring.go
+++ b/internal/controller/rekor/actions/server/monitoring.go
@@ -1,63 +1,21 @@
 package server
 
 import (
-	"context"
-	"fmt"
-	"maps"
-	"slices"
-
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/controller/rekor/actions"
-	"github.com/securesign/operator/internal/labels"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Rekor] {
-	return &monitoringAction{}
-}
-
-type monitoringAction struct {
-	action.BaseAction
-}
-
-func (i monitoringAction) Name() string {
-	return "create monitoring"
-}
-
-func (i monitoringAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Rekor) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && instance.Spec.Monitoring.Enabled
-}
-
-func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor) *action.Result {
-	var (
-		err error
-	)
-
-	monitoringLabels := labels.For(actions.ServerComponentName, actions.MonitoringRoleName, instance.Name)
-
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.ServerDeploymentName),
-		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
-		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(
-			labels.ForComponent(actions.ServerComponentName, instance.Name),
-			kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
-		),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance, metav1.Condition{
-			Type:    actions.ServerCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  constants.Failure,
-			Message: err.Error(),
-		})
-	}
-
-	// monitors & RBAC are not watched - do not need to re-enqueue
-	return i.Continue()
+func NewCreateMonitorAction(registry *monitoring.ServiceMonitorRegistry) action.Action[*rhtasv1alpha1.Rekor] {
+	return monitoring.NewMonitoringAction(monitoring.MonitoringConfig[*rhtasv1alpha1.Rekor]{
+		ComponentName:      actions.ServerComponentName,
+		DeploymentName:     actions.ServerDeploymentName,
+		MonitoringRoleName: actions.MonitoringRoleName,
+		MetricsPortName:    actions.MetricsPortName,
+		IsMonitoringEnabled: func(instance *rhtasv1alpha1.Rekor) bool {
+			return instance.Spec.Monitoring.Enabled
+		},
+		Registry: registry,
+	})
 }

--- a/internal/controller/securesign/securesign_controller.go
+++ b/internal/controller/securesign/securesign_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/controller"
@@ -52,7 +53,7 @@ type securesignReconciler struct {
 	recorder record.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, _ *monitoring.ServiceMonitorRegistry) controller.Controller {
 	return &securesignReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/testonly/suite.go
+++ b/internal/controller/testonly/suite.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/controller"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -104,11 +105,14 @@ func (t *controllerSuite) BeforeSuite() {
 	Expect(t.k8sClient).NotTo(BeNil())
 
 	recorder := record.NewFakeRecorder(1000)
+	logger := logf.FromContext(context.TODO()).WithName("servicemonitor-watcher")
+	monitoringRegistry := monitoring.NewRegistry(k8sManager.GetClient(), recorder, logger)
 
 	err = t.supplier(
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
 		recorder,
+		monitoringRegistry,
 	).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/trillian/actions/logserver/monitoring.go
+++ b/internal/controller/trillian/actions/logserver/monitoring.go
@@ -1,76 +1,45 @@
 package logserver
 
 import (
-	"context"
 	"fmt"
-	"maps"
-	"slices"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/controller/trillian/actions"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Trillian] {
-	return &monitoringAction{}
-}
-
-type monitoringAction struct {
-	action.BaseAction
-}
-
-func (i monitoringAction) Name() string {
-	return "create monitoring"
-}
-
-func (i monitoringAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Trillian) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && instance.Spec.Monitoring.Enabled
-}
-
-func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian) *action.Result {
-	var (
-		err error
-	)
-
-	monitoringLabels := labels.For(actions.LogServerComponentName, actions.LogServerMonitoringName, instance.Name)
-
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.LogServerComponentName),
-		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
-		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-
-		ensure.Optional(statusTLS(instance).CertRef != nil,
-			kubernetes.EnsureServiceMonitorSpec(
-				labels.ForComponent(actions.LogServerComponentName, instance.Name),
-				kubernetes.ServiceMonitorHttpsEndpoint(
-					actions.MetricsPortName,
-					fmt.Sprintf("%s.%s.svc", actions.LogserverDeploymentName, instance.Namespace),
-					statusTLS(instance).CertRef,
-				),
-			)),
-		ensure.Optional(statusTLS(instance).CertRef == nil,
-			kubernetes.EnsureServiceMonitorSpec(
-				labels.ForComponent(actions.LogServerComponentName, instance.Name),
-				kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
-			)),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance,
-			metav1.Condition{
-				Type:    actions.ServerCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  constants.Failure,
-				Message: err.Error(),
-			},
-		)
-	}
-
-	// monitors & RBAC are not watched - do not need to re-enqueue
-	return i.Continue()
+func NewCreateMonitorAction(registry *monitoring.ServiceMonitorRegistry) action.Action[*rhtasv1alpha1.Trillian] {
+	return monitoring.NewMonitoringAction(monitoring.MonitoringConfig[*rhtasv1alpha1.Trillian]{
+		ComponentName:      actions.LogServerComponentName,
+		DeploymentName:     actions.LogServerComponentName,
+		MonitoringRoleName: actions.LogServerMonitoringName,
+		MetricsPortName:    actions.MetricsPortName,
+		IsMonitoringEnabled: func(instance *rhtasv1alpha1.Trillian) bool {
+			return instance.Spec.Monitoring.Enabled
+		},
+		CustomEndpointBuilder: func(instance *rhtasv1alpha1.Trillian) []func(*unstructured.Unstructured) error {
+			return []func(*unstructured.Unstructured) error{
+				ensure.Optional(statusTLS(instance).CertRef != nil,
+					kubernetes.EnsureServiceMonitorSpec(
+						labels.ForComponent(actions.LogServerComponentName, instance.Name),
+						kubernetes.ServiceMonitorHttpsEndpoint(
+							actions.MetricsPortName,
+							fmt.Sprintf("%s.%s.svc", actions.LogserverDeploymentName, instance.Namespace),
+							statusTLS(instance).CertRef,
+						),
+					)),
+				ensure.Optional(statusTLS(instance).CertRef == nil,
+					kubernetes.EnsureServiceMonitorSpec(
+						labels.ForComponent(actions.LogServerComponentName, instance.Name),
+						kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
+					)),
+			}
+		},
+		Registry: registry,
+	})
 }

--- a/internal/controller/trillian/actions/logsigner/monitoring.go
+++ b/internal/controller/trillian/actions/logsigner/monitoring.go
@@ -1,76 +1,45 @@
 package logsigner
 
 import (
-	"context"
 	"fmt"
-	"maps"
-	"slices"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/controller/trillian/actions"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func NewCreateMonitorAction() action.Action[*rhtasv1alpha1.Trillian] {
-	return &monitoringAction{}
-}
-
-type monitoringAction struct {
-	action.BaseAction
-}
-
-func (i monitoringAction) Name() string {
-	return "create monitoring"
-}
-
-func (i monitoringAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.Trillian) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && instance.Spec.Monitoring.Enabled
-}
-
-func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian) *action.Result {
-	var (
-		err error
-	)
-
-	monitoringLabels := labels.For(actions.LogSignerComponentName, actions.LogSignerMonitoringName, instance.Name)
-
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, actions.LogSignerComponentName),
-		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
-		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-
-		ensure.Optional(statusTLS(instance).CertRef != nil,
-			kubernetes.EnsureServiceMonitorSpec(
-				labels.ForComponent(actions.LogSignerComponentName, instance.Name),
-				kubernetes.ServiceMonitorHttpsEndpoint(
-					actions.MetricsPortName,
-					fmt.Sprintf("%s.%s.svc", actions.LogsignerDeploymentName, instance.Namespace),
-					statusTLS(instance).CertRef,
-				),
-			)),
-		ensure.Optional(statusTLS(instance).CertRef == nil,
-			kubernetes.EnsureServiceMonitorSpec(
-				labels.ForComponent(actions.LogSignerComponentName, instance.Name),
-				kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
-			)),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance,
-			metav1.Condition{
-				Type:    actions.ServerCondition,
-				Status:  metav1.ConditionFalse,
-				Reason:  constants.Failure,
-				Message: err.Error(),
-			},
-		)
-	}
-
-	// monitors & RBAC are not watched - do not need to re-enqueue
-	return i.Continue()
+func NewCreateMonitorAction(registry *monitoring.ServiceMonitorRegistry) action.Action[*rhtasv1alpha1.Trillian] {
+	return monitoring.NewMonitoringAction(monitoring.MonitoringConfig[*rhtasv1alpha1.Trillian]{
+		ComponentName:      actions.LogSignerComponentName,
+		DeploymentName:     actions.LogSignerComponentName,
+		MonitoringRoleName: actions.LogSignerMonitoringName,
+		MetricsPortName:    actions.MetricsPortName,
+		IsMonitoringEnabled: func(instance *rhtasv1alpha1.Trillian) bool {
+			return instance.Spec.Monitoring.Enabled
+		},
+		CustomEndpointBuilder: func(instance *rhtasv1alpha1.Trillian) []func(*unstructured.Unstructured) error {
+			return []func(*unstructured.Unstructured) error{
+				ensure.Optional(statusTLS(instance).CertRef != nil,
+					kubernetes.EnsureServiceMonitorSpec(
+						labels.ForComponent(actions.LogSignerComponentName, instance.Name),
+						kubernetes.ServiceMonitorHttpsEndpoint(
+							actions.MetricsPortName,
+							fmt.Sprintf("%s.%s.svc", actions.LogsignerDeploymentName, instance.Namespace),
+							statusTLS(instance).CertRef,
+						),
+					)),
+				ensure.Optional(statusTLS(instance).CertRef == nil,
+					kubernetes.EnsureServiceMonitorSpec(
+						labels.ForComponent(actions.LogSignerComponentName, instance.Name),
+						kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
+					)),
+			}
+		},
+		Registry: registry,
+	})
 }

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
@@ -46,15 +47,17 @@ import (
 // trillianReconciler reconciles a Trillian object
 type trillianReconciler struct {
 	client.Client
-	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	scheme             *runtime.Scheme
+	recorder           record.EventRecorder
+	monitoringRegistry *monitoring.ServiceMonitorRegistry
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, monitoringRegistry *monitoring.ServiceMonitorRegistry) controller.Controller {
 	return &trillianReconciler{
-		Client:   c,
-		scheme:   scheme,
-		recorder: recorder,
+		Client:             c,
+		scheme:             scheme,
+		recorder:           recorder,
+		monitoringRegistry: monitoringRegistry,
 	}
 }
 
@@ -115,11 +118,11 @@ func (r *trillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		logserver.NewDeployAction(),
 		logserver.NewCreateServiceAction(),
-		logserver.NewCreateMonitorAction(),
+		logserver.NewCreateMonitorAction(r.monitoringRegistry),
 
 		logsigner.NewDeployAction(),
 		logsigner.NewCreateServiceAction(),
-		logsigner.NewCreateMonitorAction(),
+		logsigner.NewCreateMonitorAction(r.monitoringRegistry),
 
 		transitions.NewToInitializePhaseAction[*rhtasv1alpha1.Trillian](),
 

--- a/internal/controller/tsa/actions/monitoring.go
+++ b/internal/controller/tsa/actions/monitoring.go
@@ -1,55 +1,20 @@
 package actions
 
 import (
-	"context"
-	"fmt"
-	"maps"
-	"slices"
-
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/constants"
-	"github.com/securesign/operator/internal/labels"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/securesign/operator/internal/action/monitoring"
 )
 
-func NewMonitoringAction() action.Action[*rhtasv1alpha1.TimestampAuthority] {
-	return &monitoringAction{}
-}
-
-type monitoringAction struct {
-	action.BaseAction
-}
-
-func (i monitoringAction) Name() string {
-	return "create monitoring"
-}
-
-func (i monitoringAction) CanHandle(_ context.Context, instance *rhtasv1alpha1.TimestampAuthority) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, constants.Ready)
-	return (c.Reason == constants.Creating || c.Reason == constants.Ready) && instance.Spec.Monitoring.Enabled
-}
-
-func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1.TimestampAuthority) *action.Result {
-	var (
-		err error
-	)
-	monitoringLabels := labels.For(ComponentName, MonitoringRoleName, instance.Name)
-
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, kubernetes.CreateServiceMonitor(instance.Namespace, DeploymentName),
-		ensure.ControllerReference[*unstructured.Unstructured](instance, i.Client),
-		ensure.Labels[*unstructured.Unstructured](slices.Collect(maps.Keys(monitoringLabels)), monitoringLabels),
-		kubernetes.EnsureServiceMonitorSpec(
-			labels.ForComponent(ComponentName, instance.Name),
-			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
-		),
-	); err != nil {
-		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
-	}
-
-	// monitors & RBAC are not watched - do not need to re-enqueue
-	return i.Continue()
+func NewMonitoringAction(registry *monitoring.ServiceMonitorRegistry) action.Action[*rhtasv1alpha1.TimestampAuthority] {
+	return monitoring.NewMonitoringAction(monitoring.MonitoringConfig[*rhtasv1alpha1.TimestampAuthority]{
+		ComponentName:      ComponentName,
+		DeploymentName:     DeploymentName,
+		MonitoringRoleName: MonitoringRoleName,
+		MetricsPortName:    MetricsPortName,
+		IsMonitoringEnabled: func(instance *rhtasv1alpha1.TimestampAuthority) bool {
+			return instance.Spec.Monitoring.Enabled
+		},
+		Registry: registry,
+	})
 }

--- a/internal/controller/tsa/timestampauthority_controller.go
+++ b/internal/controller/tsa/timestampauthority_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
@@ -43,15 +44,17 @@ import (
 // timestampAuthorityReconciler reconciles a TimestampAuthority object
 type timestampAuthorityReconciler struct {
 	client.Client
-	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	scheme             *runtime.Scheme
+	recorder           record.EventRecorder
+	monitoringRegistry *monitoring.ServiceMonitorRegistry
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, monitoringRegistry *monitoring.ServiceMonitorRegistry) controller.Controller {
 	return &timestampAuthorityReconciler{
-		Client:   c,
-		scheme:   scheme,
-		recorder: recorder,
+		Client:             c,
+		scheme:             scheme,
+		recorder:           recorder,
+		monitoringRegistry: monitoringRegistry,
 	}
 }
 
@@ -103,7 +106,7 @@ func (r *timestampAuthorityReconciler) Reconcile(ctx context.Context, req ctrl.R
 		actions.NewServiceAction(),
 		actions.NewIngressAction(),
 		actions.NewStatusUrlAction(),
-		actions.NewMonitoringAction(),
+		actions.NewMonitoringAction(r.monitoringRegistry),
 
 		transitions.NewToInitializePhaseAction[*rhtasv1alpha1.TimestampAuthority](),
 

--- a/internal/controller/tuf/tuf_controller.go
+++ b/internal/controller/tuf/tuf_controller.go
@@ -22,6 +22,7 @@ import (
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/monitoring"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
@@ -48,7 +49,7 @@ type tufReconciler struct {
 	recorder record.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder, _ *monitoring.ServiceMonitorRegistry) controller.Controller {
 	return &tufReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"github.com/securesign/operator/internal/action/monitoring"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -39,4 +40,4 @@ type Controller interface {
 	SetupWithManager(ctrl.Manager) error
 }
 
-type Constructor func(client.Client, *runtime.Scheme, record.EventRecorder) Controller
+type Constructor func(client.Client, *runtime.Scheme, record.EventRecorder, *monitoring.ServiceMonitorRegistry) Controller


### PR DESCRIPTION
…upported in the cluster

This PR adds a feature to automatically track the `ServiceMonitor` support within a cluster, create status events against the owners of those resources, and reconcile the resources when updated and the API is supported.

## Summary by Sourcery

Add a centralized ServiceMonitor framework by introducing a registry, CRD watcher, and generic monitoring action, refactor existing controllers to leverage the new framework, and update RBAC and main.go to support ServiceMonitor API availability.

New Features:
- Introduce a ServiceMonitorRegistry to centrally manage ServiceMonitor specifications and emit status events
- Implement a CRDWatcher that detects ServiceMonitor CRD availability and triggers reconciliation when the API is supported
- Provide a generic MonitoringAction to unify ServiceMonitor creation logic across all controllers

Enhancements:
- Refactor Trillian, Rekor, CTlog, Fulcio, and TSA controllers to use the new generic monitoring framework
- Update main.go to set up the CRD watcher and add RBAC permissions for watching CustomResourceDefinitions

Build:
- Expand RBAC role to allow get/list/watch on apiextensions.k8s.io/customresourcedefinitions