### PR TITLE
FIPS: Check user provided ctlog crypto for fips compliance

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/securesign/operator/internal/controller"
 	"github.com/securesign/operator/internal/images"
 	"github.com/securesign/operator/internal/utils"
+	cryptoutil "github.com/securesign/operator/internal/utils/crypto"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/klog/v2"
@@ -137,6 +138,15 @@ func main() {
 		setupLog.Info("Platform explicitly configured via flag/env", "openshift", appconfig.Openshift)
 	}
 
+	tlsOpts := []func(*tls.Config){}
+	if cryptoutil.FIPSEnabled {
+		setupLog.Info("Operator is running in FIPS enabled environment", "FIPSEnabled", cryptoutil.FIPSEnabled)
+		fipsTLSOpts := func(c *tls.Config) {
+			c.MinVersion = tls.VersionTLS12
+		}
+		tlsOpts = append(tlsOpts, fipsTLSOpts)
+	}
+
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
 	// prevent from being vulnerable to the HTTP/2 Stream Cancelation and
@@ -148,7 +158,6 @@ func main() {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
-	tlsOpts := []func(*tls.Config){}
 	if !enableHTTP2 {
 		tlsOpts = append(tlsOpts, disableHTTP2)
 	}

--- a/internal/controller/ctlog/actions/handle_keys.go
+++ b/internal/controller/ctlog/actions/handle_keys.go
@@ -12,6 +12,7 @@ import (
 	"github.com/securesign/operator/internal/controller/ctlog/utils"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
+	cryptoutil "github.com/securesign/operator/internal/utils/crypto"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	v1 "k8s.io/api/core/v1"
@@ -78,10 +79,24 @@ func (g handleKeys) Handle(ctx context.Context, instance *v1alpha1.CTlog) *actio
 
 	keys, err := g.setupKeys(instance.Namespace, newKeyStatus)
 	if err != nil {
-		return g.Error(ctx, fmt.Errorf("could not generate keys: %w", err), instance)
+		return g.Error(ctx, fmt.Errorf("could not generate keys: %w", err), instance,
+			metav1.Condition{
+				Type:               ConfigCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             SignerKeyReason,
+				Message:            "Waiting for Ctlog signer key",
+				ObservedGeneration: instance.Generation,
+			})
 	}
 	if _, err = g.generateAndUploadSecret(ctx, instance, newKeyStatus, keys); err != nil {
-		return g.Error(ctx, fmt.Errorf("could not generate Secret: %w", err), instance)
+		return g.Error(ctx, fmt.Errorf("could not generate Secret: %w", err), instance,
+			metav1.Condition{
+				Type:               ConfigCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             SignerKeyReason,
+				Message:            "Waiting for Ctlog signer key",
+				ObservedGeneration: instance.Generation,
+			})
 	}
 
 	instance.Status = *newKeyStatus
@@ -123,6 +138,11 @@ func (g handleKeys) setupKeys(ns string, instanceStatus *v1alpha1.CTlogStatus) (
 		if err != nil {
 			return nil, err
 		}
+		if cryptoutil.FIPSEnabled {
+			if err := cryptoutil.ValidatePrivateKeyPEM(config.PrivateKey, config.PrivateKeyPass); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if instanceStatus.PublicKeyRef == nil {
@@ -131,6 +151,11 @@ func (g handleKeys) setupKeys(ns string, instanceStatus *v1alpha1.CTlogStatus) (
 		config.PublicKey, err = kubernetes.GetSecretData(g.Client, ns, instanceStatus.PublicKeyRef)
 		if err != nil {
 			return nil, err
+		}
+		if cryptoutil.FIPSEnabled {
+			if err := cryptoutil.ValidatePublicKeyPEM(config.PublicKey); err != nil {
+				return nil, err
+			}
 		}
 		return config, nil
 	}

--- a/internal/controller/ctlog/actions/handle_keys_test.go
+++ b/internal/controller/ctlog/actions/handle_keys_test.go
@@ -2,6 +2,8 @@ package actions
 
 import (
 	"context"
+	"crypto/elliptic"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -12,6 +14,8 @@ import (
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
 	utils2 "github.com/securesign/operator/internal/utils"
+	cryptoutil "github.com/securesign/operator/internal/utils/crypto"
+	fipsTest "github.com/securesign/operator/internal/utils/crypto/test"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -562,6 +566,195 @@ func TestKeys_Handle(t *testing.T) {
 				find := &v1alpha1.CTlog{}
 				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(instance), find)).To(Succeed())
 				tt.want.verify(g, find.Status, c, configSecretWatch.ResultChan())
+			}
+		})
+	}
+}
+
+func TestKeys_Handle_FIPS(t *testing.T) {
+	g := NewWithT(t)
+
+	cryptoutil.FIPSEnabled = true
+	t.Cleanup(func() {
+		cryptoutil.FIPSEnabled = false
+	})
+
+	invalidPub, invalidPriv, _, err := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P224())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	validPub, validPriv, _, err := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P256())
+	g.Expect(err).NotTo(HaveOccurred())
+
+	type env struct {
+		spec    v1alpha1.CTlogSpec
+		objects []client.Object
+		status  v1alpha1.CTlogStatus
+	}
+
+	type want struct {
+		result *action.Result
+		err    error
+	}
+
+	tests := []struct {
+		name string
+		env  env
+		want want
+	}{
+		{
+			name: "valid private key (EC P256)",
+			env: env{
+				spec: v1alpha1.CTlogSpec{
+					PrivateKeyRef: &v1alpha1.SecretKeySelector{
+						LocalObjectReference: v1alpha1.LocalObjectReference{
+							Name: "privateKey",
+						},
+						Key: "private",
+					},
+				},
+				status: v1alpha1.CTlogStatus{},
+				objects: []client.Object{
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "privateKey",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"private": validPriv,
+						},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+			},
+		},
+		{
+			name: "valid public key",
+			env: env{
+				spec: v1alpha1.CTlogSpec{
+					PublicKeyRef: &v1alpha1.SecretKeySelector{
+						LocalObjectReference: v1alpha1.LocalObjectReference{
+							Name: "pubKey",
+						},
+						Key: "public",
+					},
+				},
+				status: v1alpha1.CTlogStatus{},
+				objects: []client.Object{
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pubKey",
+							Namespace: "default",
+						}, Data: map[string][]byte{
+							"public": validPub,
+						},
+					},
+				},
+			},
+			want: want{
+				result: testAction.StatusUpdate(),
+			},
+		},
+		{
+			name: "invalid private key (EC P224)",
+			env: env{
+				spec: v1alpha1.CTlogSpec{
+					PrivateKeyRef: &v1alpha1.SecretKeySelector{
+						LocalObjectReference: v1alpha1.LocalObjectReference{
+							Name: "bad",
+						},
+						Key: "private",
+					},
+				},
+				status: v1alpha1.CTlogStatus{},
+				objects: []client.Object{
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "bad",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"private": invalidPriv,
+						},
+					},
+				},
+			},
+			want: want{
+				err: cryptoutil.ErrKeyTooSmall,
+			},
+		},
+		{
+			name: "invalid public key",
+			env: env{
+				spec: v1alpha1.CTlogSpec{
+					PrivateKeyRef: &v1alpha1.SecretKeySelector{
+						LocalObjectReference: v1alpha1.LocalObjectReference{
+							Name: "privateKey",
+						}, Key: "private",
+					},
+					PublicKeyRef: &v1alpha1.SecretKeySelector{
+						LocalObjectReference: v1alpha1.LocalObjectReference{
+							Name: "badPubKey",
+						},
+						Key: "public",
+					},
+				},
+				status: v1alpha1.CTlogStatus{},
+				objects: []client.Object{
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "badPubKey",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"public": invalidPub,
+						},
+					},
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "privateKey",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{"private": validPriv},
+					},
+				},
+			},
+			want: want{
+				err: cryptoutil.ErrKeyTooSmall,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			instance := &v1alpha1.CTlog{
+				ObjectMeta: metav1.ObjectMeta{Name: "instance", Namespace: "default"},
+				Spec:       tt.env.spec,
+				Status:     tt.env.status,
+			}
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.ReadyCondition, Reason: state.Creating.String()})
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				WithObjects(tt.env.objects...).
+				Build()
+			a := testAction.PrepareAction(c, NewHandleKeysAction())
+			res := a.Handle(ctx, instance)
+
+			if tt.want.err != nil {
+				if !action.IsError(res) {
+					t.Fatalf("expected error result, got: %#v", res)
+				}
+				if !errors.Is(res.Err, tt.want.err) {
+					t.Fatalf("expected error to match %v, got: %v", tt.want.err, res.Err)
+				}
+				return
+			}
+
+			if !reflect.DeepEqual(res, tt.want.result) {
+				t.Errorf("Handle() = %v, want %v", res, tt.want.result)
 			}
 		})
 	}

