### PR TITLE
feat: add validating webhook for run-levels

### DIFF
--- a/.github/actions/kind-cluster/action.yml
+++ b/.github/actions/kind-cluster/action.yml
@@ -121,3 +121,10 @@ runs:
       shell: bash
       run: |
         kustomize build --enable-helm ./ci/nfs/overlay/ | kubectl apply -f -
+
+    - name: Install Cert-Manager
+      shell: bash
+      run: |
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.19.1/cert-manager.yaml
+        kubectl wait --for=condition=available deployment/cert-manager-webhook -n cert-manager --timeout=5m
+        kubectl wait --for=condition=available deployment/cert-manager -n cert-manager --timeout=5m

--- a/.tekton/rhtas-operator-bundle-pull-request.yaml
+++ b/.tekton/rhtas-operator-bundle-pull-request.yaml
@@ -40,7 +40,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: manager-pipelinerun-selector
-    value: appstudio.openshift.io/application=operator,appstudio.openshift.io/component=rhtas-operator,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (pull_request,incoming)
+    value: appstudio.openshift.io/application=operator,appstudio.openshift.io/component=rhtas-operator,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (pull_request,incoming,retest-all-comment)
   - name: manager-registry-url
     value: registry.redhat.io/rhtas/rhtas-rhel9-operator
   pipelineRef:

--- a/api/v1alpha1/securesign_types.go
+++ b/api/v1alpha1/securesign_types.go
@@ -73,6 +73,7 @@ type SecuresignTSAStatus struct {
 //+kubebuilder:printcolumn:name="Rekor URL",type=string,JSONPath=`.status.rekor.url`,description="The rekor url"
 //+kubebuilder:printcolumn:name="Fulcio URL",type=string,JSONPath=`.status.fulcio.url`,description="The fulcio url"
 //+kubebuilder:printcolumn:name="Tuf URL",type=string,JSONPath=`.status.tuf.url`,description="The tuf url"
+//+kubebuilder:webhook:path=/validate,mutating=false,failurePolicy=fail,groups=rhtas.redhat.com,resources=securesigns,verbs=create;update,versions=v1alpha1,name=validation.securesigns.rhtas.redhat.com,sideEffects=None,admissionReviewVersions=v1
 
 // Securesign is the Schema for the securesigns API
 type Securesign struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,6 +61,7 @@ import (
 	"github.com/securesign/operator/internal/controller/trillian"
 	"github.com/securesign/operator/internal/controller/tsa"
 	"github.com/securesign/operator/internal/controller/tuf"
+	rhtas_webhook "github.com/securesign/operator/internal/webhook"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -204,6 +205,17 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr).
+		For(&rhtasv1alpha1.Securesign{}).
+		WithValidator(&rhtas_webhook.SecureSignValidator{
+			Client: mgr.GetClient(),
+		}).
+		WithValidatorCustomPath("/validate").
+		Complete(); err != nil {
+		setupLog.Error(err, "unable to create SecureSign validating webhook")
 		os.Exit(1)
 	}
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,9 +15,6 @@ namePrefix: rhtas-
 #commonLabels:
 #  someName: someValue
 
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
@@ -26,6 +23,7 @@ resources:
 - ../rbac
 - ../manager
 - ../prometheus
+- ../webhook
 
 patches:
 - path: manager_metrics_patch.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -67,6 +67,10 @@ spec:
         - --leader-elect
         image: controller:latest
         name: manager
+        volumeMounts:
+        - name: webhook-cert
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
@@ -97,3 +101,7 @@ spec:
             memory: 64Mi
       serviceAccountName: operator-controller-manager
       terminationGracePeriodSeconds: 10
+      volumes:
+      - name: webhook-cert
+        secret:
+          secretName: webhook-server-tls

--- a/config/overlays/kubernetes/cert_resources.yaml
+++ b/config/overlays/kubernetes/cert_resources.yaml
@@ -1,0 +1,21 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: openshift-rhtas-operator
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: webhook-serving-cert
+  namespace: openshift-rhtas-operator
+spec:
+  secretName: webhook-server-tls
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+  dnsNames:
+  - rhtas-controller-manager-webhook-service.openshift-rhtas-operator.svc
+  - rhtas-controller-manager-webhook-service.openshift-rhtas-operator.svc.cluster.local

--- a/config/overlays/kubernetes/kustomization.yaml
+++ b/config/overlays/kubernetes/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-rhtas-operator
+
+resources:
+- ../../default
+- cert_resources.yaml
+
+patches:
+- path: webhook_patch.yaml
+  target:
+    kind: ValidatingWebhookConfiguration
+    name: validation.securesigns.rhtas.redhat.com

--- a/config/overlays/kubernetes/webhook_patch.yaml
+++ b/config/overlays/kubernetes/webhook_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.securesigns.rhtas.redhat.com
+  annotations:
+    cert-manager.io/inject-ca-from: openshift-rhtas-operator/webhook-serving-cert

--- a/config/overlays/openshift/inject_ca_bundle_annotation_patch.yaml
+++ b/config/overlays/openshift/inject_ca_bundle_annotation_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.securesigns.rhtas.redhat.com
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/config/overlays/openshift/kustomization.yaml
+++ b/config/overlays/openshift/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default
+
+patches:
+  - path: serving_cert_annotation_patch.yaml
+    target:
+      kind: Service
+      name: controller-manager-webhook-service
+
+  - path: inject_ca_bundle_annotation_patch.yaml
+    target:
+      kind: ValidatingWebhookConfiguration
+      name: validation.securesigns.rhtas.redhat.com

--- a/config/overlays/openshift/serving_cert_annotation_patch.yaml
+++ b/config/overlays/openshift/serving_cert_annotation_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-webhook-service
+  namespace: openshift-rhtas-operator
+  labels:
+    control-plane: controller-manager
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-tls

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - service.yaml
+  - webhook.yaml

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-webhook-service
+  namespace: openshift-rhtas-operator
+  labels:
+    control-plane: operator-controller-manager
+spec:
+  ports:
+    - name: https-webhook
+      port: 443
+      targetPort: 9443
+      protocol: TCP
+  selector:
+    control-plane: operator-controller-manager

--- a/config/webhook/webhook.yaml
+++ b/config/webhook/webhook.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.securesigns.rhtas.redhat.com
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: controller-manager-webhook-service
+      namespace: openshift-rhtas-operator
+      path: /validate
+  failurePolicy: Fail
+  name: validation.securesigns.rhtas.redhat.com
+  rules:
+  - apiGroups:
+    - rhtas.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - securesigns
+  sideEffects: None

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/operator-framework/api v0.35.0
 	github.com/operator-framework/operator-lib v0.19.0
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.46.0
 	google.golang.org/protobuf v1.36.10
 	k8s.io/api v0.34.1

--- a/internal/webhook/securesign_validator.go
+++ b/internal/webhook/securesign_validator.go
@@ -1,0 +1,64 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func (v *SecureSignValidator) validateNamespacePolicy(ctx context.Context, operandCR *rhtasv1alpha1.Securesign) (admission.Warnings, error) {
+	reqLog := logf.FromContext(ctx)
+	targetNamespace := operandCR.GetNamespace()
+
+	if targetNamespace == "default" {
+		reqLog.Info("Validation failed: Deployment blocked in 'default' namespace.")
+		return nil, fmt.Errorf("installation into the 'default' namespace is prohibited by RHTAS policy")
+	}
+
+	ns := &corev1.Namespace{}
+
+	if err := v.Client.Get(ctx, types.NamespacedName{Name: targetNamespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		reqLog.Error(err, "Failed to retrieve target namespace object for validation.")
+		return nil, fmt.Errorf("failed to retrieve target namespace %s: %w", targetNamespace, err)
+	}
+
+	runLevel, found := ns.Labels["openshift.io/run-level"]
+	if found && reservedRunLevels[runLevel] {
+		reqLog.Info("Validation failed: Deployment blocked in reserved namespace.",
+			"namespace", targetNamespace, "run-level", runLevel)
+		return nil, fmt.Errorf("installation into reserved OpenShift namespace '%s' (run-level %s) is prohibited by RHTAS policy", targetNamespace, runLevel)
+	}
+
+	return nil, nil
+}
+
+func (v *SecureSignValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	operandCR, ok := obj.(*rhtasv1alpha1.Securesign)
+	if !ok {
+		return nil, fmt.Errorf("expected SecureSign CR but got %T", obj)
+	}
+	return v.validateNamespacePolicy(ctx, operandCR)
+}
+
+func (v *SecureSignValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	operandCR, ok := newObj.(*rhtasv1alpha1.Securesign)
+	if !ok {
+		return nil, fmt.Errorf("expected SecureSign CR but got %T", newObj)
+	}
+	return v.validateNamespacePolicy(ctx, operandCR)
+}
+
+func (v *SecureSignValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	// Allow all delete operations
+	return nil, nil
+}

--- a/internal/webhook/test/webhook_test.go
+++ b/internal/webhook/test/webhook_test.go
@@ -1,0 +1,104 @@
+package webhook_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/securesign/operator/api/v1alpha1"
+	webhook "github.com/securesign/operator/internal/webhook"
+)
+
+func GenerateSecuresignObj(namespace string, labels map[string]string) *v1alpha1.Securesign {
+	return &v1alpha1.Securesign{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rhtas.redhat.com/v1alpha1",
+			Kind:       "Securesign",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-instance",
+			Namespace: namespace,
+			Labels:    labels,
+		},
+	}
+}
+
+func TestSecureSignValidator(t *testing.T) {
+	mockNsReserved := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-system",
+			Labels: map[string]string{
+				"openshift.io/run-level": "0",
+			},
+		},
+	}
+	mockNsAllowed := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-valid-ns",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithObjects(mockNsReserved, mockNsAllowed).Build()
+
+	validator := webhook.SecureSignValidator{
+		Client: c,
+	}
+
+	tests := []struct {
+		name      string
+		obj       runtime.Object
+		expectErr bool
+	}{
+		{
+			name:      "Case 1: Allowed Dynamic Namespace",
+			obj:       GenerateSecuresignObj("test-valid-ns", nil),
+			expectErr: false,
+		},
+		{
+			name:      "Case 2: Denied Default Namespace",
+			obj:       GenerateSecuresignObj("default", nil),
+			expectErr: true,
+		},
+		{
+			name:      "Case 3: Denied Reserved Openshift Namespace",
+			obj:       GenerateSecuresignObj("kube-system", nil),
+			expectErr: true,
+		},
+		{
+			name:      "Case 4: Wrong Resource Type (Denial)",
+			obj:       &unstructured.Unstructured{},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			_, createErr := validator.ValidateCreate(ctx, tc.obj)
+			if tc.expectErr {
+				require.Error(t, createErr, "ValidateCreate expected an error but got nil.")
+			} else {
+				require.NoError(t, createErr, "ValidateCreate returned an unexpected error.")
+			}
+
+			_, updateErr := validator.ValidateUpdate(ctx, tc.obj, tc.obj)
+			if tc.expectErr {
+				require.Error(t, updateErr, "ValidateUpdate expected an error but got nil.")
+			} else {
+				require.NoError(t, updateErr, "ValidateUpdate returned an unexpected error.")
+			}
+
+			_, deleteErr := validator.ValidateDelete(ctx, tc.obj)
+			require.NoError(t, deleteErr, "ValidateDelete unexpectedly returned an error.")
+		})
+	}
+}

