### PR TITLE
feat: add gRPC client-side load balancing for trillian-logserver

### DIFF
--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -140,6 +140,7 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 			"--trillian_log_server.address", instance.Spec.Trillian.Address,
 			"--trillian_log_server.port", strconv.Itoa(int(*instance.Spec.Trillian.Port)),
 			"--trillian_log_server.sharding_config", "/sharding/sharding-config.yaml",
+			"--trillian_log_server.grpc_default_service_config", `{"loadBalancingConfig":[{"round_robin":{}}]}`,
 
 			"--rekor_server.address", "0.0.0.0",
 			// boolean flag MUST be without parameter (default value) or use the equal sign (https://github.com/spf13/pflag?tab=readme-ov-file#command-line-flag-syntax)

--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -62,7 +62,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 
 	insCopy := instance.DeepCopy()
 	if insCopy.Spec.Trillian.Address == "" {
-		insCopy.Spec.Trillian.Address = fmt.Sprintf("%s.%s.svc", actions2.LogserverDeploymentName, instance.Namespace)
+		insCopy.Spec.Trillian.Address = fmt.Sprintf("dns:///%s.%s.svc", actions2.LogserverDeploymentName, instance.Namespace)
 	}
 	i.Logger.V(1).Info("trillian logserver", "address", insCopy.Spec.Trillian.Address)
 

--- a/internal/controller/rekor/actions/server/deployment_test.go
+++ b/internal/controller/rekor/actions/server/deployment_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/controller/rekor/actions"
+	actions2 "github.com/securesign/operator/internal/controller/trillian/actions"
+	"github.com/securesign/operator/internal/state"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	v2 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	testNamespace  = "default"
+	testPrivateKey = "private"
+)
+
+func TestDeployAction_Handle_DefaultTrillianAddress(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+
+	instance := &rhtasv1alpha1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rekor",
+			Namespace: testNamespace,
+		},
+		Spec: rhtasv1alpha1.RekorSpec{
+			Trillian: rhtasv1alpha1.TrillianService{
+				Port: ptr.To[int32](8091),
+			},
+			Signer: rhtasv1alpha1.RekorSigner{
+				KMS: signerKMSSecret,
+			},
+			SearchIndex: rhtasv1alpha1.SearchIndex{
+				Create: ptr.To(true),
+			},
+		},
+		Status: rhtasv1alpha1.RekorStatus{
+			TreeID:          ptr.To[int64](123456),
+			ServerConfigRef: &rhtasv1alpha1.LocalObjectReference{Name: "test-config"},
+			Signer: rhtasv1alpha1.RekorSigner{
+				KeyRef: &rhtasv1alpha1.SecretKeySelector{
+					LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "signer-secret"},
+					Key:                  testPrivateKey,
+				},
+			},
+		},
+	}
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:   constants.ReadyCondition,
+		Status: metav1.ConditionFalse,
+		Reason: state.Creating.String(),
+	})
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:   actions.ServerCondition,
+		Status: metav1.ConditionFalse,
+		Reason: state.Creating.String(),
+	})
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewDeployAction())
+	result := a.Handle(ctx, instance)
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).ToNot(HaveOccurred())
+
+	dep := &v2.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{
+		Name:      actions.ServerDeploymentName,
+		Namespace: testNamespace,
+	}, dep)).To(Succeed())
+
+	container := dep.Spec.Template.Spec.Containers[0]
+	g.Expect(container.Args).To(ContainElement("dns:///" + actions2.LogserverDeploymentName + "." + testNamespace + ".svc"))
+	g.Expect(container.Args).To(ContainElement(`{"loadBalancingConfig":[{"round_robin":{}}]}`))
+}

--- a/internal/controller/trillian/actions/logserver/service.go
+++ b/internal/controller/trillian/actions/logserver/service.go
@@ -14,8 +14,10 @@ import (
 	"github.com/securesign/operator/internal/state"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -69,11 +71,19 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 		})
 	}
 
+	// Migrate existing ClusterIP service to headless: ClusterIP is immutable,
+	// so we must delete and recreate if it was previously a regular service.
+	if migrated, err := i.migrateToHeadless(ctx, instance); err != nil {
+		return i.Error(ctx, fmt.Errorf("could not migrate service to headless: %w", err), instance)
+	} else if migrated {
+		return i.Requeue()
+	}
+
 	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client,
 		&v1.Service{
 			ObjectMeta: metav1.ObjectMeta{Name: actions.LogserverDeploymentName, Namespace: instance.Namespace},
 		},
-		kubernetes.EnsureServiceSpec(labels, ports...),
+		kubernetes.EnsureHeadlessServiceSpec(labels, ports...),
 		ensure.ControllerReference[*v1.Service](instance, i.Client),
 		ensure.Labels[*v1.Service](slices.Collect(maps.Keys(labels)), labels),
 		//TLS: Annotate service
