### PR TITLE
chore: suppress SA1019 for deprecated GetEventRecorderFor

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,11 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      # TODO: Migrate to GetEventRecorder - https://issues.redhat.com/browse/SECURESIGN-3651
+      - linters:
+          - staticcheck
+        text: "SA1019: manager.GetEventRecorderFor is deprecated"
 formatters:
   enable:
     - gofmt


### PR DESCRIPTION
## Summary
- Adds a golangci-lint exclusion rule to suppress `SA1019: manager.GetEventRecorderFor is deprecated`
- The full migration to `GetEventRecorder` is done on `main` branch
- Release branches continue using the old API which is still supported on target OCP versions

Ref: https://issues.redhat.com/browse/SECURESIGN-3651

🤖 Generated with [Claude Code](https://claude.com/claude-code)