--- a/internal/webhook/webhooks.go
+++ b/internal/webhook/webhooks.go
@@ -1,0 +1,20 @@
+package webhooks
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	admission "sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// SecureSignValidator checks for namespace security policy compliance.
+type SecureSignValidator struct {
+	Client client.Client
+}
+
+var _ admission.CustomValidator = &SecureSignValidator{}
+
+// Reserved OpenShift run-level labels to block
+var reservedRunLevels = map[string]bool{
+	"0": true, // Critical infrastructure
+	"1": true, // Infrastructure
+	"9": true, // General platform services
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a validating webhook to the operator for Securesign CRs to enforce RHTAS namespace policies, integrate cert-manager for TLS, update kustomize and Makefile for overlay support, and extend both unit and e2e tests as well as CI workflows to cover the new webhook functionality

New Features:
- Add a validating webhook for Securesign CR to enforce namespace run-level policies and block installs in the default or reserved OpenShift namespaces
- Register the SecureSignValidator with the controller manager and expose the webhook on port 9443 with certificate injection

Enhancements:
- Extend Makefile with an OPENSHIFT flag to select the appropriate kustomize overlay for build, deploy, and undeploy targets
- Augment kustomize overlays to include webhook service, cert-manager Issuer/Certificate resources, and webhook configuration
- Patch manager deployment YAML to mount the webhook TLS secret and open the webhook port

CI:
- Update GitHub Actions kind-cluster workflow to install cert-manager
- Adjust Tekton pipeline pull-request selector to include 'retest-all-comment' events

Tests:
- Add unit tests for SecureSignValidator covering allowed and disallowed namespace scenarios
- Enhance e2e test suite to install webhook infrastructure, wait for manager pod readiness, and verify CA bundle injection into the ValidatingWebhookConfiguration