### PR TITLE
chore: migrate from deprecated GetEventRecorderFor to GetEventRecorder

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -245,7 +245,7 @@ func setupController(name string, constructor controller.Constructor, manager ct
 	if err := constructor(
 		manager.GetClient(),
 		manager.GetScheme(),
-		manager.GetEventRecorderFor(name+"-controller"),
+		manager.GetEventRecorder(name+"-controller"),
 	).SetupWithManager(manager); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", name)
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,17 +21,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - namespaces
   verbs:
   - create
@@ -153,6 +142,17 @@ rules:
   verbs:
   - create
   - get
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
   - patch
   - update
   - watch

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/securesign/operator/internal/apis"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -17,7 +17,7 @@ type Result struct {
 
 type Action[T apis.ConditionsAwareObject] interface {
 	InjectClient(client client.Client)
-	InjectRecorder(recorder record.EventRecorder)
+	InjectRecorder(recorder events.EventRecorder)
 	InjectLogger(logger logr.Logger)
 
 	// a user friendly name for the action

--- a/internal/action/base_action.go
+++ b/internal/action/base_action.go
@@ -11,7 +11,7 @@ import (
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/state"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -19,7 +19,7 @@ import (
 
 type BaseAction struct {
 	Client   client.Client
-	Recorder record.EventRecorder
+	Recorder events.EventRecorder
 	Logger   logr.Logger
 }
 
@@ -27,7 +27,7 @@ func (action *BaseAction) InjectClient(client client.Client) {
 	action.Client = client
 }
 
-func (action *BaseAction) InjectRecorder(recorder record.EventRecorder) {
+func (action *BaseAction) InjectRecorder(recorder events.EventRecorder) {
 	action.Recorder = recorder
 }
 

--- a/internal/action/pvc/action.go
+++ b/internal/action/pvc/action.go
@@ -144,7 +144,7 @@ func (i pvcAction[T]) Handle(ctx context.Context, instance T) *action.Result {
 			Reason:             ReasonCreated,
 			ObservedGeneration: instance.GetGeneration(),
 		})
-		i.Recorder.Eventf(instance, v1.EventTypeNormal, "PersistentVolumeClaimCreated", "New PersistentVolumeClaim created `%s`", pvc.Name)
+		i.Recorder.Eventf(instance, pvc, v1.EventTypeNormal, "PersistentVolumeClaimCreated", "Created", "New PersistentVolumeClaim created `%s`", pvc.Name)
 	case controllerutil.OperationResultUpdated:
 		instance.SetCondition(metav1.Condition{
 			Type:               ConditionType,
@@ -152,7 +152,7 @@ func (i pvcAction[T]) Handle(ctx context.Context, instance T) *action.Result {
 			Reason:             ReasonUpdated,
 			ObservedGeneration: instance.GetGeneration(),
 		})
-		i.Recorder.Eventf(instance, v1.EventTypeNormal, "PersistentVolumeClaimUpdated", "PersistentVolumeClaim updated `%s`", pvc.Name)
+		i.Recorder.Eventf(instance, pvc, v1.EventTypeNormal, "PersistentVolumeClaimUpdated", "Updated", "PersistentVolumeClaim updated `%s`", pvc.Name)
 	case controllerutil.OperationResultNone:
 		instance.SetCondition(metav1.Condition{
 			Type:               ConditionType,

--- a/internal/action/tree/action.go
+++ b/internal/action/tree/action.go
@@ -76,7 +76,7 @@ func (i resolveTree[T]) handleMissingCondition(ctx context.Context, instance T) 
 			Status: metav1.ConditionTrue,
 			Reason: state.Ready.String(),
 		})
-		i.Recorder.Eventf(instance, corev1.EventTypeNormal, "ExistingTrillianTreeFound", "Existing Trillian tree found: %d", wrapped.GetStatusTreeID())
+		i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "ExistingTrillianTreeFound", "Discovered", "Existing Trillian tree found: %d", wrapped.GetStatusTreeID())
 		return i.StatusUpdate(ctx, instance)
 	}
 	return nil
@@ -363,7 +363,7 @@ func (i resolveTree[T]) handleExtractJobResult(ctx context.Context, instance T) 
 			Status: metav1.ConditionTrue,
 			Reason: state.Ready.String(),
 		})
