### PR TITLE
chore: initialise 1.4.1 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
   IMG: ghcr.io/securesign/secure-sign-operator:dev-${{ github.sha }}
   BUNDLE_IMG: ghcr.io/securesign/secure-sign-operator-bundle:dev-${{ github.sha }}
   CATALOG_IMG: ghcr.io/securesign/secure-sign-operator-fbc:dev-${{ github.sha }}
-  NEW_OLM_CHANNEL: rhtas-operator.v1.4.0
+  NEW_OLM_CHANNEL: rhtas-operator.v1.4.1
   OCP_VERSION: ${{ vars.OLM_INDEX_VERSION }}
 
 jobs:

--- a/.tekton/rhtas-operator-bundle-pull-request.yaml
+++ b/.tekton/rhtas-operator-bundle-pull-request.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.4.1"
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -42,7 +42,7 @@ spec:
   - name: image-expires-after
     value: 5d
   - name: manager-pipelinerun-selector
-    value: appstudio.openshift.io/application=operator,appstudio.openshift.io/component=rhtas-operator,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (pull_request,incoming,retest-all-comment)
+    value: appstudio.openshift.io/application=operator-v1-4,appstudio.openshift.io/component=rhtas-operator-v1-4,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (pull_request,incoming,retest-all-comment)
   - name: manager-registry-url
     value: registry.redhat.io/rhtas/rhtas-rhel9-operator
   - name: fips-check

--- a/.tekton/rhtas-operator-bundle-push.yaml
+++ b/.tekton/rhtas-operator-bundle-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.4.1"
   - name: git-url
     value: '{{source_url}}'
   - name: revision
@@ -38,7 +38,7 @@ spec:
   - name: hermetic
     value: "true"
   - name: manager-pipelinerun-selector
-    value: appstudio.openshift.io/application=operator,appstudio.openshift.io/component=rhtas-operator,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (push,incoming,retest-all-comment)
+    value: appstudio.openshift.io/application=operator-v1-4,appstudio.openshift.io/component=rhtas-operator-v1-4,pipelinesascode.tekton.dev/sha={{revision}},pipelinesascode.tekton.dev/event-type in (push,incoming,retest-all-comment)
   - name: manager-registry-url
     value: registry.redhat.io/rhtas/rhtas-rhel9-operator
   - name: fips-check

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.4.1"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rhtas-operator-push.yaml
+++ b/.tekton/rhtas-operator-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.0"
+    value: "1.4.1"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/Dockerfile.rhtas-operator.rh
+++ b/Dockerfile.rhtas-operator.rh
@@ -1,4 +1,4 @@
-ARG VERSION="1.4.0"
+ARG VERSION="1.4.1"
 
 # Build the manager binary
 FROM registry.redhat.io/ubi9/go-toolset:9.7-1776763740@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS builder

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.4.0
+VERSION ?= 1.4.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION="1.4.0"
+ARG VERSION="1.4.1"
 ARG CHANNELS="stable,stable-v1.4"
 ARG DEFAULT_CHANNEL="stable"
 ARG BUNDLE_GEN_FLAGS="-q --overwrite=false --version $VERSION --channels=$CHANNELS --default-channel=$DEFAULT_CHANNEL"

--- a/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["Red Hat Trusted Artifact Signer"]'
     repository: https://github.com/securesign/secure-sign-operator
     support: Red Hat
-  name: rhtas-operator.v1.4.0
+  name: rhtas-operator.v1.4.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -112,4 +112,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/securesign/secure-sign-operator
-  version: 1.4.0
+  version: 1.4.1


### PR DESCRIPTION
## Summary
Initialize version 1.4.1 patch release

- Bump VERSION from 1.4.0 → 1.4.1
- Update NEW_OLM_CHANNEL to rhtas-operator.v1.4.1
- CHANNELS unchanged (stable,stable-v1.4)
- Image digest unchanged (will be updated by build pipeline)

## Files changed
- Makefile
- bundle.Dockerfile
- Dockerfile.rhtas-operator.rh
- config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
- .github/workflows/main.yml
- .tekton/rhtas-operator-*.yaml (4 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)