@@ -93,4 +103,34 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 	} else {
 		return i.Continue()
 	}
+}
+
+// migrateToHeadless checks if the existing trillian-logserver service has a
+// ClusterIP assigned (non-headless). Since ClusterIP is an immutable field,
+// the service must be deleted so it can be recreated as headless on the next
+// reconciliation. Headless services are required for gRPC client-side load
+// balancing (round_robin) because DNS must return individual pod IPs.
+func (i createServiceAction) migrateToHeadless(ctx context.Context, instance *rhtasv1alpha1.Trillian) (bool, error) {
+	existing := &v1.Service{}
+	err := i.Client.Get(ctx, types.NamespacedName{
+		Name:      actions.LogserverDeploymentName,
+		Namespace: instance.Namespace,
+	}, existing)
+	if apiErrors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	if existing.Spec.ClusterIP != v1.ClusterIPNone {
+		i.Logger.Info("Deleting ClusterIP service to recreate as headless for gRPC load balancing",
+			"service", actions.LogserverDeploymentName)
+		if err := i.Client.Delete(ctx, existing); err != nil && !apiErrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to delete service: %w", err)
+		}
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/internal/controller/trillian/actions/logserver/service_test.go
+++ b/internal/controller/trillian/actions/logserver/service_test.go
@@ -1,0 +1,153 @@
+package logserver
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/controller/trillian/actions"
+	"github.com/securesign/operator/internal/state"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestMigrateToHeadless(t *testing.T) {
+	ctx := context.TODO()
+
+	tests := []struct {
+		name           string
+		objects        []client.Object
+		expectMigrated bool
+		expectErr      bool
+		expectDeleted  bool
+	}{
+		{
+			name:           "no existing service - nothing to migrate",
+			objects:        []client.Object{},
+			expectMigrated: false,
+			expectErr:      false,
+			expectDeleted:  false,
+		},
+		{
+			name: "existing ClusterIP service - should delete for migration",
+			objects: []client.Object{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      actions.LogserverDeploymentName,
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						ClusterIP: "10.0.0.1",
+						Selector:  map[string]string{"app": "trillian-logserver"},
+						Ports: []v1.ServicePort{
+							{Name: "grpc", Port: 8091},
+						},
+					},
+				},
+			},
+			expectMigrated: true,
+			expectErr:      false,
+			expectDeleted:  true,
+		},
+		{
+			name: "existing headless service - no migration needed",
+			objects: []client.Object{
+				&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      actions.LogserverDeploymentName,
+						Namespace: "default",
+					},
+					Spec: v1.ServiceSpec{
+						ClusterIP: v1.ClusterIPNone,
+						Selector:  map[string]string{"app": "trillian-logserver"},
+						Ports: []v1.ServicePort{
+							{Name: "grpc", Port: 8091},
+						},
+					},
+				},
+			},
+			expectMigrated: false,
+			expectErr:      false,
+			expectDeleted:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(tt.objects...).
+				Build()
+
+			a := testAction.PrepareAction(c, NewCreateServiceAction())
+			action := a.(*createServiceAction)
+
+			instance := &rhtasv1alpha1.Trillian{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-trillian",
+					Namespace: "default",
+				},
+			}
+
+			migrated, err := action.migrateToHeadless(ctx, instance)
+
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+			}
+			g.Expect(migrated).To(Equal(tt.expectMigrated))
+
+			if tt.expectDeleted {
+				svc := &v1.Service{}
+				err := c.Get(ctx, client.ObjectKey{
+					Name:      actions.LogserverDeploymentName,
+					Namespace: "default",
+				}, svc)
+				g.Expect(err).To(HaveOccurred())
+			}
+		})
+	}
+}
+
+func TestCreateServiceAction_Handle_CreatesHeadless(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+
+	instance := &rhtasv1alpha1.Trillian{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-trillian",
+			Namespace: "default",
+		},
+		Status: rhtasv1alpha1.TrillianStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   actions.ServerCondition,
+					Status: metav1.ConditionFalse,
+					Reason: state.Creating.String(),
+				},
+			},
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewCreateServiceAction())
+	result := a.Handle(ctx, instance)
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).ToNot(HaveOccurred())
+
+	svc := &v1.Service{}
+	g.Expect(c.Get(ctx, client.ObjectKey{
+		Name:      actions.LogserverDeploymentName,
+		Namespace: "default",
+	}, svc)).To(Succeed())
+	g.Expect(svc.Spec.ClusterIP).To(Equal(v1.ClusterIPNone))
+}

