### PR TITLE
ci: use 4 cpu large runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -267,7 +267,8 @@ jobs:
 
   test-upgrade:
     name: Test upgrade operator
-    runs-on: ubuntu-24.04
+    runs-on:
+      labels: ubuntu-4core
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Use ubuntu-24.04-4core instead of ubuntu-24.04 for the test-upgrade job