### PR TITLE
fix: improve TSA probes with startup probe for initialization verification

### DIFF
--- a/internal/controller/tsa/actions/deployment.go
+++ b/internal/controller/tsa/actions/deployment.go
@@ -256,7 +256,10 @@ func (i deployAction) ensureDeployment(instance *rhtasv1alpha1.TimestampAuthorit
 		}
 		container.LivenessProbe.HTTPGet.Path = "/ping"
 		container.LivenessProbe.HTTPGet.Port = intstr.FromInt32(3000)
-		container.LivenessProbe.InitialDelaySeconds = 5
+		container.LivenessProbe.InitialDelaySeconds = 0
+		container.LivenessProbe.PeriodSeconds = 10
+		container.LivenessProbe.TimeoutSeconds = 1
+		container.LivenessProbe.FailureThreshold = 3
 
 		if container.ReadinessProbe == nil {
 			container.ReadinessProbe = &core.Probe{}
@@ -264,10 +267,26 @@ func (i deployAction) ensureDeployment(instance *rhtasv1alpha1.TimestampAuthorit
 		if container.ReadinessProbe.HTTPGet == nil {
 			container.ReadinessProbe.HTTPGet = &core.HTTPGetAction{}
 		}
-
 		container.ReadinessProbe.HTTPGet.Path = "/ping"
 		container.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(3000)
-		container.ReadinessProbe.InitialDelaySeconds = 5
+		container.ReadinessProbe.InitialDelaySeconds = 0
+		container.ReadinessProbe.PeriodSeconds = 10
+		container.ReadinessProbe.TimeoutSeconds = 1
+		container.ReadinessProbe.FailureThreshold = 3
+
+		// StartupProbe verifies TSA is fully initialized by checking certificate chain endpoint
+		// This runs only at startup, allowing heavy checks without impacting ongoing probes
+		if container.StartupProbe == nil {
+			container.StartupProbe = &core.Probe{}
+		}
+		if container.StartupProbe.HTTPGet == nil {
+			container.StartupProbe.HTTPGet = &core.HTTPGetAction{}
+		}
+		container.StartupProbe.HTTPGet.Path = "/api/v1/timestamp/certchain"
+		container.StartupProbe.HTTPGet.Port = intstr.FromInt32(3000)
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 12
 
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Add **StartupProbe** that checks `/api/v1/timestamp/certchain` to verify TSA is fully initialized before liveness/readiness probes begin
- Remove `InitialDelaySeconds` from liveness/readiness probes — redundant when a startup probe gates activation
- Add explicit `PeriodSeconds`, `TimeoutSeconds`, `FailureThreshold` to liveness and readiness probes for predictable behavior

## Why

The TSA container needs to load and validate its certificate chain at startup. Without a startup probe, the liveness probe can kill the container before initialization completes, and `InitialDelaySeconds` is a fragile workaround that either wastes time (too long) or risks premature restarts (too short).

The startup probe checks the actual functional dependency (`/api/v1/timestamp/certchain` — a lightweight cached GET) with a 60s budget, while ongoing liveness/readiness probes stay lightweight with `/ping`.

## Probe configuration

| Probe | Endpoint | Period | Timeout | FailureThreshold |
|-------|----------|--------|---------|-----------------|
| Startup | `/api/v1/timestamp/certchain` | 5s | 5s | 12 (60s budget) |
| Liveness | `/ping` | 10s | 1s | 3 |
| Readiness | `/ping` | 10s | 1s | 3 |

## Test plan

- [x] `make test` passes
- [ ] CI e2e tests pass with the new probe configuration