--- a/internal/controller/trillian/actions/logserver/service_test.go
+++ b/internal/controller/trillian/actions/logserver/service_test.go
@@ -15,8 +15,11 @@ import (
 )
 
 const (
-	testNamespace    = "default"
-	testTrillianName = "test-trillian"
+	testNamespace     = "default"
+	testTrillianName  = "test-trillian"
+	testSelectorKey   = "app"
+	testSelectorValue = "trillian-logserver"
+	testPortName      = "grpc"
 )
 
 func TestMigrateToHeadless(t *testing.T) {
@@ -46,9 +49,9 @@ func TestMigrateToHeadless(t *testing.T) {
 					},
 					Spec: v1.ServiceSpec{
 						ClusterIP: "10.0.0.1",
-						Selector:  map[string]string{"app": "trillian-logserver"},
+						Selector:  map[string]string{testSelectorKey: testSelectorValue},
 						Ports: []v1.ServicePort{
-							{Name: "grpc", Port: 8091},
+							{Name: testPortName, Port: actions.ServerPort},
 						},
 					},
 				},
@@ -67,9 +70,9 @@ func TestMigrateToHeadless(t *testing.T) {
 					},
 					Spec: v1.ServiceSpec{
 						ClusterIP: v1.ClusterIPNone,
-						Selector:  map[string]string{"app": "trillian-logserver"},
+						Selector:  map[string]string{testSelectorKey: testSelectorValue},
 						Ports: []v1.ServicePort{
-							{Name: "grpc", Port: 8091},
+							{Name: testPortName, Port: actions.ServerPort},
 						},
 					},
 				},
@@ -155,4 +158,57 @@ func TestCreateServiceAction_Handle_CreatesHeadless(t *testing.T) {
 		Namespace: testNamespace,
 	}, svc)).To(Succeed())
 	g.Expect(svc.Spec.ClusterIP).To(Equal(v1.ClusterIPNone))
+}
+
+func TestCreateServiceAction_Handle_MigratesClusterIP(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+
+	instance := &rhtasv1alpha1.Trillian{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTrillianName,
+			Namespace: testNamespace,
+		},
+		Status: rhtasv1alpha1.TrillianStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   actions.ServerCondition,
+					Status: metav1.ConditionFalse,
+					Reason: state.Creating.String(),
+				},
+			},
+		},
+	}
+
+	existingSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      actions.LogserverDeploymentName,
+			Namespace: testNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Selector:  map[string]string{testSelectorKey: testSelectorValue},
+			Ports: []v1.ServicePort{
+				{Name: testPortName, Port: actions.ServerPort},
+			},
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance, existingSvc).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewCreateServiceAction())
+	result := a.Handle(ctx, instance)
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).ToNot(HaveOccurred())
+	g.Expect(result.Result.RequeueAfter).To(BeNumerically(">", 0))
+
+	svc := &v1.Service{}
+	err := c.Get(ctx, client.ObjectKey{
+		Name:      actions.LogserverDeploymentName,
+		Namespace: testNamespace,
+	}, svc)
+	g.Expect(err).To(HaveOccurred())
 }