-		i.Recorder.Eventf(instance, corev1.EventTypeNormal, "TrillianTreeCreated", "New Trillian tree created: %d", treeID)
+		i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "TrillianTreeCreated", "Created", "New Trillian tree created: %d", treeID)
 		return i.StatusUpdate(ctx, instance)
 	} else {
 		i.Logger.V(1).Info("ConfigMap not ready or data is empty, requeuing reconciliation")

--- a/internal/controller/ctlog/actions/handle_fulcio_root.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root.go
@@ -90,7 +90,7 @@ func (g handleFulcioCert) Handle(ctx context.Context, instance *v1alpha1.CTlog) 
 		if slices.Contains(instance.Status.RootCertificates, sks) {
 			return g.Continue()
 		}
-		g.Recorder.Event(instance, v1.EventTypeNormal, "FulcioCertDiscovered", "Fulcio certificate detected")
+		g.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "FulcioCertDiscovered", "Discovered", "Fulcio certificate detected")
 		instance.Status.RootCertificates = append(instance.Status.RootCertificates, sks)
 	} else {
 		instance.Status.RootCertificates = instance.Spec.RootCertificates

--- a/internal/controller/ctlog/actions/handle_keys.go
+++ b/internal/controller/ctlog/actions/handle_keys.go
@@ -153,12 +153,12 @@ func (g handleKeys) discoverPrivateKey(ctx context.Context, instance *v1alpha1.C
 			if newKeyStatus.PrivateKeyPasswordRef != nil {
 				// we search for password encrypted private key
 				if isEncrypted && newKeyStatus.PrivateKeyPasswordRef.Name == passwordKeyRef {
-					g.Recorder.Event(instance, v1.EventTypeNormal, "PrivateKeyDiscovered", "Existing private key discovered")
+					g.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "PrivateKeyDiscovered", "Discovered", "Existing private key discovered")
 					newKeyStatus.PrivateKeyRef = g.sksByLabel(partialPrivateSecret, CTLogPrivateLabel)
 					continue
 				}
 			} else if !isEncrypted {
-				g.Recorder.Event(instance, v1.EventTypeNormal, "PrivateKeyDiscovered", "Existing private key discovered")
+				g.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "PrivateKeyDiscovered", "Discovered", "Existing private key discovered")
 				newKeyStatus.PrivateKeyRef = g.sksByLabel(partialPrivateSecret, CTLogPrivateLabel)
 				continue
 			}
@@ -167,7 +167,7 @@ func (g handleKeys) discoverPrivateKey(ctx context.Context, instance *v1alpha1.C
 		if err != nil {
 			g.Logger.Error(err, "problem with invalidating private key secret", "namespace", instance.Namespace)
 		}
-		g.Recorder.Event(instance, v1.EventTypeNormal, "PrivateSecretLabelRemoved", "Private key secret invalidated")
+		g.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "PrivateSecretLabelRemoved", "LabelRemoved", "Private key secret invalidated")
 	}
 }
 
@@ -189,7 +189,7 @@ func (g handleKeys) discoverPubliceKey(ctx context.Context, instance *v1alpha1.C
 		if newKeyStatus.PublicKeyRef == nil {
 			// we are still searching for new key
 			if privateKeyRef, ok := partialPubSecret.Annotations[privateKeyRefAnnotation]; ok && privateKeyRef == newKeyStatus.PrivateKeyRef.Name {
-				g.Recorder.Event(instance, v1.EventTypeNormal, "PublicKeyDiscovered", "Existing public key discovered")
+				g.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "PublicKeyDiscovered", "Discovered", "Existing public key discovered")
 				newKeyStatus.PublicKeyRef = g.sksByLabel(partialPubSecret, CTLPubLabel)
 				continue
 			}
@@ -198,7 +198,7 @@ func (g handleKeys) discoverPubliceKey(ctx context.Context, instance *v1alpha1.C
 		if err != nil {
 			g.Logger.Error(err, "problem with invalidating public key secret", "namespace", instance.Namespace)
 		}
-		g.Recorder.Event(instance, v1.EventTypeNormal, "PrivateSecretLabelRemoved", "Public key secret invalidated")
+		g.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "PrivateSecretLabelRemoved", "LabelRemoved", "Public key secret invalidated")
 	}
 }
 

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -95,7 +95,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 		}
 
 		instance.Status.ServerConfigRef = instance.Spec.ServerConfigRef
