### PR TITLE
fix: guard against nil RootKeySecretRef in TUF init job

### DIFF
--- a/internal/controller/tuf/actions/migration_job_test.go
+++ b/internal/controller/tuf/actions/migration_job_test.go
@@ -114,6 +114,58 @@ func TestMigrateJob_NoRootKeySecret(t *testing.T) {
 	g.Expect(*deployment.Spec.Replicas).To(BeNumerically("==", 1))
 }
 
+func TestMigrateJob_NilRootKeySecretRef(t *testing.T) {
+	g := NewWithT(t)
+
+	migrateJobTestAction := setupMigrateAction()
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tufConstants.DeploymentName,
+			Namespace: t.Name(),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+		},
+	}
+	g.Expect(migrateJobTestAction.Client.Create(t.Context(), deployment)).To(Succeed())
+
+	instance := &v1alpha1.Tuf{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: t.Name(),
+		},
+		Spec: v1alpha1.TufSpec{
+			// RootKeySecretRef is nil — simulates upgrade with externally stored TUF signing keys
+			RootKeySecretRef:    nil,
+			SigningConfigURLMode: v1alpha1.SigningConfigURLInternal,
+		},
+		Status: v1alpha1.TufStatus{Conditions: []metav1.Condition{
+			{
+				Type:   constants.ReadyCondition,
+				Reason: state.Initialize.String(),
+				Status: metav1.ConditionFalse,
+			},
+		}}}
+	g.Expect(migrateJobTestAction.Client.Create(t.Context(), instance)).To(Succeed())
+
+	g.Expect(migrateJobTestAction.CanHandle(t.Context(), instance)).To(BeTrue())
+	result := migrateJobTestAction.Handle(t.Context(), instance)
+	g.Expect(result.Err).To(HaveOccurred())
+	g.Expect(result.Err).To(MatchError(ContainSubstring("cannot migrate TUF: root key secret not specified")))
+
+	g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Reason).To(Equal(state.Failure.String()))
+	g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Message).To(ContainSubstring("cannot migrate TUF: root key secret not specified"))
+
+	// Verify deployment is NOT touched (non-destructive)
+	g.Expect(migrateJobTestAction.Client.Get(t.Context(), client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+	g.Expect(*deployment.Spec.Replicas).To(BeNumerically("==", 1))
+
+	// Verify no migration job was created
+	jobList := &batchv1.JobList{}
+	g.Expect(migrateJobTestAction.Client.List(t.Context(), jobList, client.InNamespace(t.Name()))).To(Succeed())
+	g.Expect(jobList.Items).To(BeEmpty())
+}
+
 func TestMigrateJob_Succeeded(t *testing.T) {
 	g := NewWithT(t)
 

--- a/internal/controller/tuf/utils/tuf_init_job.go
+++ b/internal/controller/tuf/utils/tuf_init_job.go
@@ -23,6 +23,10 @@ const (
 
 func EnsureTufInitJob(instance *rhtasv1alpha1.Tuf, sa string, labels map[string]string, oidcIssuers []string) func(*batchv1.Job) error {
 	return func(job *batchv1.Job) error {
+		if instance.Spec.RootKeySecretRef == nil {
+			return fmt.Errorf("rootKeySecretRef is not set")
+		}
+
 		// prepare args
 		args := []string{"--operator", constants.OperatorName, "--export-keys", instance.Spec.RootKeySecretRef.Name}
 		for _, key := range instance.Spec.Keys {

--- a/internal/controller/tuf/utils/tuf_init_job_test.go
+++ b/internal/controller/tuf/utils/tuf_init_job_test.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"testing"
+
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEnsureTufInitJob_NilRootKeySecretRef(t *testing.T) {
+	instance := &rhtasv1alpha1.Tuf{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tuf",
+			Namespace: "test-ns",
+		},
+		Spec: rhtasv1alpha1.TufSpec{
+			Port: 8080,
+			Keys: []rhtasv1alpha1.TufKey{
+				{
+					Name: "rekor.pub",
+					SecretRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "rekor-pub-key"},
+						Key:                  "public",
+					},
+				},
+			},
+			RootKeySecretRef: nil,
+		},
+	}
+
+	job := &batchv1.Job{}
+	ensureFn := EnsureTufInitJob(instance, "test-sa", map[string]string{"app": "tuf"}, nil)
+	err := ensureFn(job)
+	if err == nil {
+		t.Fatal("expected error when RootKeySecretRef is nil, got nil")
+	}
+	if err.Error() != "rootKeySecretRef is not set" {
+		t.Errorf("unexpected error message: %s", err.Error())
+	}
+}
+
+func TestEnsureTufInitJob_WithRootKeySecretRef(t *testing.T) {
+	instance := &rhtasv1alpha1.Tuf{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tuf",
+			Namespace: "test-ns",
+		},
+		Spec: rhtasv1alpha1.TufSpec{
+			Port: 8080,
+			Keys: []rhtasv1alpha1.TufKey{
+				{
+					Name: "rekor.pub",
+					SecretRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "rekor-pub-key"},
+						Key:                  "public",
+					},
+				},
+			},
+			Rekor: rhtasv1alpha1.RekorService{
+				Address: "http://rekor.test-ns.svc",
+			},
+			RootKeySecretRef: &rhtasv1alpha1.LocalObjectReference{Name: "tuf-root-keys"},
+		},
+		Status: rhtasv1alpha1.TufStatus{
+			Keys: []rhtasv1alpha1.TufKey{
+				{
+					Name: "rekor.pub",
+					SecretRef: &rhtasv1alpha1.SecretKeySelector{
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "rekor-pub-key"},
+						Key:                  "public",
+					},
+				},
+			},
+			PvcName: "tuf-pvc",
+		},
+	}
+
+	job := &batchv1.Job{}
+	ensureFn := EnsureTufInitJob(instance, "test-sa", map[string]string{"app": "tuf"}, nil)
+	err := ensureFn(job)
+	if err != nil {
+		t.Fatalf("unexpected error when RootKeySecretRef is set: %v", err)
+	}
+
+	// Verify the job was configured with the correct export-keys argument
+	container := job.Spec.Template.Spec.Containers[0]
+	found := false
+	for _, arg := range container.Args {
+		if len(arg) > 0 && contains(arg, "--export-keys tuf-root-keys") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected --export-keys tuf-root-keys in args, got: %v", container.Args)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- During an upgrade from an older operator version, `RootKeySecretRef` may be nil if the field wasn't present in the original CRD. `EnsureTufInitJob` dereferences it without a nil check, causing a panic.
- Added a nil guard that returns a clear error (`rootKeySecretRef is not set`) instead of panicking.
- Added unit tests for both the nil case (safe error state) and the normal case (correct `--export-keys` argument).

Supersedes #1732
Related: SECURESIGN-4125

## Test plan
- [x] `TestEnsureTufInitJob_NilRootKeySecretRef` — verifies nil `RootKeySecretRef` produces a clean error, no panic
- [x] `TestEnsureTufInitJob_WithRootKeySecretRef` — verifies normal operation and correct job args
- [x] All existing TUF controller and action tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)