### PR TITLE
fix(ci): deploy NFS CSI driver to nfs-storage namespace with SCC grants

### DIFF
--- a/ci/nfs/csi-driver-nfs/kustomization.yaml
+++ b/ci/nfs/csi-driver-nfs/kustomization.yaml
@@ -1,7 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+resources:
+  - rbac.yaml
+
 helmCharts:
   - name: csi-driver-nfs
     releaseName: 4.11.0
+    namespace: nfs-storage
     repo: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
+    valuesInline:
+      serviceAccount:
+        controller: csi-nfs-controller-sa
+        node: csi-nfs-node-sa

--- a/ci/nfs/csi-driver-nfs/rbac.yaml
+++ b/ci/nfs/csi-driver-nfs/rbac.yaml
@@ -1,0 +1,44 @@
+# Both controller and node pods run the nfs container with privileged: true,
+# hostNetwork, and hostPath volumes — hardcoded in the upstream chart templates.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csi-nfs-scc-role
+  namespace: nfs-storage
+rules:
+  - apiGroups: [ "security.openshift.io" ]
+    resources: [ "securitycontextconstraints" ]
+    verbs: [ "use" ]
+    resourceNames: [ "privileged" ]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-nfs-controller-scc-rb
+  namespace: nfs-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-nfs-scc-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-nfs-controller-sa
+    namespace: nfs-storage
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-nfs-node-scc-rb
+  namespace: nfs-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-nfs-scc-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-nfs-node-sa
+    namespace: nfs-storage


### PR DESCRIPTION
The CSI driver was deployed into the application namespace and failed to start on OpenShift because its service accounts lacked the privileged SCC. Set the Helm release namespace to nfs-storage and add SCC RBAC for both csi-nfs-controller-sa and csi-nfs-node-sa.