### PR TITLE
fix(SECURESIGN-4123): reduce cache memory footprint with label selectors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -168,8 +168,6 @@ func main() {
 	// Restrict informer caches for high-cardinality core types to only objects managed by this operator.
 	// Without this, each Owns() watch caches ALL objects of that type cluster-wide, causing OOM on
 	// production clusters with hundreds of Deployments/Services from other workloads (SECURESIGN-4123).
-	// Secrets and ConfigMaps are intentionally excluded: user-provided refs (e.g. Spec.RootKeySecretRef,
-	// Spec.Signer.File.PrivateKeyRef, Spec.Db.DatabaseSecretRef) may lack operator labels.
 	operatorLabelSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			labels.LabelAppPartOf: constants.AppName,
@@ -186,7 +184,9 @@ func main() {
 	cacheOpts := cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
 			&appsv1.Deployment{}:    operatorCacheSelector,
+			&appsv1.ReplicaSet{}:    operatorCacheSelector,
 			&appsv1.StatefulSet{}:   operatorCacheSelector,
+			&corev1.Pod{}:           operatorCacheSelector,
 			&corev1.Service{}:       operatorCacheSelector,
 			&networkingv1.Ingress{}: operatorCacheSelector,
 			&batchv1.CronJob{}:      operatorCacheSelector,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -183,13 +183,15 @@ func main() {
 
 	cacheOpts := cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
-			&appsv1.Deployment{}:    operatorCacheSelector,
-			&appsv1.ReplicaSet{}:    operatorCacheSelector,
-			&appsv1.StatefulSet{}:   operatorCacheSelector,
-			&corev1.Pod{}:           operatorCacheSelector,
-			&corev1.Service{}:       operatorCacheSelector,
-			&networkingv1.Ingress{}: operatorCacheSelector,
-			&batchv1.CronJob{}:      operatorCacheSelector,
+			&appsv1.Deployment{}:            operatorCacheSelector,
+			&appsv1.ReplicaSet{}:            operatorCacheSelector,
+			&appsv1.StatefulSet{}:           operatorCacheSelector,
+			&corev1.Pod{}:                   operatorCacheSelector,
+			&corev1.Service{}:               operatorCacheSelector,
+			&networkingv1.Ingress{}:         operatorCacheSelector,
+			&batchv1.CronJob{}:              operatorCacheSelector,
+			&batchv1.Job{}:                  operatorCacheSelector,
+			&corev1.PersistentVolumeClaim{}: operatorCacheSelector,
 		},
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,10 +22,17 @@ import (
 	"os"
 
 	appconfig "github.com/securesign/operator/internal/config"
+	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/controller"
 	"github.com/securesign/operator/internal/images"
+	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -158,8 +165,32 @@ func main() {
 		TLSOpts: tlsOpts,
 	})
 
+	// Restrict informer caches for high-cardinality core types to only objects managed by this operator.
+	// Without this, each Owns() watch caches ALL objects of that type cluster-wide, causing OOM on
+	// production clusters with hundreds of Deployments/Services from other workloads (SECURESIGN-4123).
+	// Secrets and ConfigMaps are intentionally excluded: user-provided refs (e.g. Spec.RootKeySecretRef,
+	// Spec.Signer.File.PrivateKeyRef, Spec.Db.DatabaseSecretRef) may lack operator labels.
+	operatorLabelSelector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			labels.LabelAppPartOf: constants.AppName,
+		},
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to create operator label selector for cache")
+		os.Exit(1)
+	}
+	operatorCacheSelector := cache.ByObject{
+		Label: operatorLabelSelector,
+	}
+
 	cacheOpts := cache.Options{
-		ByObject: map[client.Object]cache.ByObject{},
+		ByObject: map[client.Object]cache.ByObject{
+			&appsv1.Deployment{}:    operatorCacheSelector,
+			&appsv1.StatefulSet{}:   operatorCacheSelector,
+			&corev1.Service{}:       operatorCacheSelector,
+			&networkingv1.Ingress{}: operatorCacheSelector,
+			&batchv1.CronJob{}:      operatorCacheSelector,
+		},
 	}
 
 	if kubernetes.IsOpenShift() {

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -91,9 +91,9 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
-            memory: 64Mi
+            memory: 128Mi
       serviceAccountName: operator-controller-manager
       terminationGracePeriodSeconds: 10

--- a/internal/action/tree/action.go
+++ b/internal/action/tree/action.go
@@ -251,6 +251,10 @@ func (i resolveTree[T]) handleJob(ctx context.Context, instance T) *action.Resul
 		ensure.ControllerReference[*batchv1.Job](instance, i.Client),
 		ensure.Labels[*batchv1.Job](slices.Collect(maps.Keys(labels)), labels),
 		func(object *batchv1.Job) error {
+			object.Spec.Template.Labels = labels
+			return nil
+		},
+		func(object *batchv1.Job) error {
 			return ensureTls.TrustedCA(instance.GetTrustedCA(), createTreeContainerName)(&object.Spec.Template)
 		},
 	); err != nil {

--- a/internal/controller/rekor/actions/backfillRedis/backfill_redis_cronjob.go
+++ b/internal/controller/rekor/actions/backfillRedis/backfill_redis_cronjob.go
@@ -107,6 +107,7 @@ func (i backfillRedisCronJob) Handle(ctx context.Context, instance *rhtasv1alpha
 func (i backfillRedisCronJob) ensureBacfillCronJob(instance *rhtasv1alpha1.Rekor) func(*batchv1.CronJob) error {
 	return func(job *batchv1.CronJob) error {
 		job.Spec.Schedule = instance.Spec.BackFillRedis.Schedule
+		job.Spec.JobTemplate.Spec.Template.Labels = labels.For(actions.BackfillRedisCronJobName, actions.BackfillRedisCronJobName, instance.Name)
 		templateSpec := &job.Spec.JobTemplate.Spec.Template.Spec
 		templateSpec.ServiceAccountName = actions.RBACName
 		templateSpec.RestartPolicy = "OnFailure"


### PR DESCRIPTION
## Summary

Restrict `controller-runtime` informer caches for high-cardinality core types (`Deployment`, `ReplicaSet`, `StatefulSet`, `Pod`, `Service`, `Ingress`, `CronJob`) to only objects labeled `app.kubernetes.io/part-of: trusted-artifact-signer`. Without this, each `Owns()` watch caches ALL objects of that type cluster-wide, causing OOM on production clusters

Bump memory limit to 512Mi and request to 128Mi

Peak RSS: >256 MiB (OOM) → ~80 MiB with all filters active

ref: [SECURESIGN-4123](https://redhat.atlassian.net/browse/SECURESIGN-4123)