### PR TITLE
feat: Add configurable Ingress hostname template for non-OpenShift cluster

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ env:
   CATALOG_IMG: ghcr.io/securesign/secure-sign-operator-fbc:dev-${{ github.sha }}
   NEW_OLM_CHANNEL: rhtas-operator.v1.5.0
   OCP_VERSION: ${{ vars.OLM_INDEX_VERSION }}
+  INGRESS_HOST_TEMPLATE: '%[1]s.%[2]s.127.0.0.1.nip.io'
 
 jobs:
   build-operator:
@@ -244,9 +245,14 @@ jobs:
         run: |
           kubectl wait --for=condition=available deployment/rhtas-operator-controller-manager --timeout=120s -n openshift-rhtas-operator
 
+      - name: Configure Ingress hostname template
+        run: |
+          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
+          kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
+
       - name: Add service hosts to /etc/hosts
         run: |
-          sudo echo "127.0.0.1 fulcio-server.local tuf.local rekor-server.local keycloak-internal.keycloak-system.svc rekor-search-ui.local cli-server.local tsa-server.local" | sudo tee -a /etc/hosts
+          sudo echo "127.0.0.1 keycloak-internal.keycloak-system.svc" | sudo tee -a /etc/hosts
       - name: Install cosign
         run: go install github.com/sigstore/cosign/v3/cmd/cosign@v3.0.5
 
@@ -325,6 +331,8 @@ jobs:
           kind load image-archive operator-bundle-oci.tar
           kind load image-archive operator-fbc-oci.tar
 
+      # The base (released) operator version does not support INGRESS_HOST_TEMPLATE,
+      # so it produces static .local hostnames that require /etc/hosts entries.
       - name: Add service hosts to /etc/hosts
         run: |
           sudo echo "127.0.0.1 fulcio-server.local tuf.local rekor-server.local keycloak-internal.keycloak-system.svc rekor-search-ui.local cli-server.local tsa-server.local" | sudo tee -a /etc/hosts
@@ -339,6 +347,9 @@ jobs:
         env:
           TEST_BASE_CATALOG: registry.redhat.io/redhat/redhat-operator-index:${{ vars.OLM_INDEX_VERSION }}
           TEST_TARGET_CATALOG: ${{ env.CATALOG_IMG }}
+          # Keep default .local hostnames — the base operator doesn't support INGRESS_HOST_TEMPLATE,
+          # and switching hostnames mid-upgrade would break Ingress routing.
+          INGRESS_HOST_TEMPLATE: '%[1]s.local'
         run: go test -p 1 ./test/e2e/... -tags=upgrade -timeout 20m
 
       - name: Archive test artifacts
@@ -409,9 +420,14 @@ jobs:
         run: |
           kubectl wait --for=condition=available deployment/rhtas-operator-controller-manager --timeout=120s -n openshift-rhtas-operator
 
+      - name: Configure Ingress hostname template
+        run: |
+          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
+          kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
+
       - name: Add service hosts to /etc/hosts
         run: |
-          sudo echo "127.0.0.1 fulcio-server.local tuf.local rekor-server.local keycloak-internal.keycloak-system.svc rekor-search-ui.local cli-server.local tsa-server.local" | sudo tee -a /etc/hosts
+          sudo echo "127.0.0.1 keycloak-internal.keycloak-system.svc" | sudo tee -a /etc/hosts
 
       - name: Install cosign
         run: go install github.com/sigstore/cosign/v3/cmd/cosign@v3.0.5
@@ -489,7 +505,7 @@ jobs:
 
       - name: Add service hosts to /etc/hosts
         run: |
-          sudo echo "127.0.0.1 fulcio-server.local tuf.local rekor-server.local rekor-search-ui.local cli-server.local" | sudo tee -a /etc/hosts
+          echo "# service hosts added here if needed"
 
       - name: Replace images
         run: make dev-images generate && cat config/default/images.env
@@ -573,7 +589,7 @@ jobs:
 
       - name: Add service hosts to /etc/hosts
         run: |
-          sudo echo "127.0.0.1 fulcio-server.local tuf.local rekor-server.local rekor-search-ui.local tsa-server.local cli-server.local ${{ steps.kind.outputs.oidc_host }}" | sudo tee -a /etc/hosts
+          sudo echo "127.0.0.1 ${{ steps.kind.outputs.oidc_host }}" | sudo tee -a /etc/hosts
 
       - name: Replace images
         run: make dev-images generate && cat config/default/images.env
