### PR TITLE
fix: skip TSA ingress resolution when TSA key is not configured

### DIFF
--- a/internal/controller/tuf/actions/tuf_init_job.go
+++ b/internal/controller/tuf/actions/tuf_init_job.go
@@ -134,8 +134,17 @@ func (i initJobAction) resolveServiceURLs(ctx context.Context, instance *rhtasv1
 	}{
 		{&instance.Spec.Fulcio.Address, fulcio.DeploymentName, ""},
 		{&instance.Spec.Rekor.Address, rekor.ServerDeploymentName, ""},
-		{&instance.Spec.Tsa.Address, tsa.DeploymentName, tsa.TimestampPath},
 	}
+
+	// Only resolve TSA ingress if tsa.certchain.pem key is configured
+	if hasTSAKey(instance.Spec.Keys) {
+		services = append(services, struct {
+			address     *string
+			ingressName string
+			suffix      string
+		}{&instance.Spec.Tsa.Address, tsa.DeploymentName, tsa.TimestampPath})
+	}
+
 	for _, svc := range services {
 		if *svc.address == "" {
 			if url, err := i.resolveURLFromIngress(ctx, svc.ingressName, instance.Namespace); err == nil {
@@ -146,6 +155,15 @@ func (i initJobAction) resolveServiceURLs(ctx context.Context, instance *rhtasv1
 		}
 	}
 	return nil
+}
+
+func hasTSAKey(keys []rhtasv1alpha1.TufKey) bool {
+	for _, key := range keys {
+		if key.Name == "tsa.certchain.pem" {
+			return true
+		}
+	}
+	return false
 }
 
 func (i initJobAction) resolveURLFromIngress(ctx context.Context, ingressName, namespace string) (string, error) {

--- a/internal/controller/tuf/actions/tuf_init_job_test.go
+++ b/internal/controller/tuf/actions/tuf_init_job_test.go
@@ -1,0 +1,55 @@
+package actions
+
+import (
+	"testing"
+
+	"github.com/securesign/operator/api/v1alpha1"
+)
+
+func TestHasTSAKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		keys     []v1alpha1.TufKey
+		expected bool
+	}{
+		{
+			name:     "no keys",
+			keys:     nil,
+			expected: false,
+		},
+		{
+			name: "keys without TSA",
+			keys: []v1alpha1.TufKey{
+				{Name: "rekor.pub"},
+				{Name: "ctfe.pub"},
+				{Name: "fulcio_v1.crt.pem"},
+			},
+			expected: false,
+		},
+		{
+			name: "keys with TSA",
+			keys: []v1alpha1.TufKey{
+				{Name: "rekor.pub"},
+				{Name: "ctfe.pub"},
+				{Name: "fulcio_v1.crt.pem"},
+				{Name: "tsa.certchain.pem"},
+			},
+			expected: true,
+		},
+		{
+			name: "only TSA key",
+			keys: []v1alpha1.TufKey{
+				{Name: "tsa.certchain.pem"},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasTSAKey(tt.keys); got != tt.expected {
+				t.Errorf("hasTSAKey() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- When `signingConfigURLMode: external`, `resolveServiceURLs()` unconditionally resolves the TSA ingress, causing TUF init to fail if TSA is not deployed
- This fix makes TSA ingress resolution conditional on whether `tsa.certchain.pem` is present in the configured TUF keys
- Adds unit tests for the new `hasTSAKey` helper

## Details
The bug manifests when a user deploys RHTAS without TSA (removing `tsa.certchain.pem` from TUF keys). In `external` mode, `resolveServiceURLs()` always tries to look up the TSA ingress, which doesn't exist, causing TUF initialization to fail with an ingress-not-found error.

The fix aligns `resolveServiceURLs()` with the existing pattern in `utils/tuf_init_job.go`, where TSA args are only added when the `tsa.certchain.pem` key is present in the spec.

Fixes: SECURESIGN-4125

## Test plan
- [ ] Unit tests pass (`go test ./internal/controller/tuf/actions/...`)
- [ ] E2E: Deploy RHTAS without TSA, verify TUF init succeeds with `signingConfigURLMode: external`
- [ ] E2E: Deploy RHTAS with TSA, verify TUF init still resolves TSA ingress correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Jira: https://issues.redhat.com/browse/SECURESIGN-4125