--- a/internal/controller/ctlog/actions/tls.go
+++ b/internal/controller/ctlog/actions/tls.go
@@ -6,6 +6,8 @@ import (
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/state"
+	cryptoutil "github.com/securesign/operator/internal/utils/crypto"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -32,6 +34,19 @@ func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *a
 	// TLS
 	switch {
 	case instance.Spec.TLS.CertRef != nil:
+		if cryptoutil.FIPSEnabled {
+			if err := cryptoutil.ValidateTLS(i.Client, instance.Namespace, instance.Spec.TLS); err != nil {
+				i.Logger.Error(err, "TLS material is not FIPS-compliant")
+				meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+					Type:    TLSCondition,
+					Status:  metav1.ConditionFalse,
+					Reason:  state.Failure.String(),
+					Message: "TLS material is not FIPS-compliant",
+				})
+				i.StatusUpdate(ctx, instance)
+				return i.Requeue()
+			}
+		}
 		instance.Status.TLS = instance.Spec.TLS
 	case kubernetes.IsOpenShift():
 		instance.Status.TLS = rhtasv1alpha1.TLS{

--- a/internal/utils/crypto/fips.go
+++ b/internal/utils/crypto/fips.go
@@ -1,0 +1,297 @@
+package cryptoutil
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	FIPSEnabled         bool
+	ErrInvalidPEM       = errors.New("fips: invalid PEM")
+	ErrUnsupportedKey   = errors.New("fips: unsupported key type")
+	ErrNonFIPSAlgorithm = errors.New("fips: non-FIPS-approved algorithm/curve")
+	ErrKeyTooSmall      = errors.New("fips: key size below FIPS minimum")
+	ErrNoPassword       = errors.New("fips: encrypted PEM but no password provided")
+	ErrFailedToDecrypt  = errors.New("fips: failed to decrypt PEM")
+	ErrNonFIPSSignature = errors.New("fips: non-FIPS-approved signature algorithm")
+
+	fipsApprovedCurves = map[string]elliptic.Curve{
+		"P-256": elliptic.P256(),
+		"P-384": elliptic.P384(),
+		"P-521": elliptic.P521(),
+	}
+
+	fipsApprovedSignatureAlgos = map[x509.SignatureAlgorithm]struct{}{
+		x509.SHA256WithRSA:    {},
+		x509.SHA384WithRSA:    {},
+		x509.SHA512WithRSA:    {},
+		x509.ECDSAWithSHA256:  {},
+		x509.ECDSAWithSHA384:  {},
+		x509.ECDSAWithSHA512:  {},
+		x509.SHA256WithRSAPSS: {},
+		x509.SHA384WithRSAPSS: {},
+		x509.SHA512WithRSAPSS: {},
+	}
+)
+
+func init() {
+	FIPSEnabled = IsFIPS()
+}
+
+func IsFIPS() bool {
+	const fipsPath = "/proc/sys/crypto/fips_enabled"
+
+	data, err := os.ReadFile(fipsPath)
+	if err != nil {
+		return false
+	}
+
+	return strings.TrimSpace(string(data)) == "1"
+}
+
+func ValidatePrivateKeyPEM(pemBytes []byte, password []byte) error {
+	if !FIPSEnabled {
+		return nil
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return ErrInvalidPEM
+	}
+
+	der := block.Bytes
+	if x509.IsEncryptedPEMBlock(block) { //nolint:staticcheck
+		if len(password) == 0 {
+			return ErrNoPassword
+		}
+		decrypted, err := x509.DecryptPEMBlock(block, password) //nolint:staticcheck
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrFailedToDecrypt, err)
+		}
+		der = decrypted
+	}
+
+	if key, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		return validatePrivateKeyType(key)
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return validatePrivateKeyType(key)
+	}
+	if key, err := x509.ParseECPrivateKey(der); err == nil {
+		return validatePrivateKeyType(key)
+	}
+
+	return ErrUnsupportedKey
+}
+
+func ValidatePublicKeyPEM(pemBytes []byte) error {
+	if !FIPSEnabled {
+		return nil
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return ErrInvalidPEM
+	}
+
+	der := block.Bytes
+	if key, err := x509.ParsePKIXPublicKey(der); err == nil {
+		return validatePublicKeyType(key)
+	}
+	if key, err := x509.ParsePKCS1PublicKey(der); err == nil {
+		return validatePublicKeyType(key)
+	}
+
+	return ErrUnsupportedKey
+}
+
+func ValidateCertificatePEM(pemBytes []byte) error {
+	if !FIPSEnabled {
+		return nil
+	}
+
+	if len(bytes.TrimSpace(pemBytes)) == 0 {
+		return ErrInvalidPEM
+	}
+
+	for {
+		block, rest := pem.Decode(pemBytes)
+		if block == nil {
+			if len(bytes.TrimSpace(pemBytes)) == 0 {
+				return nil
+			}
+			return fmt.Errorf("%w: trailing data after PEM block", ErrInvalidPEM)
+		}
+
+		if block.Type != "CERTIFICATE" {
+			return fmt.Errorf("%w: unexpected PEM block %q", ErrInvalidPEM, block.Type)
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("%w: failed to parse certificate: %v", ErrInvalidPEM, err)
+		}
+
+		if err := validateSignatureAlgorithm(cert.SignatureAlgorithm); err != nil {
+			return fmt.Errorf("certificate signature: %w", err)
+		}
+
+		if err := validatePublicKeyType(cert.PublicKey); err != nil {
+			return fmt.Errorf("certificate public key: %w", err)
+		}
+
+		pemBytes = rest
+	}
+}
+
+func ValidatePublicKeyDER(der []byte) error {
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	})
+	if len(pemBytes) == 0 {
+		return fmt.Errorf("failed to encode public key")
+	}
+	return ValidatePublicKeyPEM(pemBytes)
+}
+
+func ValidateTLS(client client.Client, namespace string, tls v1alpha1.TLS) error {
+	if tls.CertRef != nil {
+		cert, err := kubernetes.GetSecretData(client, namespace, tls.CertRef)
+		if err != nil {
+			return fmt.Errorf("failed to get certificate: %w", err)
+		}
+		if err := ValidateCertificatePEM(cert); err != nil {
+			return fmt.Errorf("certificate validation failed: %w", err)
+		}
+	}
+
+	if tls.PrivateKeyRef != nil {
+		key, err := kubernetes.GetSecretData(client, namespace, tls.PrivateKeyRef)
+		if err != nil {
+			return fmt.Errorf("failed to get private key: %w", err)
+		}
+		if err := ValidatePrivateKeyPEM(key, nil); err != nil {
+			return fmt.Errorf("private key validation failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func ValidateTrustedCA(ctx context.Context, c client.Client, namespace string, ca *v1alpha1.LocalObjectReference) error {
+	if !FIPSEnabled || ca == nil {
+		return nil
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: ca.Name}, cm); err != nil {
+		return fmt.Errorf("could not load trusted CA %q: %w", ca.Name, err)
+	}
+
+	for k, v := range cm.Data {
+		rest := []byte(v)
+
+		for {
+			block, remaining := pem.Decode(rest)
+			if block == nil {
+				if len(rest) == 0 {
+					break
+				}
+				return fmt.Errorf("%w: trusted CA entry %q contains invalid PEM", ErrInvalidPEM, k)
+			}
+
+			if block.Type != "CERTIFICATE" {
+				return fmt.Errorf("%w: trusted CA entry %q has unexpected PEM block %q", ErrInvalidPEM, k, block.Type)
+			}
+
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err != nil {
+				return fmt.Errorf("%w: trusted CA entry %q failed to parse certificate: %v", ErrInvalidPEM, k, err)
+			}
+
+			if err := validateSignatureAlgorithm(cert.SignatureAlgorithm); err != nil {
+				return fmt.Errorf("trusted CA entry %q certificate signature: %w", k, err)
+			}
+			if err := validatePublicKeyType(cert.PublicKey); err != nil {
+				return fmt.Errorf("trusted CA entry %q certificate public key: %w", k, err)
+			}
+
+			rest = remaining
+		}
+	}
+
+	return nil
+}
+
+func validatePrivateKeyType(key interface{}) error {
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		if k.N.BitLen() < 2048 {
+			return fmt.Errorf("%w: RSA key size %d bits (minimum 2048)", ErrKeyTooSmall, k.N.BitLen())
+		}
+		return nil
+
+	case *ecdsa.PrivateKey:
+		return validateECDSACurve(k.Params())
+
+	default:
+		return ErrUnsupportedKey
+	}
+}
+
+func validatePublicKeyType(key interface{}) error {
+	switch k := key.(type) {
+	case *rsa.PublicKey:
+		if k.N.BitLen() < 2048 {
+			return fmt.Errorf("%w: RSA key size %d bits (minimum 2048)", ErrKeyTooSmall, k.N.BitLen())
+		}
+		return nil
+
+	case *ecdsa.PublicKey:
+		return validateECDSACurve(k.Params())
+
+	default:
+		return ErrUnsupportedKey
+	}
+}
+
+func validateECDSACurve(params *elliptic.CurveParams) error {
+	if params == nil {
+		return fmt.Errorf("%w: unknown ECDSA curve", ErrNonFIPSAlgorithm)
+	}
+
+	if params.BitSize < 256 {
+		return fmt.Errorf("%w: ECDSA curve %s (%d bits, minimum 256)", ErrKeyTooSmall, params.Name, params.BitSize)
+	}
+
+	_, ok := fipsApprovedCurves[params.Name]
+	if !ok {
+		return fmt.Errorf("%w: ECDSA curve %s", ErrNonFIPSAlgorithm, params.Name)
+	}
+	return nil
+}
+
+func validateSignatureAlgorithm(algo x509.SignatureAlgorithm) error {
+	if _, ok := fipsApprovedSignatureAlgos[algo]; ok {
+		return nil
+	}
+	return fmt.Errorf("%w: %s", ErrNonFIPSSignature, algo.String())
+}
+
+//ref: https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/blob/rhel9/policies/FIPS.pol

--- a/internal/utils/crypto/fips_test.go
+++ b/internal/utils/crypto/fips_test.go
@@ -1,0 +1,436 @@
+package cryptoutil
+
+import (
+	"context"
+	"crypto/elliptic"
+	"encoding/pem"
+	"errors"
+	"testing"
+
+	"github.com/securesign/operator/api/v1alpha1"
+	fipsTest "github.com/securesign/operator/internal/utils/crypto/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_ValidatePrivateKeyPEM(t *testing.T) {
+	type testCase struct {
+		name        string
+		fipsEnabled bool
+		build       func(t *testing.T) (pemBytes, password []byte)
+		wantErr     error
+	}
+
+	tests := []testCase{
+		{
+			name:        "FIPS disabled returns nil",
+			fipsEnabled: false,
+			build: func(t *testing.T) ([]byte, []byte) {
+				return []byte{}, nil
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid PEM with FIPS enabled returns ErrInvalidPEM",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				return []byte{}, nil
+			},
+			wantErr: ErrInvalidPEM,
+		},
+		{
+			name:        "valid PKCS8 RSA key passes",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				return fipsTest.GenerateRSAPKCS8PEM(t, 2048), nil
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid PKCS8 RSA key fails",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				return fipsTest.GenerateRSAPKCS8PEM(t, 1024), nil
+			},
+			wantErr: ErrKeyTooSmall,
+		},
+		{
+			name:        "valid PKCS1 RSA key passes",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				return fipsTest.GenerateRSAPKCS1PEM(t, 2048), nil
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid PKCS1 RSA key fails",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				return fipsTest.GenerateRSAPKCS1PEM(t, 1024), nil
+			},
+			wantErr: ErrKeyTooSmall,
+		},
+		{
+			name:        "valid EC key passes",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				_, priv, _, _ := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P256())
+				return priv, nil
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid EC key fails",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				_, priv, _, _ := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P224())
+				return priv, nil
+			},
+			wantErr: ErrKeyTooSmall,
+		},
+		{
+			name:        "encrypted PEM without password returns error",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				pemBytes, _ := fipsTest.GenerateEncryptedRSAPEM(t, 2048)
+				return pemBytes, nil
+			},
+			wantErr: ErrNoPassword,
+		},
+		{
+			name:        "encrypted PEM with wrong password returns decrypt error",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				pemBytes, _ := fipsTest.GenerateEncryptedRSAPEM(t, 2048)
+				return pemBytes, []byte("wrong-password")
+			},
+			wantErr: ErrFailedToDecrypt,
+		},
+		{
+			name:        "encrypted PEM with correct password passes",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				return fipsTest.GenerateEncryptedRSAPEM(t, 2048)
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "unsupported key type returns ErrUnsupportedKey",
+			fipsEnabled: true,
+			build: func(t *testing.T) ([]byte, []byte) {
+				unsupportedKeyPEM := pem.EncodeToMemory(&pem.Block{
+					Type:  "PRIVATE KEY",
+					Bytes: []byte("this is not a valid private key DER"),
+				})
+				return unsupportedKeyPEM, nil
+			},
+			wantErr: ErrUnsupportedKey,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			FIPSEnabled = tt.fipsEnabled
+
+			pemBytes, password := tt.build(t)
+			err := ValidatePrivateKeyPEM(pemBytes, password)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func Test_ValidatePublicKeyPEM(t *testing.T) {
+	type testCase struct {
+		name        string
+		fipsEnabled bool
+		build       func(t *testing.T) []byte
+		wantErr     error
+	}
+
+	tests := []testCase{
+		{
+			name:        "FIPS disabled returns nil",
+			fipsEnabled: false,
+			build: func(t *testing.T) []byte {
+				return []byte{}
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid PEM with FIPS enabled returns ErrInvalidPEM",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				return []byte{}
+			},
+			wantErr: ErrInvalidPEM,
+		},
+		{
+			name:        "valid PKIX RSA key passes",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				return fipsTest.GenerateRSAPKIXPublicKeyPEM(t, 2048)
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid PKIX RSA key fails",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				return fipsTest.GenerateRSAPKIXPublicKeyPEM(t, 1024)
+			},
+			wantErr: ErrKeyTooSmall,
+		},
+		{
+			name:        "valid PKCS1 RSA key passes",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				return fipsTest.GenerateRSAPKCS1PublicKeyPEM(t, 2048)
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid PKCS1 RSA key fails",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				return fipsTest.GenerateRSAPKCS1PublicKeyPEM(t, 1024)
+			},
+			wantErr: ErrKeyTooSmall,
+		},
+		{
+			name:        "valid EC key passes",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				pub, _, _, _ := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P256())
+				return pub
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid EC key fails",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				pub, _, _, _ := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P224())
+				return pub
+			},
+			wantErr: ErrKeyTooSmall,
+		},
+		{
+			name:        "unsupported key type returns ErrUnsupportedKey",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				unsupportedKeyPEM := pem.EncodeToMemory(&pem.Block{
+					Type:  "PUBLIC KEY",
+					Bytes: []byte("this is not a valid public key DER"),
+				})
+				return unsupportedKeyPEM
+			},
+			wantErr: ErrUnsupportedKey,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			FIPSEnabled = tt.fipsEnabled
+
+			pemBytes := tt.build(t)
+			err := ValidatePublicKeyPEM(pemBytes)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func Test_ValidateCertificatePEM(t *testing.T) {
+	type testCase struct {
+		name        string
+		fipsEnabled bool
+		build       func(t *testing.T) []byte
+		wantErr     error
+	}
+
+	tests := []testCase{
+		{
+			name:        "FIPS disabled returns nil",
+			fipsEnabled: false,
+			build: func(t *testing.T) []byte {
+				return []byte{}
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid PEM with FIPS enabled returns ErrInvalidPEM",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				return []byte{}
+			},
+			wantErr: ErrInvalidPEM,
+		},
+		{
+			name:        "valid EC certificate passes",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				_, _, cert, _ := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P256())
+				return cert
+			},
+			wantErr: nil,
+		},
+		{
+			name:        "invalid EC certificate fails",
+			fipsEnabled: true,
+			build: func(t *testing.T) []byte {
+				_, _, cert, _ := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P224())
+				return cert
+			},
+			wantErr: ErrKeyTooSmall,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			FIPSEnabled = tt.fipsEnabled
+
+			pemBytes := tt.build(t)
+			err := ValidateCertificatePEM(pemBytes)
+
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected error %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func Test_ValidateTrustedCA(t *testing.T) {
+	type testCase struct {
+		name        string
+		fipsEnabled bool
+		ca          *client.ObjectKey
+		objects     []client.Object
+		wantErr     bool
+	}
+
+	_, _, validCert, _ := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P256())
+	_, _, invalidCert, _ := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P224())
+
+	tests := []testCase{
+		{
+			name:        "FIPS disabled skips validation",
+			fipsEnabled: false,
+			ca:          nil,
+			objects:     nil,
+			wantErr:     false,
+		},
+		{
+			name:        "FIPS enabled but no CA provided",
+			fipsEnabled: true,
+			ca:          nil,
+			objects:     nil,
+			wantErr:     false,
+		},
+		{
+			name:        "missing ConfigMap returns error",
+			fipsEnabled: true,
+			ca: &client.ObjectKey{
+				Name:      "missing",
+				Namespace: "default",
+			},
+			objects: nil,
+			wantErr: true,
+		},
+		{
+			name:        "ConfigMap without PEM entries returns error",
+			fipsEnabled: true,
+			ca: &client.ObjectKey{
+				Name:      "ca",
+				Namespace: "default",
+			},
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ca",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"notes": "not a certificate",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "ConfigMap with invalid PEM returns error",
+			fipsEnabled: true,
+			ca: &client.ObjectKey{
+				Name:      "ca",
+				Namespace: "default",
+			},
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ca",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"ca.crt": string(invalidCert),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:        "ConfigMap with valid PEM passes",
+			fipsEnabled: true,
+			ca: &client.ObjectKey{
+				Name:      "ca",
+				Namespace: "default",
+			},
+			objects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ca",
+						Namespace: "default",
+					},
+					Data: map[string]string{
+						"ca.crt": string(validCert),
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			FIPSEnabled = tt.fipsEnabled
+			cli := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(tt.objects...).
+				Build()
+
+			var caRef *v1alpha1.LocalObjectReference
+			if tt.ca != nil {
+				caRef = &v1alpha1.LocalObjectReference{Name: tt.ca.Name}
+			}
+
+			err := ValidateTrustedCA(context.Background(), cli, "default", caRef)
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/utils/crypto/test/helpers.go
+++ b/internal/utils/crypto/test/helpers.go
@@ -1,0 +1,141 @@
+package fipsTest
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func GenerateRSAPKCS8PEM(t *testing.T, keyBits int) []byte {
+	t.Helper()
+	der, _ := x509.MarshalPKCS8PrivateKey(mustGenerateRSAKey(t, keyBits))
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	})
+}
+
+func GenerateRSAPKCS1PEM(t *testing.T, keyBits int) []byte {
+	der := x509.MarshalPKCS1PrivateKey(mustGenerateRSAKey(t, keyBits))
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: der,
+	})
+}
+
+func GenerateEncryptedRSAPEM(t *testing.T, keyBits int) ([]byte, []byte) {
+	t.Helper()
+	der := x509.MarshalPKCS1PrivateKey(mustGenerateRSAKey(t, keyBits))
+	password := []byte("pass")
+	block, _ := x509.EncryptPEMBlock( //nolint:staticcheck
+		rand.Reader,
+		"RSA PRIVATE KEY",
+		der,
+		password,
+		x509.PEMCipherAES256,
+	)
+	return pem.EncodeToMemory(block), password
+}
+
+func GenerateRSAPKIXPublicKeyPEM(t *testing.T, keyBits int) []byte {
+	t.Helper()
+	der, _ := x509.MarshalPKIXPublicKey(&mustGenerateRSAKey(t, keyBits).PublicKey)
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	})
+}
+
+func GenerateRSAPKCS1PublicKeyPEM(t *testing.T, keyBits int) []byte {
+	t.Helper()
+	der := x509.MarshalPKCS1PublicKey(&mustGenerateRSAKey(t, keyBits).PublicKey)
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PUBLIC KEY",
+		Bytes: der,
+	})
+}
+
+func mustGenerateRSAKey(t *testing.T, keyBits int) *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(rand.Reader, keyBits)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+	return key
+}
+
+func GenerateECCertificatePEM(passwordProtected bool, certPassword string, curve elliptic.Curve) ([]byte, []byte, []byte, error) {
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	privateKeyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	var block *pem.Block
+	if passwordProtected {
+		block, err = x509.EncryptPEMBlock(rand.Reader, "EC PRIVATE KEY", privateKeyBytes, []byte(certPassword), x509.PEMCipher3DES) //nolint:staticcheck
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	} else {
+		block = &pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: privateKeyBytes,
+		}
+	}
+	privateKeyPem := pem.EncodeToMemory(block)
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	publicKeyPem := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: publicKeyBytes,
+		},
+	)
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(365 * 24 * 10 * time.Hour)
+
+	issuer := pkix.Name{
+		CommonName:         "local",
+		Country:            []string{"CR"},
+		Organization:       []string{"RedHat"},
+		Province:           []string{"Czech Republic"},
+		Locality:           []string{"Brno"},
+		OrganizationalUnit: []string{"QE"},
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               issuer,
+		SignatureAlgorithm:    x509.ECDSAWithSHA256,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		Issuer:                issuer,
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, nil, err
+
+	}
+	root := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: derBytes,
+		},
+	)
+	return publicKeyPem, privateKeyPem, root, err
+}