-		i.Recorder.Eventf(instance, corev1.EventTypeNormal, "CTLogConfigUpdated", "CTLog config updated: %s", instance.Spec.ServerConfigRef.Name)
+		i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "CTLogConfigUpdated", "Updated", "CTLog config updated: %s", instance.Spec.ServerConfigRef.Name)
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:               ConfigCondition,
 			Status:             metav1.ConditionTrue,
@@ -126,7 +126,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 			if errors.Is(err, errSecretInvalid) {
 				// Secret needs recreation - log and continue
 				i.Logger.Info("Server config secret needs recreation", "secret", instance.Status.ServerConfigRef.Name)
-				i.Recorder.Eventf(instance, corev1.EventTypeWarning, "CTLogConfigRecreate", "Config secret will be recreated: %s", instance.Status.ServerConfigRef.Name)
+				i.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "CTLogConfigRecreate", "Recreating", "Config secret will be recreated: %s", instance.Status.ServerConfigRef.Name)
 			} else {
 				// API error - fail reconciliation
 				return i.Error(ctx, fmt.Errorf("error validating server config secret: %w", err), instance,
@@ -225,7 +225,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 	instance.Status.ServerConfigRef = &rhtasv1alpha1.LocalObjectReference{Name: newConfig.Name}
 
 	i.Logger.Info("Server config secret created", "secret", newConfig.Name)
-	i.Recorder.Eventf(instance, corev1.EventTypeNormal, "CTLogConfigCreated", "Config secret created successfully: %s", newConfig.Name)
+	i.Recorder.Eventf(instance, newConfig, corev1.EventTypeNormal, "CTLogConfigCreated", "Created", "Config secret created successfully: %s", newConfig.Name)
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 		Type:               ConfigCondition,
 		Status:             metav1.ConditionTrue,
@@ -260,11 +260,11 @@ func (i serverConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.CTlog
 		err = i.Client.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: partialConfig.Name, Namespace: partialConfig.Namespace}})
 		if err != nil {
 			i.Logger.Error(err, "unable to delete secret", "namespace", instance.Namespace, "name", partialConfig.Name)
-			i.Recorder.Eventf(instance, corev1.EventTypeWarning, "CTLogConfigCleanupFailed", "Unable to delete old config secret: %s", partialConfig.Name)
+			i.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "CTLogConfigCleanupFailed", "CleanupFailed", "Unable to delete old config secret: %s", partialConfig.Name)
 			continue
 		}
 		i.Logger.Info("Remove invalid Secret with ctlog configuration", "Name", partialConfig.Name)
-		i.Recorder.Eventf(instance, corev1.EventTypeNormal, "CTLogConfigCleanedUp", "Old config secret deleted successfully: %s", partialConfig.Name)
+		i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "CTLogConfigCleanedUp", "Deleted", "Old config secret deleted successfully: %s", partialConfig.Name)
 	}
 }
 

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -31,7 +31,7 @@ import (
 	v12 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -53,10 +53,10 @@ import (
 type ctlogReconciler struct {
 	client.Client
 	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	recorder events.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder events.EventRecorder) controller.Controller {
 	return &ctlogReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/fulcio/actions/generate_cert.go
+++ b/internal/controller/fulcio/actions/generate_cert.go
@@ -130,7 +130,7 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 			})
 		}
 		message := fmt.Sprintf("Removed '%s' label from %s secret", FulcioCALabel, partialSecret.Name)
