### PR TITLE
ci: wait for namespace deletion in e2e tests

### DIFF
--- a/test/e2e/namespaced.go
+++ b/test/e2e/namespaced.go
@@ -51,7 +51,7 @@ var _ = Describe("Install components to separate namespaces", Ordered, func() {
 					continue
 				}
 				steps.DumpNamespace(cli, n)(ctx)
-				_ = cli.Delete(ctx, n)
+				support.DeleteNamespace(ctx, cli, n)
 			}
 		})
 		for i := range namespaces {

--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -11,10 +11,12 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 	v12 "k8s.io/api/apps/v1"
 	v13 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -74,6 +76,16 @@ func CreateTestNamespace(ctx context.Context, cli client.Client) *v1.Namespace {
 	Expect(cli.Create(ctx, ns)).To(Succeed())
 	core.GinkgoWriter.Println("Created test namespace: " + ns.Name)
 	return ns
+}
+
+// DeleteNamespace deletes a namespace and waits for it to be fully removed.
+// Without the wait, Kubernetes' async deletion leaves cluster-scoped or uniquely-constrained
+// resources alive, causing conflicts when the next test creates resources with the same identifiers.
+func DeleteNamespace(ctx context.Context, cli client.Client, ns *v1.Namespace) {
+	_ = cli.Delete(ctx, ns)
+	Eventually(func(ctx context.Context) error {
+		return cli.Get(ctx, client.ObjectKeyFromObject(ns), &v1.Namespace{})
+	}).WithContext(ctx).WithTimeout(1 * time.Minute).Should(And(HaveOccurred(), WithTransform(errors.IsNotFound, BeTrue())))
 }
 
 func PrepareImage(ctx context.Context) string {

--- a/test/e2e/support/steps/namespace.go
+++ b/test/e2e/support/steps/namespace.go
@@ -15,7 +15,7 @@ func CreateNamespace(cli client.Client, callback func(*v1.Namespace)) func(ctx g
 	return func(ctx ginkgo.SpecContext) {
 		namespace := support.CreateTestNamespace(ctx, cli)
 		ginkgo.DeferCleanup(func(ctx ginkgo.SpecContext) {
-			_ = cli.Delete(ctx, namespace)
+			support.DeleteNamespace(ctx, cli, namespace)
 		})
 		ginkgo.DeferCleanup(DumpNamespace(cli, namespace))
 		callback(namespace)


### PR DESCRIPTION
Refs: [SECURESIGN-3862](https://redhat.atlassian.net/browse/SECURESIGN-3862)