--- a/test/e2e/fips/ctlog_test.go
+++ b/test/e2e/fips/ctlog_test.go
@@ -1,0 +1,250 @@
+//go:build fips
+
+package fips
+
+import (
+	"crypto/elliptic"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/securesign/operator/api/v1alpha1"
+	ctlogactions "github.com/securesign/operator/internal/controller/ctlog/actions"
+	ctlogUtils "github.com/securesign/operator/internal/controller/ctlog/utils"
+	"github.com/securesign/operator/internal/state"
+	fipsTest "github.com/securesign/operator/internal/utils/crypto/test"
+	"github.com/securesign/operator/test/e2e/support"
+	"github.com/securesign/operator/test/e2e/support/steps"
+	"github.com/securesign/operator/test/e2e/support/tas/ctlog"
+	"github.com/securesign/operator/test/e2e/support/tas/securesign"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Securesign FIPS - ctlog test", Ordered, func() {
+	cli, _ := support.CreateClient()
+
+	var namespace *v1.Namespace
+	var s *v1alpha1.Securesign
+
+	Describe("Reject non-FIPS ctlog key then accept FIPS-compliant key", func() {
+
+		BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+			namespace = new
+		}))
+
+		BeforeAll(func(ctx SpecContext) {
+			invalidPub, invalidPriv, _, err := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P224())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cli.Create(ctx, ctlog.CreateCustomCtlogSecret(namespace.Name, "my-invalid-ctlog-secret", map[string][]byte{
+				"private": invalidPriv,
+				"public":  invalidPub,
+			}))).To(Succeed())
+			Expect(cli.Create(ctx, ctlog.CreateSecret(namespace.Name, "my-ctlog-secret"))).To(Succeed())
+		})
+
+		BeforeAll(func(ctx SpecContext) {
+			s = securesign.Create(namespace.Name, "test",
+				securesign.WithDefaults(),
+				func(v *v1alpha1.Securesign) {
+					v.Spec.Ctlog.PrivateKeyRef = &v1alpha1.SecretKeySelector{
+						LocalObjectReference: v1alpha1.LocalObjectReference{
+							Name: "my-invalid-ctlog-secret",
+						},
+						Key: "private",
+					}
+					v.Spec.Ctlog.PublicKeyRef = &v1alpha1.SecretKeySelector{
+						LocalObjectReference: v1alpha1.LocalObjectReference{
+							Name: "my-invalid-ctlog-secret",
+						},
+						Key: "public",
+					}
+				},
+			)
+			Expect(cli.Create(ctx, s)).To(Succeed())
+		})
+
+		It("CTlog reports ServerConfigAvailable False with SignerKey reason", func(ctx SpecContext) {
+			Eventually(func(g Gomega) bool {
+				ctlog := ctlog.Get(ctx, cli, namespace.Name, s.Name)
+				g.Expect(ctlog).ToNot(BeNil())
+				c := meta.FindStatusCondition(ctlog.Status.Conditions, ctlogactions.ConfigCondition)
+				return c != nil && string(c.Status) == "False" &&
+					c.Reason == ctlogactions.SignerKeyReason &&
+					strings.Contains(strings.ToLower(c.Message), "waiting for ctlog signer key")
+			}).WithContext(ctx).Should(BeTrue())
+		})
+
+		It("Update ctlog signer to use FIPS-compliant secret and verify readiness", func(ctx SpecContext) {
+			Eventually(func(g Gomega) error {
+				g.Expect(cli.Get(ctx, types.NamespacedName{Name: s.Name, Namespace: namespace.Name}, s)).To(Succeed())
+
+				s.Spec.Ctlog.PrivateKeyRef = &v1alpha1.SecretKeySelector{
+					LocalObjectReference: v1alpha1.LocalObjectReference{
+						Name: "my-ctlog-secret",
+					},
+					Key: "private",
+				}
+				s.Spec.Ctlog.PublicKeyRef = &v1alpha1.SecretKeySelector{
+					LocalObjectReference: v1alpha1.LocalObjectReference{
+						Name: "my-ctlog-secret",
+					},
+					Key: "public",
+				}
+
+				return cli.Update(ctx, s)
+			}).Should(Succeed())
+			ctlog.Verify(ctx, cli, namespace.Name, s.Name)
+		})
+	})
+
+	Describe("Reject non-FIPS ctlog custom server config then accept FIPS-compliant config", func() {
+		var treeID int64
+
+		BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+			namespace = new
+		}))
+
+		BeforeAll(func(ctx SpecContext) {
+			s = securesign.Create(namespace.Name, "test",
+				securesign.WithDefaults(),
+			)
+			Expect(cli.Create(ctx, s)).To(Succeed())
+			ctlog.Verify(ctx, cli, namespace.Name, s.Name)
+			ct := ctlog.Get(ctx, cli, namespace.Name, s.Name)
+			Expect(ct).ToNot(BeNil())
+			Expect(ct.Status.TreeID).ToNot(BeNil())
+			treeID = *ct.Status.TreeID
+		})
+
+		BeforeAll(func(ctx SpecContext) {
+			invalidPub, invalidPriv, _, err := fipsTest.GenerateECCertificatePEM(true, "pass", elliptic.P224())
+			Expect(err).NotTo(HaveOccurred())
+
+			validPub, validPriv, validCert, err := fipsTest.GenerateECCertificatePEM(true, "pass", elliptic.P256())
+			Expect(err).NotTo(HaveOccurred())
+
+			trillianURL := fmt.Sprintf("trillian-logserver.%s.svc:8091", namespace.Name)
+
+			invalidConfig, err := ctlogUtils.CreateCtlogConfig(
+				trillianURL,
+				treeID,
+				[]ctlogUtils.RootCertificate{validCert},
+				&ctlogUtils.KeyConfig{
+					PrivateKey:     invalidPriv,
+					PublicKey:      invalidPub,
+					PrivateKeyPass: []byte("pass"),
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			validConfig, err := ctlogUtils.CreateCtlogConfig(
+				trillianURL,
+				treeID,
+				[]ctlogUtils.RootCertificate{validCert},
+				&ctlogUtils.KeyConfig{
+					PrivateKey:     validPriv,
+					PublicKey:      validPub,
+					PrivateKeyPass: []byte("pass"),
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cli.Create(ctx, ctlog.CreateCustomCtlogSecret(namespace.Name, "my-invalid-ctlog-config", invalidConfig))).To(Succeed())
+			Expect(cli.Create(ctx, ctlog.CreateCustomCtlogSecret(namespace.Name, "my-ctlog-config", validConfig))).To(Succeed())
+		})
+
+		It("Update ctlog server config to non-FIPS secret and expect failure", func(ctx SpecContext) {
+			Eventually(func(g Gomega) error {
+				g.Expect(cli.Get(ctx, types.NamespacedName{Name: s.Name, Namespace: namespace.Name}, s)).To(Succeed())
+				s.Spec.Ctlog.ServerConfigRef = &v1alpha1.LocalObjectReference{
+					Name: "my-invalid-ctlog-config",
+				}
+				return cli.Update(ctx, s)
+			}).Should(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				ct := ctlog.Get(ctx, cli, namespace.Name, s.Name)
+				g.Expect(ct).ToNot(BeNil())
+				c := meta.FindStatusCondition(ct.Status.Conditions, ctlogactions.ConfigCondition)
+				return c != nil && string(c.Status) == "False" &&
+					c.Reason == state.Failure.String() &&
+					strings.Contains(strings.ToLower(c.Message), "invalid server config")
+			}).WithContext(ctx).Should(BeTrue())
+		})
+
+		It("Update ctlog server config to FIPS-compliant secret and verify readiness", func(ctx SpecContext) {
+			Eventually(func(g Gomega) error {
+				g.Expect(cli.Get(ctx, types.NamespacedName{Name: s.Name, Namespace: namespace.Name}, s)).To(Succeed())
+
+				s.Spec.Ctlog.ServerConfigRef = &v1alpha1.LocalObjectReference{
+					Name: "my-ctlog-config",
+				}
+
+				return cli.Update(ctx, s)
+			}).Should(Succeed())
+			ctlog.Verify(ctx, cli, namespace.Name, s.Name)
+		})
+	})
+
+	Describe("Reject non-FIPS ctlog TLS", func() {
+
+		BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+			namespace = new
+		}))
+
+		BeforeAll(func(ctx SpecContext) {
+			_, invalidPriv, invalidCert, err := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P224())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, validPriv, validCert, err := fipsTest.GenerateECCertificatePEM(false, "", elliptic.P256())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cli.Create(ctx, ctlog.CreateCustomCtlogSecret(namespace.Name, "my-invalid-ctlog-tls-secret", map[string][]byte{
+				"tls.crt": invalidCert,
+				"tls.key": invalidPriv,
+			}))).To(Succeed())
+			Expect(cli.Create(ctx, ctlog.CreateCustomCtlogSecret(namespace.Name, "my-ctlog-tls-secret", map[string][]byte{
+				"tls.crt": validCert,
+				"tls.key": validPriv,
+			}))).To(Succeed())
+		})
+
+		BeforeAll(func(ctx SpecContext) {
+			s = securesign.Create(namespace.Name, "test",
+				securesign.WithDefaults(),
+				func(v *v1alpha1.Securesign) {
+					v.Spec.Ctlog.TLS = v1alpha1.TLS{
+						CertRef: &v1alpha1.SecretKeySelector{
+							LocalObjectReference: v1alpha1.LocalObjectReference{
+								Name: "my-invalid-ctlog-tls-secret",
+							},
+							Key: "tls.crt",
+						},
+						PrivateKeyRef: &v1alpha1.SecretKeySelector{
+							LocalObjectReference: v1alpha1.LocalObjectReference{
+								Name: "my-invalid-ctlog-tls-secret",
+							},
+							Key: "tls.key",
+						},
+					}
+				},
+			)
+			Expect(cli.Create(ctx, s)).To(Succeed())
+		})
+
+		It("CTlog reports ServerTLS False with Failure reason", func(ctx SpecContext) {
+			Eventually(func(g Gomega) bool {
+				ct := ctlog.Get(ctx, cli, namespace.Name, s.Name)
+				g.Expect(ct).ToNot(BeNil())
+				c := meta.FindStatusCondition(ct.Status.Conditions, ctlogactions.TLSCondition)
+				return c != nil && string(c.Status) == "False" &&
+					c.Reason == state.Failure.String() &&
+					strings.Contains(strings.ToLower(c.Message), "fips")
+			}).WithContext(ctx).Should(BeTrue())
+		})
+	})
+})