-		g.Recorder.Event(instance, v1.EventTypeNormal, "CertificateSecretLabelRemoved", message)
+		g.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "CertificateSecretLabelRemoved", "LabelRemoved", message)
 		g.Logger.Info(message)
 	}
 
@@ -180,7 +180,7 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 			})
 	}
 
-	g.Recorder.Event(instance, v1.EventTypeNormal, "FulcioCertUpdated", "Fulcio certificate secret updated")
+	g.Recorder.Eventf(instance, newCert, v1.EventTypeNormal, "FulcioCertUpdated", "Updated", "Fulcio certificate secret updated")
 
 	g.alignStatusFields(newCert, instance)
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{

--- a/internal/controller/fulcio/actions/server_config.go
+++ b/internal/controller/fulcio/actions/server_config.go
@@ -131,7 +131,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulcio
 		return i.Error(ctx, fmt.Errorf("could not create Server config: %w", err), instance)
 	}
 
-	i.Recorder.Eventf(instance, v1.EventTypeNormal, "FulcioConfigUpdated", "Fulcio config updated: %s", newConfig.Name)
+	i.Recorder.Eventf(instance, newConfig, v1.EventTypeNormal, "FulcioConfigUpdated", "Updated", "Fulcio config updated: %s", newConfig.Name)
 	instance.Status.ServerConfigRef = &rhtasv1alpha1.LocalObjectReference{Name: newConfig.Name}
 
 	meta.SetStatusCondition(&instance.Status.Conditions,
@@ -175,10 +175,10 @@ func (i serverConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.Fulci
 		})
 		if err != nil {
 			i.Logger.Error(err, "problem with deleting configmap", "name", partialConfig.Name)
-			i.Recorder.Eventf(instance, v1.EventTypeWarning, "FulcioConfigDeleted", "Unable to delete secret: %s", partialConfig.Name)
+			i.Recorder.Eventf(instance, nil, v1.EventTypeWarning, "FulcioConfigDeleted", "CleanupFailed", "Unable to delete secret: %s", partialConfig.Name)
 			continue
 		}
 		i.Logger.Info("Remove invalid ConfigMap with Fulcio configuration", "name", partialConfig.Name)
-		i.Recorder.Eventf(instance, v1.EventTypeNormal, "FulcioConfigDeleted", "Fulcio config deleted: %s", partialConfig.Name)
+		i.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "FulcioConfigDeleted", "Deleted", "Fulcio config deleted: %s", partialConfig.Name)
 	}
 }

--- a/internal/controller/fulcio/fulcio_controller.go
+++ b/internal/controller/fulcio/fulcio_controller.go
@@ -29,7 +29,7 @@ import (
 	"github.com/securesign/operator/internal/controller/fulcio/actions"
 	v12 "k8s.io/api/core/v1"
 	v13 "k8s.io/api/networking/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,10 +47,10 @@ import (
 type fulcioReconciler struct {
 	client.Client
 	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	recorder events.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder events.EventRecorder) controller.Controller {
 	return &fulcioReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/generate_password.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/generate_password.go
@@ -71,7 +71,7 @@ func (i generatePasswordAction) Handle(ctx context.Context, instance *rhtasv1alp
 		LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: obj.Name},
 		Key:                  "password",
 	}
-	i.Recorder.Eventf(instance, core.EventTypeNormal, "RedisSecretCreated", "Secret with redis password created: %s", obj.Name)
+	i.Recorder.Eventf(instance, obj, core.EventTypeNormal, "RedisSecretCreated", "Created", "Secret with redis password created: %s", obj.Name)
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 		Type:               actions.RedisCondition,
 		Status:             metav1.ConditionFalse,
@@ -106,10 +106,10 @@ func (i generatePasswordAction) cleanup(ctx context.Context, instance *rhtasv1al
 		err = i.Client.Delete(ctx, &core.Secret{ObjectMeta: metav1.ObjectMeta{Name: partialSecret.Name, Namespace: partialSecret.Namespace}})
 		if err != nil {
 			i.Logger.Error(err, "unable to delete Secret", "namespace", instance.Namespace, "name", partialSecret.Name)
-			i.Recorder.Eventf(instance, core.EventTypeWarning, "RedisSecretDeleted", "Unable to delete Secret: %s", partialSecret.Name)
+			i.Recorder.Eventf(instance, nil, core.EventTypeWarning, "RedisSecretDeleted", "CleanupFailed", "Unable to delete Secret: %s", partialSecret.Name)
 			continue
 		}
 		i.Logger.Info("Remove invalid Secret with redis configuration", "Name", partialSecret.Name)
-		i.Recorder.Eventf(instance, core.EventTypeNormal, "RedisSecretDeleted", "Secret with redis configuration deleted: %s", partialSecret.Name)
+		i.Recorder.Eventf(instance, nil, core.EventTypeNormal, "RedisSecretDeleted", "Deleted", "Secret with redis configuration deleted: %s", partialSecret.Name)
 	}
 }

