### PR TITLE
ci: add batch nudge merge workflow and group MintMaker image updates

### DIFF
--- a/.github/workflows/batch-nudge-merge.yaml
+++ b/.github/workflows/batch-nudge-merge.yaml
@@ -1,0 +1,68 @@
+name: Batch Nudge Merge
+
+on:
+  schedule:
+    - cron: '17 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  discover-bases:
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.find.outputs.branches }}
+    steps:
+      - name: Find base branches with open nudge PRs
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCHES=$(gh pr list --repo "${{ github.repository }}" \
+            --label konflux-nudge --state open \
+            --json baseRefName --jq '[.[].baseRefName] | unique')
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+
+  combine:
+    needs: discover-bases
+    if: needs.discover-bases.outputs.branches != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        base_branch: ${{ fromJson(needs.discover-bases.outputs.branches) }}
+    steps:
+      - name: Get head branches for ${{ matrix.base_branch }}
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REGEX=$(gh pr list --repo "${{ github.repository }}" \
+            --label konflux-nudge --state open --base "${{ matrix.base_branch }}" \
+            --json headRefName \
+            --jq '[.[].headRefName | gsub("(?<x>[.\\\\^$|?*+()\\[\\]{}])"; "\\\(.x)")] | join("|")')
+          if [ -z "$REGEX" ]; then
+            echo "No open nudge PRs found for ${{ matrix.base_branch }}, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "branch_regex=^(${REGEX})$" >> "$GITHUB_OUTPUT"
+
+      - name: Combine Konflux Nudge PRs for ${{ matrix.base_branch }}
+        if: steps.filter.outputs.skip != 'true'
+        uses: github/combine-prs@v5.2.0
+        with:
+          branch_regex: ${{ steps.filter.outputs.branch_regex }}
+          select_label: konflux-nudge
+          combine_branch_name: chore/batch-nudge-update/${{ matrix.base_branch }}
+          pr_title: 'chore(deps): batch container image digest update for ${{ matrix.base_branch }}'
+          pr_body_header: '## Batch Container Image Digest Update for `${{ matrix.base_branch }}`'
+          ci_required: 'false'
+          review_required: 'false'
+          labels: konflux-nudge
+          autoclose: 'true'
+          min_combine_number: '2'
+          create_from_scratch: 'true'

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,15 @@
   "extends": [
     "github>securesign/renovate-config//org-inherited-config.json"
   ],
+  "packageRules": [
+    {
+      "description": "Group all images.env container image updates together",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "groupName": "Docker Images",
+      "groupSlug": "docker-deps"
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- Add `batch-nudge-merge.yaml` workflow using `github/combine-prs@v5.2.0` to combine multiple Konflux Component Nudge PRs into a single batch PR per base branch
- Add `packageRules` to `renovate.json` to group MintMaker `custom.regex` image updates into the existing `docker-deps` PR

## Problem
Konflux Component Nudge creates one PR per upstream component rebuild, each updating a single digest line in `config/default/images.env`. With 9+ PRs open, merging one conflicts all others. Manual sequential merging requires `/ok-to-test` + CI wait per PR.

## How it works
1. **`discover-bases` job** — finds all base branches (`main`, `release-*`) with 2+ open `konflux-nudge` PRs
2. **`combine` job** (per base) — builds a `branch_regex` scoped to that base's PRs, then delegates to `github/combine-prs` which handles merging, conflict reporting, PR creation, and auto-closing source PRs
3. **Triggers** — weekly (Monday 8:17 UTC) + manual `workflow_dispatch`

## Test plan
- [ ] Trigger workflow manually from Actions tab
- [ ] Verify combined PR is created with all 9 current nudge PRs listed
- [ ] Verify combined PR targets `main` (not mixed bases)
- [ ] Verify MintMaker creates grouped `docker-deps` PR on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)