--- a/internal/controller/trillian/actions/logserver/service_test.go
+++ b/internal/controller/trillian/actions/logserver/service_test.go
@@ -14,6 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	testNamespace    = "default"
+	testTrillianName = "test-trillian"
+)
+
 func TestMigrateToHeadless(t *testing.T) {
 	ctx := context.TODO()
 
@@ -37,7 +42,7 @@ func TestMigrateToHeadless(t *testing.T) {
 				&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      actions.LogserverDeploymentName,
-						Namespace: "default",
+						Namespace: testNamespace,
 					},
 					Spec: v1.ServiceSpec{
 						ClusterIP: "10.0.0.1",
@@ -58,7 +63,7 @@ func TestMigrateToHeadless(t *testing.T) {
 				&v1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      actions.LogserverDeploymentName,
-						Namespace: "default",
+						Namespace: testNamespace,
 					},
 					Spec: v1.ServiceSpec{
 						ClusterIP: v1.ClusterIPNone,
@@ -88,8 +93,8 @@ func TestMigrateToHeadless(t *testing.T) {
 
 			instance := &rhtasv1alpha1.Trillian{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-trillian",
-					Namespace: "default",
+					Name:      testTrillianName,
+					Namespace: testNamespace,
 				},
 			}
 
@@ -106,7 +111,7 @@ func TestMigrateToHeadless(t *testing.T) {
 				svc := &v1.Service{}
 				err := c.Get(ctx, client.ObjectKey{
 					Name:      actions.LogserverDeploymentName,
-					Namespace: "default",
+					Namespace: testNamespace,
 				}, svc)
 				g.Expect(err).To(HaveOccurred())
 			}
@@ -120,8 +125,8 @@ func TestCreateServiceAction_Handle_CreatesHeadless(t *testing.T) {
 
 	instance := &rhtasv1alpha1.Trillian{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-trillian",
-			Namespace: "default",
+			Name:      testTrillianName,
+			Namespace: testNamespace,
 		},
 		Status: rhtasv1alpha1.TrillianStatus{
 			Conditions: []metav1.Condition{
@@ -147,7 +152,7 @@ func TestCreateServiceAction_Handle_CreatesHeadless(t *testing.T) {
 	svc := &v1.Service{}
 	g.Expect(c.Get(ctx, client.ObjectKey{
 		Name:      actions.LogserverDeploymentName,
-		Namespace: "default",
+		Namespace: testNamespace,
 	}, svc)).To(Succeed())
 	g.Expect(svc.Spec.ClusterIP).To(Equal(v1.ClusterIPNone))
 }

--- a/internal/utils/kubernetes/service.go
+++ b/internal/utils/kubernetes/service.go
@@ -35,3 +35,16 @@ func EnsureServiceSpec(selectorLabels map[string]string, ports ...corev1.Service
 		return nil
 	}
 }
+
+// EnsureHeadlessServiceSpec sets ClusterIP to None, making the service headless.
+// Headless services return individual pod IPs in DNS responses instead of a
+// single virtual IP, which is required for gRPC client-side load balancing.
+func EnsureHeadlessServiceSpec(selectorLabels map[string]string, ports ...corev1.ServicePort) func(*corev1.Service) error {
+	return func(svc *corev1.Service) error {
+		spec := &svc.Spec
+		spec.Selector = selectorLabels
+		spec.Ports = ports
+		spec.ClusterIP = corev1.ClusterIPNone
+		return nil
+	}
+}

--- a/internal/utils/kubernetes/service_test.go
+++ b/internal/utils/kubernetes/service_test.go
@@ -81,3 +81,57 @@ func TestService(t *testing.T) {
 		})
 	}
 }
+
+func TestHeadlessService(t *testing.T) {
+	tests := []struct {
+		name    string
+		objects []client.Object
+		result  controllerutil.OperationResult
+	}{
+		{
+			"create new headless service",
+			[]client.Object{},
+			controllerutil.OperationResultCreated,
+		},
+		{
+			"existing headless service with expected values",
+			[]client.Object{
+				&v1.Service{
+					ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"},
+					Spec: v1.ServiceSpec{
+						ClusterIP: v1.ClusterIPNone,
+						Ports: []v1.ServicePort{
+							{Name: "grpc", Port: 8091},
+						},
+						Selector: map[string]string{"app": "logserver"},
+					},
+				},
+			},
+			controllerutil.OperationResultNone,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			g := gomega.NewWithT(t)
+			c := testAction.FakeClientBuilder().
+				WithObjects(tt.objects...).
+				Build()
+
+			ports := []v1.ServicePort{{Name: "grpc", Port: 8091}}
+			l := map[string]string{"app": "logserver"}
+
+			result, err := CreateOrUpdate(ctx, c,
+				&v1.Service{ObjectMeta: v2.ObjectMeta{Name: name, Namespace: "default"}},
+				EnsureHeadlessServiceSpec(l, ports...))
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(result).To(gomega.Equal(tt.result))
+
+			existing := &v1.Service{}
+			g.Expect(c.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, existing)).To(gomega.Succeed())
+			g.Expect(existing.Spec.Ports).To(gomega.Equal(ports))
+			g.Expect(existing.Spec.Selector).To(gomega.Equal(l))
+			g.Expect(existing.Spec.ClusterIP).To(gomega.Equal(v1.ClusterIPNone))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Switch `trillian-logserver` service to headless to enable gRPC client-side 
  load balancing (round_robin), fixes severely uneven CPU distribution 
  across replicas caused by the default `pick_first` policy
- Add `grpc_default_service_config` flag to `rekor-server` for round_robin.
- Handle ClusterIP -> headless migration (ClusterIP is immutable, so existing 
  services are deleted and recreated)

## Test
- Verified with rhtas-benchmark: `trillian-logserver` load balances evenly 
  across replicas after the change
- Upgrade from previous version tested,  migration from ClusterIP to 
  headless service works correctly

## Notes
- `ctlog` already load balances by [default](https://github.com/securesign/certificate-transparency-go/blob/727cb5d8e6c477051497b587b853899b54b6a1d9/trillian/ctfe/ct_server/main.go#L208), no changes needed 
- `fulcio` -> `ctlog` uses HTTP/2 via a regular ClusterIP service; improving 
  that path is out of scope for this fix

## Known limitation
New `trillian-logserver` replicas will not receive traffic until an existing connection is lost, which triggers DNS re-resolution

ref: [SECURESIGN-2935](https://redhat.atlassian.net/browse/SECURESIGN-2935)