--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -100,7 +100,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 			Reason:  state.Creating.String(),
 			Message: "Deployment created",
 		})
-		i.Recorder.Eventf(instance, v1.EventTypeNormal, "DeploymentUpdated", "Deployment updated: %s", instance.Name)
+		i.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "DeploymentUpdated", "Updated", "Deployment updated: %s", instance.Name)
 		return i.StatusUpdate(ctx, instance)
 	} else {
 		return i.Continue()

--- a/internal/controller/rekor/actions/server/generate_signer.go
+++ b/internal/controller/rekor/actions/server/generate_signer.go
@@ -167,7 +167,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Rekor) *a
 					})
 			}
 
-			g.Recorder.Eventf(instance, v1.EventTypeNormal, "SignerKeyCreated", "Signer private key created: %s", secret.Name)
+			g.Recorder.Eventf(instance, secret, v1.EventTypeNormal, "SignerKeyCreated", "Created", "Signer private key created: %s", secret.Name)
 			newSigner.KeyRef = &v1alpha1.SecretKeySelector{
 				Key: "private",
 				LocalObjectReference: v1alpha1.LocalObjectReference{

--- a/internal/controller/rekor/actions/server/resolve_pub_key.go
+++ b/internal/controller/rekor/actions/server/resolve_pub_key.go
@@ -78,13 +78,13 @@ func (i resolvePubKeyAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 		}
 		if bytes.Equal(existingPublicKey, publicKey) && instance.Status.PublicKeyRef == nil {
 			instance.Status.PublicKeyRef = sks
-			i.Recorder.Eventf(instance, v1.EventTypeNormal, "PublicKeySecretDiscovered", "Existing public key discovered: %s", sks.Name)
+			i.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "PublicKeySecretDiscovered", "Discovered", "Existing public key discovered: %s", sks.Name)
 		} else {
 			if err = labels.Remove(ctx, &partialSecret, i.Client, RekorPubLabel); err != nil {
 				return i.Error(ctx, fmt.Errorf("ResolvePubKey: %w", err), instance)
 			}
 			message := fmt.Sprintf("Removed '%s' label from %s secret", RekorPubLabel, partialSecret.Name)
-			i.Recorder.Event(instance, v1.EventTypeNormal, "PublicKeySecretLabelRemoved", message)
+			i.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "PublicKeySecretLabelRemoved", "LabelRemoved", message)
 			i.Logger.Info(message)
 		}
 	}
@@ -123,7 +123,7 @@ func (i resolvePubKeyAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			})
 	}
 
-	i.Recorder.Eventf(instance, v1.EventTypeNormal, "PublicKeySecretCreated", "New Rekor public key created: %s", newConfig.Name)
+	i.Recorder.Eventf(instance, newConfig, v1.EventTypeNormal, "PublicKeySecretCreated", "Created", "New Rekor public key created: %s", newConfig.Name)
 	c := meta.FindStatusCondition(instance.Status.Conditions, actions.ServerCondition)
 	c.Message = "Public key resolved"
 	meta.SetStatusCondition(&instance.Status.Conditions, *c)

--- a/internal/controller/rekor/actions/server/sharding_config.go
+++ b/internal/controller/rekor/actions/server/sharding_config.go
@@ -92,7 +92,7 @@ func (i shardingConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.Reko
 		return i.Error(ctx, fmt.Errorf("could not create sharding config: %w", err), instance)
 	}
 