--- a/test/e2e/support/tas/ctlog/ctlog.go
+++ b/test/e2e/support/tas/ctlog/ctlog.go
@@ -103,3 +103,13 @@ func GetTrillianAddressFromSecret(secret *v1.Secret) string {
 	// Return config for substring matching in tests
 	return config
 }
+
+func CreateCustomCtlogSecret(ns string, name string, data map[string][]byte) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: data,
+	}
+}


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add FIPS compliance validation for CTLog cryptographic materials

- Validate private/public keys and certificates against FIPS standards

- Reject non-FIPS-compliant keys (e.g., EC P224) and enforce minimum key sizes

- Add comprehensive unit and E2E tests for FIPS validation scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FIPS Detection"] -->|FIPSEnabled flag| B["Crypto Validation Module"]
  B -->|ValidatePrivateKeyPEM| C["Private Key Checks"]
  B -->|ValidatePublicKeyPEM| D["Public Key Checks"]
  B -->|ValidateCertificatePEM| E["Certificate Checks"]
  B -->|ValidateTLS| F["TLS Material Checks"]
  C -->|RSA/ECDSA validation| G["Key Size & Curve Validation"]
  D -->|RSA/ECDSA validation| G
  E -->|Signature algorithm| G
  G -->|Reject non-FIPS| H["Requeue with error"]
  G -->|Accept FIPS-compliant| I["Continue deployment"]
  J["CTLog Actions"] -->|Call validators| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>main.go</strong><dd><code>Add FIPS TLS configuration to webhook server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>deployment.go</strong><dd><code>Validate trusted CA certificates for FIPS compliance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-ac77b2ec01e2e28120a5236e2bb67566f9ee04011c659321c2f73a685f708e36">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>handle_keys.go</strong><dd><code>Validate private/public keys and add error conditions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-f1e8282ad573b633e2f74752d81594262ed6b205997182f1af99f8e4fd36006a">+27/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>server_config.go</strong><dd><code>Validate server config and crypto materials for FIPS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-0719f305d0693e40da7ab18b3e10b70c228566e10bdf99c2780651e40d172e66">+117/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>tls.go</strong><dd><code>Add FIPS validation for TLS certificates and keys</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-1f71c239f0764a61209f3026292acad6552f3db543b04698376f93ffef73f7f9">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fips.go</strong><dd><code>Implement FIPS compliance validation for cryptographic materials</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-297f2fca1731cc85731c051492874aa3dbb3ff1aa1f82bd086090ff9a1aae320">+297/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ctlog.go</strong><dd><code>Add helper function for creating custom CTLog secrets</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-7e9cca8509445602bfcfa10e282d778aef6eacb0f4c9d996562adb133d5bc36e">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>handle_keys_test.go</strong><dd><code>Add FIPS validation tests for key handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-b93ee587efe39d429c4c2b7a26c7188265468b306e72256fee89e2174f64ed09">+193/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>server_config_test.go</strong><dd><code>Add comprehensive FIPS server config validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-1d8ec2c0c48f20ca47848914885dbdc7fa72511fef64970039f15b9bcd560596">+390/-1</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>fips_test.go</strong><dd><code>Add unit tests for FIPS validation functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-554524446ade6e7da5e41fef2c21048f861251985c3e9a1d168ee02e88eb2de0">+436/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>helpers.go</strong><dd><code>Add test helpers for generating FIPS/non-FIPS crypto materials</code></dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-4a0591453abb55ce3fbce12143cd909f1fe81e2564b2525bc756f61aa95280be">+141/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ctlog_test.go</strong><dd><code>Add end-to-end FIPS compliance tests for CTLog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/securesign/secure-sign-operator/pull/1494/files#diff-3681a70c20a44f3fa2e36a19f125e5ec8ac0fd553962cc79526622dcea220c6d">+250/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