@@ -584,6 +600,11 @@ jobs:
       - name: Wait for operator to be ready
         run: |
           kubectl wait --for=condition=available deployment/rhtas-operator-controller-manager --timeout=120s -n openshift-rhtas-operator
+
+      - name: Configure Ingress hostname template
+        run: |
+          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
+          kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
 
       - name: Install securesign
         run: |
@@ -602,7 +623,7 @@ jobs:
           export FULCIO_URL=$(kubectl get fulcio -o jsonpath='{.items[0].status.url}' -n ${{ env.TEST_NAMESPACE }})
           
           export CLI_STRATEGY=cli_server
-          export CLI_SERVER_URL="http://cli-server.local"
+          export CLI_SERVER_URL="http://cli-server.trusted-artifact-signer.127.0.0.1.nip.io"
           
           cd e2e
           source ./tas-env-variables.sh

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,6 +111,9 @@ func main() {
 	utils.BoolFlagOrEnv(&appconfig.Openshift, "openshift", "OPENSHIFT", false, "Enable to ensures the operator applies OpenShift specific configurations.")
 	utils.StringFlagOrEnv(&appconfig.OpenshiftAPIServerName, "openshift-apiserver-name", "OPENSHIFT_APISERVER_NAME", "openshift-apiserver", "The OpenShift API Server name.")
 	utils.DurationFlagOrEnv(&appconfig.APIServerTimeout, "apiserver-timeout", "APISERVER_TIMEOUT", 30*time.Second, "The initial timeout for contacting the API Server, defaults to 30 seconds.")
+	utils.StringFlagOrEnv(&appconfig.IngressHostTemplate, "ingress-host-template", "INGRESS_HOST_TEMPLATE", appconfig.IngressHostTemplate,
+		"Default hostname template for non-OpenShift Ingress resources when ExternalAccess.Host is not set. "+
+			"Uses Go fmt.Sprintf with %[1]s=service name, %[2]s=namespace. Ignored on OpenShift.")
 	utils.RelatedImageFlag("trillian-log-signer-image", images.TrillianLogSigner, "The image used for trillian log signer.")
 	utils.RelatedImageFlag("trillian-log-server-image", images.TrillianServer, "The image used for trillian log server.")
 	utils.RelatedImageFlag("trillian-db-image", images.TrillianDb, "The image used for trillian's database.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,4 +7,5 @@ var (
 	Openshift              bool
 	OpenshiftAPIServerName string
 	APIServerTimeout       time.Duration
+	IngressHostTemplate    = "%[1]s.local"
 )

--- a/internal/utils/kubernetes/common.go
+++ b/internal/utils/kubernetes/common.go
@@ -86,7 +86,7 @@ func CalculateHostname(ctx context.Context, client client.Client, svcName, ns st
 		}
 		return fmt.Sprintf("%s-%s.%s", svcName, ns, ingress.Spec.Domain), nil
 	}