-	i.Recorder.Eventf(instance, v1.EventTypeNormal, "ShardingConfigCreated", "ConfigMap with sharding configuration created: %s", newConfig.Name)
+	i.Recorder.Eventf(instance, newConfig, v1.EventTypeNormal, "ShardingConfigCreated", "Created", "ConfigMap with sharding configuration created: %s", newConfig.Name)
 	instance.Status.ServerConfigRef = &rhtasv1alpha1.LocalObjectReference{Name: newConfig.Name}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
@@ -134,11 +134,11 @@ func (i shardingConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.Rek
 		})
 		if err != nil {
 			i.Logger.Error(err, "problem with deleting configmap", "name", partialConfig.Name)
-			i.Recorder.Eventf(instance, v1.EventTypeWarning, "ShardingConfigDeleted", "Unable to delete secret: %s", partialConfig.Name)
+			i.Recorder.Eventf(instance, nil, v1.EventTypeWarning, "ShardingConfigDeleted", "CleanupFailed", "Unable to delete secret: %s", partialConfig.Name)
 			continue
 		}
 		i.Logger.Info("Remove invalid ConfigMap with rekor-sharding configuration", "name", partialConfig.Name)
-		i.Recorder.Eventf(instance, v1.EventTypeNormal, "ShardingConfigDeleted", "ConfigMap with sharding configuration deleted: %s", partialConfig.Name)
+		i.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "ShardingConfigDeleted", "Deleted", "ConfigMap with sharding configuration deleted: %s", partialConfig.Name)
 	}
 }
 

--- a/internal/controller/rekor/rekor_controller.go
+++ b/internal/controller/rekor/rekor_controller.go
@@ -35,7 +35,7 @@ import (
 	"github.com/securesign/operator/internal/controller/rekor/actions/ui"
 	v13 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/networking/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 
 	v12 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,10 +54,10 @@ import (
 type rekorReconciler struct {
 	client.Client
 	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	recorder events.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder events.EventRecorder) controller.Controller {
 	return &rekorReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/securesign/securesign_controller.go
+++ b/internal/controller/securesign/securesign_controller.go
@@ -24,7 +24,7 @@ import (
 	"github.com/securesign/operator/internal/controller"
 	v12 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 
 	"github.com/operator-framework/operator-lib/predicate"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
@@ -45,10 +45,10 @@ const (
 type securesignReconciler struct {
 	client.Client
 	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	recorder events.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder events.EventRecorder) controller.Controller {
 	return &securesignReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/testonly/suite.go
+++ b/internal/controller/testonly/suite.go
@@ -28,7 +28,7 @@ import (
 	"github.com/securesign/operator/internal/controller"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -103,7 +103,7 @@ func (t *controllerSuite) BeforeSuite() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(t.k8sClient).NotTo(BeNil())
 
-	recorder := record.NewFakeRecorder(1000)
+	recorder := events.NewFakeRecorder(1000)
 
 	err = t.supplier(
 		k8sManager.GetClient(),

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -31,7 +31,7 @@ import (
 	"github.com/securesign/operator/internal/controller/trillian/actions/logserver"
 	"github.com/securesign/operator/internal/controller/trillian/actions/logsigner"
 	v12 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,10 +49,10 @@ import (
 type trillianReconciler struct {
 	client.Client
 	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	recorder events.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder events.EventRecorder) controller.Controller {
 	return &trillianReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -125,7 +125,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 			g.Logger.Error(err, "can't remove label from TSA signer secret", "Name", partialSecret.Name)
 		}
 		message := fmt.Sprintf("Removed '%s' label from %s secret", TSACertCALabel, partialSecret.Name)
-		g.Recorder.Event(instance, v1.EventTypeNormal, "CertificateSecretLabelRemoved", message)
+		g.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "CertificateSecretLabelRemoved", "LabelRemoved", message)
 		g.Logger.Info(message)
 	}
 	if meta.IsStatusConditionTrue(instance.GetConditions(), TSASignerCondition) {
@@ -206,7 +206,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 			})
 	}
 
-	g.Recorder.Event(instance, v1.EventTypeNormal, "TSACertUpdated", "TSA certificate secret updated")
+	g.Recorder.Eventf(instance, certificateChain, v1.EventTypeNormal, "TSACertUpdated", "Updated", "TSA certificate secret updated")
 	g.alignStatusFields(certificateChain.Name, instance)
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 		Type:               TSASignerCondition,

--- a/internal/controller/tsa/actions/ntpMonitoring.go
+++ b/internal/controller/tsa/actions/ntpMonitoring.go
@@ -134,7 +134,7 @@ func (i ntpMonitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			return i.Error(ctx, fmt.Errorf("can't load configMap data %w", err), instance)
 		}
 		if reflect.DeepEqual(cm.Data[ntpConfigName], string(ntpConfig)) && newStatus.Config.NtpConfigRef == nil {
-			i.Recorder.Eventf(instance, v1.EventTypeNormal, "NTPConfigDiscovered", "Existing ConfigMap with NTP configuration discovered: %s", cm.Name)
+			i.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "NTPConfigDiscovered", "Discovered", "Existing ConfigMap with NTP configuration discovered: %s", cm.Name)
 			i.alignStatusFields(&instance.Spec.NTPMonitoring, newStatus, cm.Name)
 			instance.Status.NTPMonitoring = newStatus
 			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{

--- a/internal/controller/tsa/timestampauthority_controller.go
+++ b/internal/controller/tsa/timestampauthority_controller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/securesign/operator/internal/controller"
 	"github.com/securesign/operator/internal/controller/predicate"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -46,10 +46,10 @@ import (
 type timestampAuthorityReconciler struct {
 	client.Client
 	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	recorder events.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder events.EventRecorder) controller.Controller {
 	return &timestampAuthorityReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/tuf/actions/migration_job.go
+++ b/internal/controller/tuf/actions/migration_job.go
@@ -81,7 +81,7 @@ func (i migrationJobAction) jobPresent(ctx context.Context, job *batchv1.Job, in
 	i.Logger.Info("Tuf migration job is present.", "Succeeded", job.Status.Succeeded, "Failures", job.Status.Failed)
 	if jobUtils.IsCompleted(*job) {
 		if !jobUtils.IsFailed(*job) {
-			i.Recorder.Event(instance, corev1.EventTypeNormal, "TUFMigrationJob", "TUF migration job passed")
+			i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "TUFMigrationJob", "Completed", "TUF migration job passed")
 
 			//annotate self to signal that the migration is complete
 			var (
@@ -102,7 +102,7 @@ func (i migrationJobAction) jobPresent(ctx context.Context, job *batchv1.Job, in
 			return i.StatusUpdate(ctx, instance)
 		} else {
 			err := fmt.Errorf("tuf-repository-migration job failed")
-			i.Recorder.Event(instance, corev1.EventTypeWarning, "TUFMigrationJob", err.Error())
+			i.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "TUFMigrationJob", "Failed", err.Error())
 			return i.Error(ctx, reconcile.TerminalError(err), instance)
 		}
 	} else {
@@ -122,7 +122,7 @@ func (i migrationJobAction) jobPresent(ctx context.Context, job *batchv1.Job, in
 }
 
 func (i migrationJobAction) ensureMigrationJob(ctx context.Context, labels map[string]string, instance *rhtasv1alpha1.Tuf) *action.Result {
-	i.Recorder.Event(instance, corev1.EventTypeNormal, "TUFMigrationJob", "Starting TUF migration")
+	i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "TUFMigrationJob", "Started", "Starting TUF migration")
 
 	if err := utils.ResolveServiceAddress(ctx, i.Client, instance); err != nil {
 		return i.Error(ctx, fmt.Errorf("fail to resolve service url: %w", err), instance)
@@ -152,7 +152,7 @@ func (i migrationJobAction) ensureMigrationJob(ctx context.Context, labels map[s
 			instance, metav1.Condition{Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Initialize.String(), Message: "TUF migration job creation failed"})
 	}
 
-	i.Recorder.Event(instance, corev1.EventTypeNormal, "TUFMigrationJob", "Tuf migration job created.")
+	i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "TUFMigrationJob", "Created", "Tuf migration job created.")
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 		Type:    state.Ready.String(),
 		Status:  metav1.ConditionFalse,

--- a/internal/controller/tuf/actions/migration_job_test.go
+++ b/internal/controller/tuf/actions/migration_job_test.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -32,7 +32,7 @@ func setupMigrateAction() migrationJobAction {
 	migrateJobTestAction := migrationJobAction{
 		BaseAction: common.BaseAction{
 			Client:   fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&v1alpha1.Tuf{}).Build(),
-			Recorder: record.NewFakeRecorder(10),
+			Recorder: events.NewFakeRecorder(10),
 			Logger:   logr.Logger{},
 		},
 	}

--- a/internal/controller/tuf/actions/resolve_keys_test.go
+++ b/internal/controller/tuf/actions/resolve_keys_test.go
@@ -14,14 +14,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var testAction = resolveKeysAction{
 	BaseAction: common.BaseAction{
 		Client:   fake.NewFakeClient(),
-		Recorder: record.NewFakeRecorder(3),
+		Recorder: events.NewFakeRecorder(3),
 		Logger:   logr.Logger{},
 	},
 }

--- a/internal/controller/tuf/actions/tuf_init_job.go
+++ b/internal/controller/tuf/actions/tuf_init_job.go
@@ -121,6 +121,6 @@ func (i initJobAction) ensureInitJob(ctx context.Context, labels map[string]stri
 		return i.Error(ctx, fmt.Errorf("could not create TUF init job: %w", err), instance)
 	}
 
-	i.Recorder.Event(instance, v1.EventTypeNormal, "JobCreated", "Tuf init-repository job created.")
+	i.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "JobCreated", "Created", "Tuf init-repository job created.")
 	return i.Requeue()
 }

--- a/internal/controller/tuf/tuf_controller.go
+++ b/internal/controller/tuf/tuf_controller.go
@@ -33,7 +33,7 @@ import (
 	v13 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,10 +47,10 @@ const DebugLevel int = 1
 type tufReconciler struct {
 	client.Client
 	scheme   *runtime.Scheme
-	recorder record.EventRecorder
+	recorder events.EventRecorder
 }
 
-func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder record.EventRecorder) controller.Controller {
+func NewReconciler(c client.Client, scheme *runtime.Scheme, recorder events.EventRecorder) controller.Controller {
 	return &tufReconciler{
 		Client:   c,
 		scheme:   scheme,

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -2,7 +2,7 @@ package controller
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,10 +33,10 @@ import (
 
 //+kubebuilder:rbac:groups="config.openshift.io",resources=ingresses,resourceNames=cluster,verbs=get;list;watch
 
-//+kubebuilder:rbac:groups="",resources=events,verbs=create;get;list;watch;update;patch
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;get;list;watch;update;patch
 
 type Controller interface {
 	SetupWithManager(ctrl.Manager) error
 }
 
-type Constructor func(client.Client, *runtime.Scheme, record.EventRecorder) Controller
+type Constructor func(client.Client, *runtime.Scheme, events.EventRecorder) Controller

--- a/internal/testing/action/support.go
+++ b/internal/testing/action/support.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -30,6 +30,6 @@ func FakeClientBuilder() *fake.ClientBuilder {
 func PrepareAction[T apis.ConditionsAwareObject](c client.Client, a action.Action[T]) action.Action[T] {
 	a.InjectClient(c)
 	a.InjectLogger(logr.Logger{})
-	a.InjectRecorder(record.NewFakeRecorder(10))
+	a.InjectRecorder(events.NewFakeRecorder(10))
 	return a
 }


### PR DESCRIPTION
Replace deprecated record.EventRecorder with events.EventRecorder from events.k8s.io/v1 API across all controllers and actions. Update RBAC to grant permissions on events.k8s.io group and populate meaningful action and related object parameters on all Eventf calls.