-	return svcName + ".local", nil
+	return fmt.Sprintf(config.IngressHostTemplate, svcName, ns), nil
 }
 
 func FindByLabelSelector(ctx context.Context, c client.Client, list client.ObjectList, namespace, labelSelector string) error {

--- a/internal/utils/kubernetes/common_test.go
+++ b/internal/utils/kubernetes/common_test.go
@@ -1,0 +1,135 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/securesign/operator/internal/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCalculateHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		svcName  string
+		ns       string
+		expected string
+	}{
+		{
+			name:     "default template produces static .local hostname",
+			template: "%[1]s.local",
+			svcName:  "rekor-server",
+			ns:       "test-ns",
+			expected: "rekor-server.local",
+		},
+		{
+			name:     "namespace-scoped template includes namespace",
+			template: "%[1]s.%[2]s.127.0.0.1.nip.io",
+			svcName:  "rekor-server",
+			ns:       "test-ns",
+			expected: "rekor-server.test-ns.127.0.0.1.nip.io",
+		},
+		{
+			name:     "custom template with different format",
+			template: "%[1]s-%[2]s.example.com",
+			svcName:  "fulcio-server",
+			ns:       "my-namespace",
+			expected: "fulcio-server-my-namespace.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := config.IngressHostTemplate
+			origOpenshift := config.Openshift
+			t.Cleanup(func() {
+				config.IngressHostTemplate = original
+				config.Openshift = origOpenshift
+			})
+
+			config.IngressHostTemplate = tt.template
+			config.Openshift = false
+
+			result, err := CalculateHostname(context.Background(), nil, tt.svcName, tt.ns)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCalculateHostname_OpenShift(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(configv1.AddToScheme(scheme))
+
+	tests := []struct {
+		name     string
+		domain   string
+		svcName  string
+		ns       string
+		expected string
+	}{
+		{
+			name:     "OpenShift hostname includes namespace and cluster domain",
+			domain:   "apps.cluster.example.com",
+			svcName:  "rekor-server",
+			ns:       "test-ns",
+			expected: "rekor-server-test-ns.apps.cluster.example.com",
+		},
+		{
+			name:     "OpenShift hostname with different service and namespace",
+			domain:   "apps.ocp.internal",
+			svcName:  "fulcio-server",
+			ns:       "secure-sign",
+			expected: "fulcio-server-secure-sign.apps.ocp.internal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origOpenshift := config.Openshift
+			t.Cleanup(func() { config.Openshift = origOpenshift })
+			config.Openshift = true
+
+			cli := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(&configv1.Ingress{
+					ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+					Spec:       configv1.IngressSpec{Domain: tt.domain},
+				}).
+				Build()
+
+			result, err := CalculateHostname(context.Background(), cli, tt.svcName, tt.ns)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("got %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCalculateHostname_OpenShift_MissingIngress(t *testing.T) {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(configv1.AddToScheme(scheme))
+
+	origOpenshift := config.Openshift
+	t.Cleanup(func() { config.Openshift = origOpenshift })
+	config.Openshift = true
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := CalculateHostname(context.Background(), cli, "rekor-server", "test-ns")
+	if err == nil {
+		t.Fatal("expected error when cluster Ingress is missing, got nil")
+	}
+}

--- a/test/e2e/custom_install/suite_test.go
+++ b/test/e2e/custom_install/suite_test.go
@@ -99,6 +99,10 @@ func managerPod(ns string, opts ...optManagerPod) *v1.Pod {
 							Name:  "OPENSHIFT",
 							Value: support.EnvOrDefault("OPENSHIFT", "false"),
 						},
+						{
+							Name:  "INGRESS_HOST_TEMPLATE",
+							Value: support.EnvOrDefault("INGRESS_HOST_TEMPLATE", "%[1]s.local"),
+						},
 					},
 					LivenessProbe: &v1.Probe{
 						ProbeHandler: v1.ProbeHandler{

--- a/test/e2e/support/kubernetes/olm/olm.go
+++ b/test/e2e/support/kubernetes/olm/olm.go
@@ -3,6 +3,7 @@ package olm
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -113,12 +114,7 @@ func OlmInstaller(ctx context.Context, cli client.Client, catalogImage, ns, pack
 				Package:                packageName,
 				Channel:                channel,
 				Config: &v1alpha1.SubscriptionConfig{
-					Env: []coreV1.EnvVar{
-						{
-							Name:  "OPENSHIFT",
-							Value: strconv.FormatBool(ocp),
-						},
-					},
+					Env: subscriptionEnv(ocp),
 				},
 			},
 		},
@@ -131,4 +127,20 @@ func OlmInstaller(ctx context.Context, cli client.Client, catalogImage, ns, pack
 	}
 
 	return subscription, catalog, nil
+}
+
+func subscriptionEnv(ocp bool) []coreV1.EnvVar {
+	env := []coreV1.EnvVar{
+		{
+			Name:  "OPENSHIFT",
+			Value: strconv.FormatBool(ocp),
+		},
+	}
+	if v, ok := os.LookupEnv("INGRESS_HOST_TEMPLATE"); ok {
+		env = append(env, coreV1.EnvVar{
+			Name:  "INGRESS_HOST_TEMPLATE",
+			Value: v,
+		})
+	}
+	return env
 }


### PR DESCRIPTION
Introduces --ingress-host-template flag (INGRESS_HOST_TEMPLATE env var) to control default Ingress hostnames on non-OpenShift clusters. The default "%[1]s.local" preserves existing behavior. CI is configured with "%[1]s.%[2]s.traefik.me" to produce namespace-unique hostnames, eliminating Ingress hostname collisions between e2e test namespaces that caused Konflux pipeline timeouts.

Refs: [SECURESIGN-3862](https://redhat.atlassian.net/browse/SECURESIGN-3862)