### PR TITLE
refactor(action): separate status persistence from flow control

### DIFF
--- a/api/v1alpha1/suite_test.go
+++ b/api/v1alpha1/suite_test.go
@@ -1,11 +1,10 @@
 package v1alpha1
 
 import (
-	"fmt"
 	"path/filepath"
-	"runtime"
 	"testing"
 
+	testenvhelper "github.com/securesign/operator/internal/testing/envtest"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/test"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -42,9 +41,8 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.29.1-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		BinaryAssetsDirectory: testenvhelper.FindBinaryAssetsDir(),
 	}
 
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -10,22 +10,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// Result holds the outcome of an action's Handle method.
+// It maps directly to controller-runtime's (reconcile.Result, error) tuple.
 type Result struct {
 	Result reconcile.Result
 	Err    error
 }
 
+// Action represents a single step in a controller's reconciliation sequence.
+// Actions are executed in registration order. Each action checks whether it
+// can handle the current state via CanHandle, and if so, performs work in Handle.
+//
+// Handle returns a *[Result] to control reconciliation flow:
+//   - nil ([BaseAction.Continue]): proceed to the next action
+//   - non-nil: stop the chain and return the result to controller-runtime
+//
+// See [BaseAction] for the available flow control and status persistence methods.
 type Action[T apis.ConditionsAwareObject] interface {
 	InjectClient(client client.Client)
 	InjectRecorder(recorder events.EventRecorder)
 	InjectLogger(logger logr.Logger)
 
-	// a user friendly name for the action
 	Name() string
-
-	// returns true if the action can handle the integration
 	CanHandle(context.Context, T) bool
-
-	// executes the handling function
 	Handle(context.Context, T) *Result
 }

--- a/internal/action/base_action.go
+++ b/internal/action/base_action.go
@@ -17,6 +17,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// BaseAction provides shared functionality for action implementations.
+// Embed it in your action struct and use its methods for status persistence
+// and flow control.
+//
+// Status persistence ([PersistStatus]) and flow control ([Return], [Requeue],
+// [RequeueAfter], [Continue], [Error]) are intentionally separate concerns.
+// After persisting status, the developer must explicitly choose what happens
+// next in the reconciliation loop.
 type BaseAction struct {
 	Client   client.Client
 	Recorder events.EventRecorder
@@ -35,11 +43,19 @@ func (action *BaseAction) InjectLogger(logger logr.Logger) {
 	action.Logger = logger
 }
 
+// Continue signals the reconciler to proceed to the next action in the chain.
+// Returns nil, which the reconciler loop interprets as "keep going."
 func (action *BaseAction) Continue() *Result {
 	return nil
 }
 
-func (action *BaseAction) StatusUpdate(ctx context.Context, obj client.Object) *Result {
+// PersistStatus writes the in-memory status of obj to the API server.
+// It retries on conflict and skips the write if the status has not changed.
+//
+// Returns (true, nil) when the status was written, (false, nil) when
+// unchanged (no API call made), or (false, error) on failure.
+func (action *BaseAction) PersistStatus(ctx context.Context, obj client.Object) (bool, error) {
+	changed := false
 	current := obj.DeepCopyObject().(client.Object)
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var (
@@ -59,17 +75,50 @@ func (action *BaseAction) StatusUpdate(ctx context.Context, obj client.Object) *
 			return e
 		}
 
-		if !reflect.DeepEqual(expectedStatus.Interface(), currentStatus.Interface()) {
-			if !currentStatus.CanSet() {
-				return errors.New("can not set status field")
-			}
-			currentStatus.Set(*expectedStatus)
+		if reflect.DeepEqual(expectedStatus.Interface(), currentStatus.Interface()) {
+			changed = false
+			return nil
 		}
-		return action.Client.Status().Update(ctx, current)
+		if !currentStatus.CanSet() {
+			return errors.New("can not set status field")
+		}
+		currentStatus.Set(*expectedStatus)
+		if e = action.Client.Status().Update(ctx, current); e != nil {
+			return e
+		}
+		changed = true
+		return nil
 	})
-	return &Result{Err: err}
+	return changed, err
 }
 
+// ReturnOnChange accepts any function with a (context.Context, client.Object) → (bool, error)
+// signature and returns a function that calls it and maps the result to the
+// correct flow-control action:
+//   - error     → [BaseAction.Error] (log + backoff)
+//   - changed   → [BaseAction.Return] (wait for watch event)
+//   - unchanged → [BaseAction.Continue] (next action in chain)
+//
+// Designed for use with [BaseAction.PersistStatus]:
+//
+//	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+func (action *BaseAction) ReturnOnChange(fn func(context.Context, client.Object) (bool, error)) func(context.Context, apis.ConditionsAwareObject) *Result {
+	return func(ctx context.Context, instance apis.ConditionsAwareObject) *Result {
+		changed, err := fn(ctx, instance)
+		if err != nil {
+			return action.Error(ctx, err, instance)
+		}
+		if changed {
+			return action.Return()
+		}
+		return action.Continue()
+	}
+}
+
+// Error logs the error, persists any provided conditions to the API server,
+// and returns the error to controller-runtime for retry with backoff.
+// For terminal errors (wrapped with [reconcile.TerminalError]), it sets the
+// Ready condition to Failure and controller-runtime will not retry.
 func (action *BaseAction) Error(ctx context.Context, err error, instance apis.ConditionsAwareObject, conditions ...metav1.Condition) *Result {
 	action.Logger.Error(err, "error during action execution")
 	isTerminal := errors.Is(err, reconcile.TerminalError(err))
@@ -103,6 +152,8 @@ func (action *BaseAction) Error(ctx context.Context, err error, instance apis.Co
 	}
 }
 
+// Return stops the action chain. The next reconciliation happens when
+// a watch event fires (e.g., status update or owned resource change).
 func (action *BaseAction) Return() *Result {
 	return &Result{
 		Result: reconcile.Result{},
@@ -110,11 +161,16 @@ func (action *BaseAction) Return() *Result {
 	}
 }
 
+// Requeue stops the action chain and re-reconciles after 100 milliseconds.
 func (action *BaseAction) Requeue() *Result {
+	return action.RequeueAfter(100 * time.Millisecond)
+}
+
+// RequeueAfter signals the reconciler to stop the action chain and re-reconcile
+// after the specified delay.
+func (action *BaseAction) RequeueAfter(delay time.Duration) *Result {
 	return &Result{
-		// always wait for a while before requeqe
-		Result: reconcile.Result{RequeueAfter: 5 * time.Second},
-		Err:    nil,
+		Result: reconcile.Result{RequeueAfter: delay},
 	}
 }
 

--- a/internal/action/base_action_test.go
+++ b/internal/action/base_action_test.go
@@ -1,0 +1,312 @@
+package action
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/gomega"
+	"github.com/securesign/operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	k8sClient   client.Client
+	testEnv     *envtest.Environment
+	errExpected = errors.New("expected error")
+)
+
+func TestMain(m *testing.M) {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+
+	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		panic(err)
+	}
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		panic(err)
+	}
+
+	code := m.Run()
+
+	if err := testEnv.Stop(); err != nil {
+		panic(err)
+	}
+	os.Exit(code)
+}
+
+func newBaseAction() *BaseAction {
+	return &BaseAction{
+		Client:   k8sClient,
+		Logger:   logr.Discard(),
+		Recorder: events.NewFakeRecorder(10),
+	}
+}
+
+func newTufInstance(name string) *v1alpha1.Tuf {
+	return &v1alpha1.Tuf{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+	}
+}
+
+func TestPersistStatus(t *testing.T) {
+	t.Run("persists status when changed", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("ps-changed")
+		g.Expect(k8sClient.Create(ctx, instance)).To(gomega.Succeed())
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, instance) })
+
+		a := newBaseAction()
+
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:   "Ready",
+			Status: metav1.ConditionTrue,
+			Reason: "TestReason",
+		})
+
+		changed, err := a.PersistStatus(ctx, instance)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(changed).To(gomega.BeTrue())
+
+		updated := &v1alpha1.Tuf{}
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), updated)).To(gomega.Succeed())
+		cond := meta.FindStatusCondition(updated.Status.Conditions, "Ready")
+		g.Expect(cond).ToNot(gomega.BeNil())
+		g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+		g.Expect(cond.Reason).To(gomega.Equal("TestReason"))
+	})
+
+	t.Run("skips update when status unchanged", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("ps-noop")
+		g.Expect(k8sClient.Create(ctx, instance)).To(gomega.Succeed())
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, instance) })
+
+		a := newBaseAction()
+
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:   "Ready",
+			Status: metav1.ConditionFalse,
+			Reason: "Pending",
+		})
+		changed, err := a.PersistStatus(ctx, instance)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(changed).To(gomega.BeTrue())
+
+		// Re-read from server to sync (API server truncates time precision)
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(gomega.Succeed())
+		rvBefore := instance.ResourceVersion
+
+		// Call PersistStatus again with no changes
+		changed, err = a.PersistStatus(ctx, instance)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(changed).To(gomega.BeFalse())
+
+		// resourceVersion should NOT have changed — no API call was made
+		after := &v1alpha1.Tuf{}
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), after)).To(gomega.Succeed())
+		g.Expect(after.ResourceVersion).To(gomega.Equal(rvBefore))
+	})
+
+	t.Run("returns error when object not found", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("ps-notfound")
+		a := newBaseAction()
+
+		_, err := a.PersistStatus(ctx, instance)
+		g.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	t.Run("retries on conflict and succeeds", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("ps-conflict")
+		g.Expect(k8sClient.Create(ctx, instance)).To(gomega.Succeed())
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, instance) })
+
+		a := newBaseAction()
+
+		// Bump resourceVersion on the server so instance becomes stale
+		serverCopy := instance.DeepCopy()
+		meta.SetStatusCondition(&serverCopy.Status.Conditions, metav1.Condition{
+			Type:   "Initializing",
+			Status: metav1.ConditionTrue,
+			Reason: "BumpRV",
+		})
+		g.Expect(k8sClient.Status().Update(ctx, serverCopy)).To(gomega.Succeed())
+
+		// instance now has a stale resourceVersion — PersistStatus must retry
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:   "Ready",
+			Status: metav1.ConditionTrue,
+			Reason: "TestConflict",
+		})
+
+		changed, err := a.PersistStatus(ctx, instance)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(changed).To(gomega.BeTrue())
+
+		updated := &v1alpha1.Tuf{}
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), updated)).To(gomega.Succeed())
+		g.Expect(meta.IsStatusConditionTrue(updated.Status.Conditions, "Ready")).To(gomega.BeTrue())
+	})
+}
+
+func TestRequeue(t *testing.T) {
+	t.Run("default delay", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		a := &BaseAction{}
+		result := a.Requeue()
+		g.Expect(result.Err).ToNot(gomega.HaveOccurred())
+		g.Expect(result.Result.RequeueAfter).To(gomega.Equal(100 * time.Millisecond))
+	})
+
+	t.Run("custom delay", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		a := &BaseAction{}
+		result := a.RequeueAfter(15 * time.Second)
+		g.Expect(result.Err).ToNot(gomega.HaveOccurred())
+		g.Expect(result.Result.RequeueAfter).To(gomega.Equal(15 * time.Second))
+	})
+}
+
+func TestReturn(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	a := &BaseAction{}
+	result := a.Return()
+	g.Expect(result.Err).ToNot(gomega.HaveOccurred())
+	g.Expect(result.Result).To(gomega.Equal(reconcile.Result{}))
+}
+
+func TestContinue(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	a := &BaseAction{}
+	result := a.Continue()
+	g.Expect(result).To(gomega.BeNil())
+}
+
+func stubFn(changed bool, err error) func(context.Context, client.Object) (bool, error) {
+	return func(context.Context, client.Object) (bool, error) {
+		return changed, err
+	}
+}
+
+func TestReturnOnChange(t *testing.T) {
+	t.Run("returns Continue when status unchanged", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("roc-unchanged")
+		g.Expect(k8sClient.Create(ctx, instance)).To(gomega.Succeed())
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, instance) })
+
+		a := newBaseAction()
+		result := a.ReturnOnChange(stubFn(false, nil))(ctx, instance)
+		g.Expect(result).To(gomega.BeNil())
+	})
+
+	t.Run("returns Return when status changed", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("roc-changed")
+		g.Expect(k8sClient.Create(ctx, instance)).To(gomega.Succeed())
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, instance) })
+
+		a := newBaseAction()
+		result := a.ReturnOnChange(stubFn(true, nil))(ctx, instance)
+		g.Expect(result).ToNot(gomega.BeNil())
+		g.Expect(result.Err).ToNot(gomega.HaveOccurred())
+		g.Expect(result.Result).To(gomega.Equal(reconcile.Result{}))
+	})
+
+	t.Run("returns Error when error occurred", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("roc-error")
+		g.Expect(k8sClient.Create(ctx, instance)).To(gomega.Succeed())
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, instance) })
+
+		a := newBaseAction()
+		result := a.ReturnOnChange(stubFn(false, errExpected))(ctx, instance)
+		g.Expect(result).ToNot(gomega.BeNil())
+		g.Expect(result.Err).To(gomega.MatchError(errExpected))
+	})
+
+	t.Run("error takes precedence over changed flag", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("roc-err-precedence")
+		g.Expect(k8sClient.Create(ctx, instance)).To(gomega.Succeed())
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, instance) })
+
+		a := newBaseAction()
+		result := a.ReturnOnChange(stubFn(true, errExpected))(ctx, instance)
+		g.Expect(result).ToNot(gomega.BeNil())
+		g.Expect(result.Err).To(gomega.MatchError(errExpected))
+	})
+
+	t.Run("works with PersistStatus end-to-end", func(t *testing.T) {
+		g := gomega.NewGomegaWithT(t)
+		ctx := t.Context()
+
+		instance := newTufInstance("roc-e2e")
+		g.Expect(k8sClient.Create(ctx, instance)).To(gomega.Succeed())
+		t.Cleanup(func() { _ = k8sClient.Delete(ctx, instance) })
+
+		a := newBaseAction()
+
+		// First call: status changes → Return
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:   "Ready",
+			Status: metav1.ConditionTrue,
+			Reason: "Deployed",
+		})
+		result := a.ReturnOnChange(a.PersistStatus)(ctx, instance)
+		g.Expect(result).ToNot(gomega.BeNil())
+		g.Expect(result.Err).ToNot(gomega.HaveOccurred())
+		g.Expect(result.Result).To(gomega.Equal(reconcile.Result{}))
+
+		// Re-read from server to sync
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(gomega.Succeed())
+
+		// Second call: status unchanged → Continue
+		result = a.ReturnOnChange(a.PersistStatus)(ctx, instance)
+		g.Expect(result).To(gomega.BeNil())
+	})
+}

--- a/internal/action/base_action_test.go
+++ b/internal/action/base_action_test.go
@@ -3,16 +3,15 @@ package action
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/onsi/gomega"
 	"github.com/securesign/operator/api/v1alpha1"
+	testenvhelper "github.com/securesign/operator/internal/testing/envtest"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -32,8 +31,7 @@ func TestMain(m *testing.M) {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		BinaryAssetsDirectory: testenvhelper.FindBinaryAssetsDir(),
 	}
 
 	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {

--- a/internal/action/doc.go
+++ b/internal/action/doc.go
@@ -1,0 +1,164 @@
+// Package action provides the framework for building reconciliation actions.
+//
+// # Overview
+//
+// Each controller reconciles a Custom Resource by running a sequence of actions.
+// An action is a small, focused unit of work (create a Deployment, resolve a key,
+// wait for readiness, etc.) that implements the [Action] interface.
+//
+// The reconciler executes actions in registration order:
+//
+//	for _, a := range actions {
+//	    if a.CanHandle(ctx, instance) {
+//	        result := a.Handle(ctx, instance)
+//	        if result != nil {
+//	            return result.Result, result.Err   // stop the chain
+//	        }
+//	    }
+//	}
+//	return reconcile.Result{}, nil
+//
+// # Flow Control
+//
+// Handle returns a *[Result] that tells the reconciler what to do next.
+// There are exactly four outcomes:
+//
+//   - [BaseAction.Continue] (nil) — run the next action in the chain.
+//   - [BaseAction.Return] — stop the chain; wait for a watch event to re-trigger.
+//   - [BaseAction.Requeue] / [BaseAction.RequeueAfter] — stop the chain; re-trigger after a delay.
+//   - [BaseAction.Error] — stop the chain; log the error, set failure conditions if terminal,
+//     and let controller-runtime retry with exponential backoff.
+//
+// # Status Persistence
+//
+// [BaseAction.PersistStatus] writes the current in-memory status of the object
+// to the API server. It returns (changed bool, err error) — it does NOT control
+// flow. The changed flag indicates whether the status was actually written:
+//
+//   - changed=true: an API call was made and a watch event will fire, triggering
+//     a new reconciliation. Use [BaseAction.Return] — the watch event handles it.
+//   - changed=false: the status was already up-to-date, no API call was made,
+//     and no watch event will fire. Use [BaseAction.Continue] to proceed to
+//     the next action, since the status already reflects the desired state.
+//
+// [BaseAction.ReturnOnChange] is a convenience helper that encapsulates this
+// logic. It accepts any func(context.Context, client.Object) → (bool, error)
+// and returns a function that calls it and maps the result to the correct
+// flow-control action:
+//
+//	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{...})
+//	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+//
+// When you need to run additional logic between PersistStatus and flow control
+// (e.g. cleanup), use the expanded form:
+//
+//	changed, err := i.PersistStatus(ctx, instance)
+//	if err != nil {
+//	    return i.Error(ctx, err, instance)
+//	}
+//	i.cleanup(ctx, instance, labels)
+//	if changed {
+//	    return i.Return()
+//	}
+//	return i.Continue()
+//
+// # Implementing an Action
+//
+// Embed [BaseAction] and implement [Action]:
+//
+//	type myAction struct {
+//	    action.BaseAction
+//	}
+//
+//	func (a myAction) Name() string { return "my-action" }
+//
+//	func (a myAction) CanHandle(_ context.Context, instance *v1alpha1.MyResource) bool {
+//	    // Gate on the state this action should handle.
+//	    // This prevents re-entry when the status has already been set.
+//	    return meta.IsStatusConditionFalse(instance.Status.Conditions, "Ready")
+//	}
+//
+//	func (a myAction) Handle(ctx context.Context, instance *v1alpha1.MyResource) *action.Result {
+//	    // Do work ...
+//	    meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+//	        Type:   "Ready",
+//	        Status: metav1.ConditionTrue,
+//	        Reason: "Deployed",
+//	    })
+//	    return a.ReturnOnChange(a.PersistStatus)(ctx, instance)
+//	}
+//
+// # Common Patterns
+//
+// State transition (one-shot: set final state, let watch event drive next action):
+//
+//	meta.SetStatusCondition(&instance.Status.Conditions, readyCondition)
+//	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+//
+// Polling loop (wait for external state, retry periodically):
+//
+//	if !deploymentReady {
+//	    meta.SetStatusCondition(&instance.Status.Conditions, waitingCondition)
+//	    if _, err := i.PersistStatus(ctx, instance); err != nil {
+//	        return i.Error(ctx, err, instance)
+//	    }
+//	    return i.RequeueAfter(5 * time.Second)
+//	}
+//
+// Resource creation with status checkpoint:
+//
+//	if result != controllerutil.OperationResultNone {
+//	    meta.SetStatusCondition(&instance.Status.Conditions, creatingCondition)
+//	    return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+//	}
+//	return i.Continue()
+//
+// Persist status then continue to next action.
+// The changed flag can be safely ignored here because [BaseAction.Continue]
+// proceeds to the next action in the same reconciliation cycle —
+// no watch event is needed to drive progress:
+//
+//	meta.SetStatusCondition(&instance.Status.Conditions, intermediateCondition)
+//	if _, err := i.PersistStatus(ctx, instance); err != nil {
+//	    return i.Error(ctx, err, instance)
+//	}
+//	return i.Continue()
+//
+// # Anti-Patterns
+//
+// Ignoring PersistStatus errors:
+//
+//	// BAD: status update error is silently lost
+//	_, _ = i.PersistStatus(ctx, instance)
+//	return i.Requeue()
+//
+//	// GOOD: propagate the error
+//	if _, err := i.PersistStatus(ctx, instance); err != nil {
+//	    return i.Error(ctx, err, instance)
+//	}
+//	return i.Requeue()
+//
+// Ignoring the changed flag after a state transition:
+//
+//	// BAD: if status didn't change, no watch event fires,
+//	// and reconciliation stops silently.
+//	if _, err := i.PersistStatus(ctx, instance); err != nil {
+//	    return i.Error(ctx, err, instance)
+//	}
+//	return i.Return()
+//
+//	// GOOD: use ReturnOnChange to handle flow control
+//	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+//
+// Missing CanHandle guard (causes infinite re-entry):
+//
+//	// BAD: CanHandle always returns true, Handle always sets the same condition,
+//	// PersistStatus is a no-op, Return() stops the chain — but the watch event
+//	// from a previous write may re-enter, creating a tight loop.
+//	func (a myAction) CanHandle(_ context.Context, _ *v1alpha1.X) bool { return true }
+//
+//	// GOOD: gate on the state that this action transitions FROM
+//	func (a myAction) CanHandle(_ context.Context, i *v1alpha1.X) bool {
+//	    return meta.IsStatusConditionFalse(i.Status.Conditions, "Ready")
+//	}
+package action

--- a/internal/action/pvc/action.go
+++ b/internal/action/pvc/action.go
@@ -80,7 +80,7 @@ func (i pvcAction[T]) Handle(ctx context.Context, instance T) *action.Result {
 			Reason:             ReasonSpecified,
 			ObservedGeneration: instance.GetGeneration(),
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	var name string
@@ -107,7 +107,7 @@ func (i pvcAction[T]) Handle(ctx context.Context, instance T) *action.Result {
 			Message:            fmt.Sprintf("Discovered and using  existing default PVC `%s`.", pvc.GetName()),
 			ObservedGeneration: instance.GetGeneration(),
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	if pvcSpec.Size == nil {
@@ -163,5 +163,5 @@ func (i pvcAction[T]) Handle(ctx context.Context, instance T) *action.Result {
 	}
 
 	wrapped.SetStatusPVCName(pvc.Name)
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/action/pvc/action_test.go
+++ b/internal/action/pvc/action_test.go
@@ -50,7 +50,7 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
 					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, &v1.PersistentVolumeClaim{})).
 						To(gomega.WithTransform(apierrors.IsNotFound, gomega.BeTrue()))
@@ -80,7 +80,7 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
 					pvc := &v1.PersistentVolumeClaim{}
 					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, pvc)).
@@ -164,7 +164,7 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
 					pvc := &v1.PersistentVolumeClaim{}
 					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, pvc)).
@@ -211,7 +211,7 @@ func TestHandle(t *testing.T) {
 				mutateObj: func(obj *v1alpha1.Rekor) {},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
 					pvc := &v1.PersistentVolumeClaim{}
 					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, pvc)).
@@ -268,7 +268,7 @@ func TestHandle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g gomega.Gomega, c client.WithWatch) {
 					pvc := &v1.PersistentVolumeClaim{}
 					g.Expect(c.Get(ctx, types.NamespacedName{Name: pvcNameFormat, Namespace: namespace}, pvc)).

--- a/internal/action/transitions/to_create_phase.go
+++ b/internal/action/transitions/to_create_phase.go
@@ -30,5 +30,5 @@ func (i toCreate[T]) Handle(ctx context.Context, instance T) *action.Result {
 	instance.SetCondition(metav1.Condition{Type: constants.ReadyCondition,
 		Status: metav1.ConditionFalse, Reason: state.Creating.String(),
 		ObservedGeneration: instance.GetGeneration()})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/action/transitions/to_initialize.go
+++ b/internal/action/transitions/to_initialize.go
@@ -30,5 +30,5 @@ func (i toInitializeAction[T]) Handle(ctx context.Context, instance T) *action.R
 	instance.SetCondition(metav1.Condition{Type: constants.ReadyCondition,
 		Status: metav1.ConditionFalse, Reason: state.Initialize.String(),
 		ObservedGeneration: instance.GetGeneration()})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/action/transitions/to_pending_phase.go
+++ b/internal/action/transitions/to_pending_phase.go
@@ -40,5 +40,5 @@ func (i toPending[T]) Handle(ctx context.Context, instance T) *action.Result {
 		instance.SetCondition(metav1.Condition{Type: c,
 			Status: metav1.ConditionUnknown, Reason: state.Pending.String()})
 	}
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/action/transitions/to_ready.go
+++ b/internal/action/transitions/to_ready.go
@@ -41,5 +41,5 @@ func (i toReady[T]) Handle(ctx context.Context, instance T) *action.Result {
 		ObservedGeneration: instance.GetGeneration(),
 	})
 
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/action/tree/action.go
+++ b/internal/action/tree/action.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/images"
@@ -77,7 +78,7 @@ func (i resolveTree[T]) handleMissingCondition(ctx context.Context, instance T) 
 			Reason: state.Ready.String(),
 		})
 		i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "ExistingTrillianTreeFound", "Discovered", "Existing Trillian tree found: %d", wrapped.GetStatusTreeID())
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 	return nil
 }
@@ -87,7 +88,7 @@ func (i resolveTree[T]) handleManual(ctx context.Context, instance T) *action.Re
 
 	if wrapped.GetTreeID() != nil && *wrapped.GetTreeID() != int64(0) {
 		wrapped.SetStatusTreeID(wrapped.GetTreeID())
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	return i.Continue()
@@ -186,7 +187,7 @@ func (i resolveTree[T]) handleConfigMap(ctx context.Context, instance T) *action
 			Reason:  state.Creating.String(),
 			Message: fmt.Sprintf("ConfigMap `%s` %s", configMap.GetName(), result)},
 		)
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}
@@ -203,7 +204,7 @@ func (i resolveTree[T]) handleJob(ctx context.Context, instance T) *action.Resul
 	configMap, err := kubernetes.GetConfigMap(ctx, i.Client, instance.GetNamespace(), configMapName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return i.Requeue()
+			return i.RequeueAfter(5 * time.Second)
 		}
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not get configmap: %w", err)), instance)
 	}
@@ -288,7 +289,7 @@ func (i resolveTree[T]) handleJob(ctx context.Context, instance T) *action.Resul
 		Message: "createtree job created",
 	})
 
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }
 
 func (i resolveTree[T]) handleJobFinished(ctx context.Context, instance T) *action.Result {
@@ -301,7 +302,7 @@ func (i resolveTree[T]) handleJobFinished(ctx context.Context, instance T) *acti
 	configMap, err := kubernetes.GetConfigMap(ctx, i.Client, instance.GetNamespace(), configMapName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return i.Requeue()
+			return i.RequeueAfter(5 * time.Second)
 		}
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not get configmap: %w", err)), instance)
 	}
@@ -313,7 +314,7 @@ func (i resolveTree[T]) handleJobFinished(ctx context.Context, instance T) *acti
 		}
 	}
 	if jobName == "" {
-		return i.Requeue()
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	j, err := job.GetJob(ctx, i.Client, instance.GetNamespace(), jobName)
@@ -322,12 +323,12 @@ func (i resolveTree[T]) handleJobFinished(ctx context.Context, instance T) *acti
 	}
 
 	if j == nil {
-		return i.Requeue()
+		return i.RequeueAfter(5 * time.Second)
 	}
 	i.Logger.V(1).Info("createtree job is already present.", "Succeeded", j.Status.Succeeded, "Failures", j.Status.Failed)
 
 	if !job.IsCompleted(*j) {
-		return i.Requeue()
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	if job.IsFailed(*j) {
@@ -350,7 +351,7 @@ func (i resolveTree[T]) handleExtractJobResult(ctx context.Context, instance T) 
 	configMap, err := kubernetes.GetConfigMap(ctx, i.Client, instance.GetNamespace(), configMapName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return i.Requeue()
+			return i.RequeueAfter(5 * time.Second)
 		}
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not get configmap: %w", err)), instance)
 	}
@@ -368,10 +369,10 @@ func (i resolveTree[T]) handleExtractJobResult(ctx context.Context, instance T) 
 			Reason: state.Ready.String(),
 		})
 		i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "TrillianTreeCreated", "Created", "New Trillian tree created: %d", treeID)
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		i.Logger.V(1).Info("ConfigMap not ready or data is empty, requeuing reconciliation")
-		return i.Requeue()
+		return i.RequeueAfter(5 * time.Second)
 	}
 }
 

--- a/internal/action/tree/action_test.go
+++ b/internal/action/tree/action_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
@@ -81,7 +82,7 @@ func testMissingCondition(t *testing.T) {
 		{
 			desc: "treeID set, condition not-set",
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g Gomega, c client.WithWatch) {
 					r := v1alpha1.Rekor{}
 					g.Expect(c.Get(ctx, nnObject, &r)).To(Succeed())
@@ -142,7 +143,7 @@ func testManual(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g Gomega, c client.WithWatch) {
 					r := v1alpha1.Rekor{}
 					g.Expect(c.Get(ctx, nnObject, &r)).To(Succeed())
@@ -196,7 +197,7 @@ func testConfigMap(t *testing.T) {
 				warmUp: false,
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g Gomega, c client.WithWatch) {
 					g.Expect(c.Get(ctx, nnResult, &corev1.ConfigMap{})).To(Succeed())
 				},
@@ -251,7 +252,7 @@ func testCreateJob(t *testing.T) {
 		{
 			desc: "requeue",
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 			},
 		},
 		{
@@ -288,7 +289,7 @@ func testCreateJob(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g Gomega, c client.WithWatch) {
 					jobs := &v1.JobList{}
 					g.Expect(c.List(ctx, jobs, client.InNamespace("default"))).To(Succeed())
@@ -320,7 +321,7 @@ func testMonitorJob(t *testing.T) {
 		{
 			desc: "requeue: missing configmap",
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 			},
 		},
 		{
@@ -337,7 +338,7 @@ func testMonitorJob(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 			},
 		},
 		{
@@ -357,7 +358,7 @@ func testMonitorJob(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 			},
 		},
 		{
@@ -385,7 +386,7 @@ func testMonitorJob(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 			},
 		},
 		{
@@ -476,7 +477,7 @@ func testExtractResult(t *testing.T) {
 		{
 			desc: "requeue: missing configmap",
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 			},
 		},
 		{
@@ -496,7 +497,7 @@ func testExtractResult(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 			},
 		},
 		{
@@ -544,7 +545,7 @@ func testExtractResult(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(ctx context.Context, g Gomega, c client.WithWatch) {
 					r := v1alpha1.Rekor{}
 					g.Expect(c.Get(ctx, nnObject, &r)).To(Succeed())

--- a/internal/controller/ctlog/actions/deployment.go
+++ b/internal/controller/ctlog/actions/deployment.go
@@ -93,7 +93,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 			Message:            "deployment created",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/ctlog/actions/handle_fulcio_root.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"slices"
+	"time"
 
 	"github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -62,7 +63,7 @@ func (g handleFulcioCert) Handle(ctx context.Context, instance *v1alpha1.CTlog) 
 			ObservedGeneration: instance.Generation,
 		},
 		)
-		return g.StatusUpdate(ctx, instance)
+		return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 	}
 
 	if len(instance.Spec.RootCertificates) == 0 {
@@ -78,8 +79,10 @@ func (g handleFulcioCert) Handle(ctx context.Context, instance *v1alpha1.CTlog) 
 				Reason:  state.Failure.String(),
 				Message: "Cert not found",
 			})
-			g.StatusUpdate(ctx, instance)
-			return g.Requeue()
+			if _, err := g.PersistStatus(ctx, instance); err != nil {
+				return g.Error(ctx, err, instance)
+			}
+			return g.RequeueAfter(5 * time.Second)
 		}
 		sks := v1alpha1.SecretKeySelector{
 			LocalObjectReference: v1alpha1.LocalObjectReference{
@@ -110,5 +113,5 @@ func (g handleFulcioCert) Handle(ctx context.Context, instance *v1alpha1.CTlog) 
 		Reason: "Resolved",
 	},
 	)
-	return g.StatusUpdate(ctx, instance)
+	return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/ctlog/actions/handle_fulcio_root_test.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
@@ -224,7 +225,7 @@ func TestCert_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -249,7 +250,7 @@ func TestCert_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -296,7 +297,7 @@ func TestCert_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -343,7 +344,7 @@ func TestCert_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -389,7 +390,7 @@ func TestCert_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.RootCertificates).Should(HaveLen(1))
 					g.Expect(status.RootCertificates[0].Key).Should(Equal("key"))
@@ -435,7 +436,7 @@ func TestCert_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 

--- a/internal/controller/ctlog/actions/handle_keys.go
+++ b/internal/controller/ctlog/actions/handle_keys.go
@@ -65,7 +65,7 @@ func (g handleKeys) Handle(ctx context.Context, instance *v1alpha1.CTlog) *actio
 			ObservedGeneration: instance.Generation,
 		},
 		)
-		return g.StatusUpdate(ctx, instance)
+		return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 	}
 
 	newKeyStatus := instance.Status.DeepCopy()
@@ -101,7 +101,7 @@ func (g handleKeys) Handle(ctx context.Context, instance *v1alpha1.CTlog) *actio
 		Message:            "Keys resolved",
 		ObservedGeneration: instance.Generation,
 	})
-	return g.StatusUpdate(ctx, instance)
+	return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 }
 
 func (g handleKeys) setupKeys(ns string, instanceStatus *v1alpha1.CTlogStatus) (*utils.KeyConfig, error) {

--- a/internal/controller/ctlog/actions/handle_keys_test.go
+++ b/internal/controller/ctlog/actions/handle_keys_test.go
@@ -231,7 +231,7 @@ func TestKeys_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -292,7 +292,7 @@ func TestKeys_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -357,7 +357,7 @@ func TestKeys_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -424,7 +424,7 @@ func TestKeys_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -462,7 +462,7 @@ func TestKeys_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
@@ -505,7 +505,7 @@ func TestKeys_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status v1alpha1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 

--- a/internal/controller/ctlog/actions/initialize.go
+++ b/internal/controller/ctlog/actions/initialize.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -52,7 +53,10 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CT
 			Message:            "Waiting for deployment to be ready",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	return i.Continue()

--- a/internal/controller/ctlog/actions/monitor/statefulset.go
+++ b/internal/controller/ctlog/actions/monitor/statefulset.go
@@ -105,7 +105,9 @@ func (i statefulSetAction) Handle(ctx context.Context, instance *rhtasv1alpha1.C
 			Reason:  state.Creating.String(),
 			Message: "Monitor created",
 		})
-		_ = i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
 	}
 	return i.Continue()
 }

--- a/internal/controller/ctlog/actions/monitor/svc.go
+++ b/internal/controller/ctlog/actions/monitor/svc.go
@@ -74,7 +74,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Reason:  state.Creating.String(),
 			Message: "Service created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -65,53 +65,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 	)
 
 	if instance.Spec.ServerConfigRef != nil {
-		// Validate that the custom secret is accessible
-		secret, err := kubernetes.GetSecret(i.Client, instance.Namespace, instance.Spec.ServerConfigRef.Name)
-		if err != nil {
-			return i.Error(ctx, fmt.Errorf("error accessing custom server config secret: %w", err), instance,
-				metav1.Condition{
-					Type:               ConfigCondition,
-					Status:             metav1.ConditionFalse,
-					Reason:             state.Failure.String(),
-					Message:            fmt.Sprintf("Error accessing custom server config secret: %s", instance.Spec.ServerConfigRef.Name),
-					ObservedGeneration: instance.Generation,
-				})
-		}
-		if secret.Data == nil || secret.Data[ctlogUtils.ConfigKey] == nil {
-			return i.Error(ctx, fmt.Errorf("custom server config secret is invalid"), instance,
-				metav1.Condition{
-					Type:               ConfigCondition,
-					Status:             metav1.ConditionFalse,
-					Reason:             state.Failure.String(),
-					Message:            fmt.Sprintf("Custom server config secret is missing '%s' key: %s", ctlogUtils.ConfigKey, instance.Spec.ServerConfigRef.Name),
-					ObservedGeneration: instance.Generation,
-				})
-		}
-
-		c := meta.FindStatusCondition(instance.Status.Conditions, ConfigCondition)
-		if c != nil && c.Status == metav1.ConditionTrue &&
-			c.ObservedGeneration == instance.Generation &&
-			equality.Semantic.DeepEqual(instance.Status.ServerConfigRef, instance.Spec.ServerConfigRef) {
-			return i.Continue()
-		}
-
-		instance.Status.ServerConfigRef = instance.Spec.ServerConfigRef
-		i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "CTLogConfigUpdated", "Updated", "CTLog config updated: %s", instance.Spec.ServerConfigRef.Name)
-		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:               ConfigCondition,
-			Status:             metav1.ConditionTrue,
-			Reason:             state.Ready.String(),
-			Message:            "Using custom server config",
-			ObservedGeneration: instance.Generation,
-		})
-		changed, err := i.PersistStatus(ctx, instance)
-		if err != nil {
-			return i.Error(ctx, err, instance)
-		}
-		if !changed {
-			return i.Requeue()
-		}
-		return i.Return()
+		return i.handleCustomConfig(ctx, instance)
 	}
 
 	// Validate prerequisites and normalize Trillian address before validation
@@ -254,6 +208,48 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 		return i.Return()
 	}
 	return i.Continue()
+}
+
+func (i serverConfig) handleCustomConfig(ctx context.Context, instance *rhtasv1alpha1.CTlog) *action.Result {
+	secret, err := kubernetes.GetSecret(i.Client, instance.Namespace, instance.Spec.ServerConfigRef.Name)
+	if err != nil {
+		return i.Error(ctx, fmt.Errorf("error accessing custom server config secret: %w", err), instance,
+			metav1.Condition{
+				Type:               ConfigCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Failure.String(),
+				Message:            fmt.Sprintf("Error accessing custom server config secret: %s", instance.Spec.ServerConfigRef.Name),
+				ObservedGeneration: instance.Generation,
+			})
+	}
+	if secret.Data == nil || secret.Data[ctlogUtils.ConfigKey] == nil {
+		return i.Error(ctx, fmt.Errorf("custom server config secret is invalid"), instance,
+			metav1.Condition{
+				Type:               ConfigCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Failure.String(),
+				Message:            fmt.Sprintf("Custom server config secret is missing '%s' key: %s", ctlogUtils.ConfigKey, instance.Spec.ServerConfigRef.Name),
+				ObservedGeneration: instance.Generation,
+			})
+	}
+
+	c := meta.FindStatusCondition(instance.Status.Conditions, ConfigCondition)
+	if c != nil && c.Status == metav1.ConditionTrue &&
+		c.ObservedGeneration == instance.Generation &&
+		equality.Semantic.DeepEqual(instance.Status.ServerConfigRef, instance.Spec.ServerConfigRef) {
+		return i.Continue()
+	}
+
+	instance.Status.ServerConfigRef = instance.Spec.ServerConfigRef
+	i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "CTLogConfigUpdated", "Updated", "CTLog config updated: %s", instance.Spec.ServerConfigRef.Name)
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:               ConfigCondition,
+		Status:             metav1.ConditionTrue,
+		Reason:             state.Ready.String(),
+		Message:            "Using custom server config",
+		ObservedGeneration: instance.Generation,
+	})
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }
 
 func (i serverConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.CTlog, configLabels map[string]string) {

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -103,7 +104,14 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 			Message:            "Using custom server config",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		changed, err := i.PersistStatus(ctx, instance)
+		if err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		if !changed {
+			return i.Requeue()
+		}
+		return i.Return()
 	}
 
 	// Validate prerequisites and normalize Trillian address before validation
@@ -151,7 +159,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 					Message:            c.Message,
 					ObservedGeneration: instance.Generation,
 				})
-				return i.StatusUpdate(ctx, instance)
+				return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 			}
 			return i.Continue()
 		}
@@ -168,8 +176,10 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 			Message:            fmt.Sprintf("Waiting for Fulcio root certificate: %v", err.Error()),
 			ObservedGeneration: instance.Generation,
 		})
-		i.StatusUpdate(ctx, instance)
-		return i.Requeue()
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	certConfig, err := i.handlePrivateKey(instance)
@@ -181,8 +191,10 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 			Message:            "Waiting for Ctlog private key secret",
 			ObservedGeneration: instance.Generation,
 		})
-		i.StatusUpdate(ctx, instance)
-		return i.Requeue()
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	var cfg map[string][]byte
@@ -233,11 +245,15 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 		Message:            "Server config created",
 		ObservedGeneration: instance.Generation,
 	})
-	result := i.StatusUpdate(ctx, instance)
-	if action.IsSuccess(result) {
-		i.cleanup(ctx, instance, configLabels)
+	changed, err := i.PersistStatus(ctx, instance)
+	if err != nil {
+		return i.Error(ctx, err, instance)
 	}
-	return result
+	i.cleanup(ctx, instance, configLabels)
+	if changed {
+		return i.Return()
+	}
+	return i.Continue()
 }
 
 func (i serverConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.CTlog, configLabels map[string]string) {

--- a/internal/controller/ctlog/actions/server_config_test.go
+++ b/internal/controller/ctlog/actions/server_config_test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
@@ -198,7 +199,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(Equal("config"))
@@ -236,7 +237,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
@@ -265,7 +266,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(Equal("new_config"))
@@ -304,7 +305,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(BeNil())
 					g.Expect(instance.Status.Conditions).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
@@ -346,7 +347,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.Requeue(),
+				result: testAction.RequeueAfter(5 * time.Second),
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(BeNil())
 					g.Expect(instance.Status.Conditions).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
@@ -397,7 +398,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(Not(BeNil()))
 
@@ -459,7 +460,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(Not(BeNil()))
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(Not(Equal("config")))
@@ -625,7 +626,7 @@ func TestServerConfig_Update(t *testing.T) {
 				}
 			}(),
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.Client, current *rhtasv1alpha1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(current.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
@@ -653,7 +654,7 @@ func TestServerConfig_Update(t *testing.T) {
 				}
 			}(),
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.Client, current *rhtasv1alpha1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).Should(Equal("existing-config"))
 
@@ -700,7 +701,7 @@ func TestServerConfig_Update(t *testing.T) {
 				}
 			}(),
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.Client, current *rhtasv1alpha1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(current.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
@@ -729,7 +730,7 @@ func TestServerConfig_Update(t *testing.T) {
 				}
 			}(),
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.Client, current *rhtasv1alpha1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
 					g.Expect(current.Status.ServerConfigRef.Name).ShouldNot(Equal("old-config"))
@@ -771,7 +772,7 @@ func TestServerConfig_Update(t *testing.T) {
 				}
 			}(),
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.Client, current *rhtasv1alpha1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).ShouldNot(Equal("old-config"))
 
@@ -798,7 +799,7 @@ func TestServerConfig_Update(t *testing.T) {
 				}
 			}(),
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.Client, current *rhtasv1alpha1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 
@@ -844,7 +845,7 @@ func TestServerConfig_Update(t *testing.T) {
 				}
 			}(),
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.Client, current *rhtasv1alpha1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).Should(Equal("custom_config"))
 
@@ -928,7 +929,7 @@ func TestServerConfig_Update(t *testing.T) {
 				}
 			}(),
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.Client, current *rhtasv1alpha1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(current.Status.ServerConfigRef.Name).Should(Equal("custom_config"))

--- a/internal/controller/ctlog/actions/service.go
+++ b/internal/controller/ctlog/actions/service.go
@@ -93,7 +93,7 @@ func (i serviceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog
 			Message:            "Service created",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/ctlog/actions/status_url.go
+++ b/internal/controller/ctlog/actions/status_url.go
@@ -39,5 +39,5 @@ func (i statusUrlAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTl
 	}
 
 	instance.Status.Url = url
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/ctlog/actions/tls.go
+++ b/internal/controller/ctlog/actions/tls.go
@@ -52,7 +52,7 @@ func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *a
 			Reason:  "NotProvided",
 			Message: "Communication to CTLog is insecure",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
@@ -61,5 +61,5 @@ func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog) *a
 		Reason:  "TLSResolved",
 		Message: "TLS configuration resolved",
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/fulcio/actions/deployment.go
+++ b/internal/controller/fulcio/actions/deployment.go
@@ -79,7 +79,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulcio
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.ReadyCondition,
 			Status: metav1.ConditionFalse, Reason: state.Creating.String(), Message: "Deployment created",
 			ObservedGeneration: instance.Generation})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/fulcio/actions/generate_cert.go
+++ b/internal/controller/fulcio/actions/generate_cert.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -80,7 +81,7 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 			Status: metav1.ConditionFalse,
 			Reason: state.Creating.String(),
 		})
-		return g.StatusUpdate(ctx, instance)
+		return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 	}
 
 	if instance.Spec.Certificate.PrivateKeyRef == nil && instance.Spec.Certificate.CARef != nil {
@@ -116,7 +117,7 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 					Status: metav1.ConditionTrue,
 					Reason: "Resolved",
 				})
-				return g.StatusUpdate(ctx, instance)
+				return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 			}
 		}
 
@@ -149,9 +150,11 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 			Reason:  state.Pending.String(),
 			Message: "Resolving keys",
 		})
-		g.StatusUpdate(ctx, instance)
+		if _, err := g.PersistStatus(ctx, instance); err != nil {
+			return g.Error(ctx, err, instance)
+		}
 		// swallow error and retry
-		return g.Requeue()
+		return g.RequeueAfter(5 * time.Second)
 	}
 
 	componentLabels := labels.For(ComponentName, DeploymentName, instance.Name)
@@ -188,7 +191,7 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 		Status: metav1.ConditionTrue,
 		Reason: "Resolved",
 	})
-	return g.StatusUpdate(ctx, instance)
+	return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 }
 
 func (g handleCert) setupCert(instance *v1alpha1.Fulcio) (*utils.FulcioCertConfig, error) {

--- a/internal/controller/fulcio/actions/generate_cert_test.go
+++ b/internal/controller/fulcio/actions/generate_cert_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	_ "embed"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/securesign/operator/internal/action"
@@ -59,7 +60,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 			},
 			want: want{
 				canHandle:     true,
-				result:        testAction.StatusUpdate(),
+				result:        testAction.Return(),
 				certCondition: metav1.ConditionTrue,
 				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
@@ -92,7 +93,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 			},
 			want: want{
 				canHandle:     true,
-				result:        testAction.Requeue(),
+				result:        testAction.RequeueAfter(5 * time.Second),
 				certCondition: metav1.ConditionFalse,
 				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
@@ -129,7 +130,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 			},
 			want: want{
 				canHandle:     true,
-				result:        testAction.StatusUpdate(),
+				result:        testAction.Return(),
 				certCondition: metav1.ConditionTrue,
 				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
@@ -171,7 +172,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 			},
 			want: want{
 				canHandle:     true,
-				result:        testAction.StatusUpdate(),
+				result:        testAction.Return(),
 				certCondition: metav1.ConditionTrue,
 				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
@@ -232,7 +233,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 			},
 			want: want{
 				canHandle:     true,
-				result:        testAction.StatusUpdate(),
+				result:        testAction.Return(),
 				certCondition: metav1.ConditionTrue,
 				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
@@ -294,7 +295,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 			},
 			want: want{
 				canHandle:     true,
-				result:        testAction.StatusUpdate(),
+				result:        testAction.Return(),
 				certCondition: metav1.ConditionTrue,
 				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
@@ -349,7 +350,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 			},
 			want: want{
 				canHandle:     true,
-				result:        testAction.StatusUpdate(),
+				result:        testAction.Return(),
 				certCondition: metav1.ConditionTrue,
 				verify: func(g Gomega, fulcio rhtasv1alpha1.FulcioStatus, cli client.WithWatch) {
 					g.Expect(fulcio.Certificate.CommonName).To(Equal("fulcio.local"))

--- a/internal/controller/fulcio/actions/ingress.go
+++ b/internal/controller/fulcio/actions/ingress.go
@@ -69,7 +69,7 @@ func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulci
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.ReadyCondition,
 			Status: metav1.ConditionFalse, Reason: state.Creating.String(), Message: "Ingress created",
 			ObservedGeneration: instance.Generation})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/fulcio/actions/initialize.go
+++ b/internal/controller/fulcio/actions/initialize.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -51,7 +52,10 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fu
 			Reason:  state.Initialize.String(),
 			Message: "Waiting for deployment to be ready",
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	return i.Continue()

--- a/internal/controller/fulcio/actions/server_config.go
+++ b/internal/controller/fulcio/actions/server_config.go
@@ -143,11 +143,15 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulcio
 			ObservedGeneration: instance.Generation},
 	)
 
-	result := i.StatusUpdate(ctx, instance)
-	if action.IsSuccess(result) {
-		i.cleanup(ctx, instance, configLabel)
+	changed, err := i.PersistStatus(ctx, instance)
+	if err != nil {
+		return i.Error(ctx, err, instance)
 	}
-	return result
+	i.cleanup(ctx, instance, configLabel)
+	if changed {
+		return i.Return()
+	}
+	return i.Continue()
 }
 
 func (i serverConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.Fulcio, configLabels map[string]string) {

--- a/internal/controller/fulcio/actions/server_config_test.go
+++ b/internal/controller/fulcio/actions/server_config_test.go
@@ -206,7 +206,7 @@ func TestConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status rhtasv1alpha1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
@@ -249,7 +249,7 @@ func TestConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status rhtasv1alpha1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).Should(Not(Equal("config")))
@@ -342,7 +342,7 @@ func TestConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status rhtasv1alpha1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).Should(Not(Equal("config")))
@@ -403,7 +403,7 @@ func TestConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status rhtasv1alpha1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).ShouldNot(Equal("config"))
@@ -455,7 +455,7 @@ func TestConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, status rhtasv1alpha1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).Should(Not(Equal("config")))

--- a/internal/controller/fulcio/actions/service.go
+++ b/internal/controller/fulcio/actions/service.go
@@ -81,7 +81,7 @@ func (i serviceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulci
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.ReadyCondition,
 			Status: metav1.ConditionFalse, Reason: state.Creating.String(), Message: "Service created",
 			ObservedGeneration: instance.Generation})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/fulcio/actions/status_url.go
+++ b/internal/controller/fulcio/actions/status_url.go
@@ -51,5 +51,5 @@ func (i statusUrlAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Ful
 	}
 
 	instance.Status.Url = url
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/rekor/actions/backfillRedis/backfill_redis_cronjob.go
+++ b/internal/controller/rekor/actions/backfillRedis/backfill_redis_cronjob.go
@@ -98,7 +98,7 @@ func (i backfillRedisCronJob) Handle(ctx context.Context, instance *rhtasv1alpha
 			Message:            "Backfill redis job created",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/monitor/statefulset.go
+++ b/internal/controller/rekor/actions/monitor/statefulset.go
@@ -89,7 +89,9 @@ func (i statefulSetAction) Handle(ctx context.Context, instance *rhtasv1alpha1.R
 			Reason:  state.Creating.String(),
 			Message: "Monitor created",
 		})
-		_ = i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
 	}
 	return i.Continue()
 }

--- a/internal/controller/rekor/actions/monitor/svc.go
+++ b/internal/controller/rekor/actions/monitor/svc.go
@@ -74,7 +74,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Reason:  state.Creating.String(),
 			Message: "Service created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/deployment.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/deployment.go
@@ -91,7 +91,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 			Reason:  state.Creating.String(),
 			Message: "Redis created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/generate_password.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/generate_password.go
@@ -79,11 +79,15 @@ func (i generatePasswordAction) Handle(ctx context.Context, instance *rhtasv1alp
 		Message:            "Redis password created",
 		ObservedGeneration: instance.Generation,
 	})
-	r := i.StatusUpdate(ctx, instance)
-	if action.IsSuccess(r) {
-		i.cleanup(ctx, instance, labels)
+	changed, err := i.PersistStatus(ctx, instance)
+	if err != nil {
+		return i.Error(ctx, err, instance)
 	}
-	return r
+	i.cleanup(ctx, instance, labels)
+	if changed {
+		return i.Return()
+	}
+	return i.Continue()
 }
 
 func (i generatePasswordAction) cleanup(ctx context.Context, instance *rhtasv1alpha1.Rekor, configLabels map[string]string) {

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/initialize.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/initialize.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -51,11 +52,14 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 			Reason:  state.Initialize.String(),
 			Message: "Waiting for deployment to be ready",
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: actions.RedisCondition,
 		Status: metav1.ConditionTrue, Reason: state.Ready.String()})
 
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/svc.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/svc.go
@@ -78,7 +78,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Reason:  state.Creating.String(),
 			Message: "Service created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/tls.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/tls.go
@@ -69,5 +69,5 @@ func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor) *a
 		Reason:  "TLSResolved",
 		Message: "TLS configuration resolved",
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -101,7 +101,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 			Message: "Deployment created",
 		})
 		i.Recorder.Eventf(instance, nil, v1.EventTypeNormal, "DeploymentUpdated", "Updated", "Deployment updated: %s", instance.Name)
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/server/generate_signer.go
+++ b/internal/controller/rekor/actions/server/generate_signer.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -81,7 +82,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Rekor) *a
 			Status: metav1.ConditionFalse,
 			Reason: state.Creating.String(),
 		})
-		return g.StatusUpdate(ctx, instance)
+		return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 	}
 
 	// Return to pending state because Signer spec changed
@@ -104,7 +105,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Rekor) *a
 			Reason:  state.Pending.String(),
 			Message: "resolving keys",
 		})
-		return g.StatusUpdate(ctx, instance)
+		return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 	}
 
 	newSigner := *instance.Spec.Signer.DeepCopy()
@@ -134,10 +135,10 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Rekor) *a
 						Reason:  state.Failure.String(),
 						Message: err.Error(),
 					})
-					return g.StatusUpdate(ctx, instance)
+					return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 				}
 				// swallow error and retry
-				return g.Requeue()
+				return g.RequeueAfter(5 * time.Second)
 			}
 
 			data := map[string][]byte{
@@ -190,7 +191,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Rekor) *a
 		Status: metav1.ConditionTrue,
 		Reason: state.Ready.String(),
 	})
-	return g.StatusUpdate(ctx, instance)
+	return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 }
 
 func (g generateSigner) createSignerKey() ([]byte, []byte, error) {

--- a/internal/controller/rekor/actions/server/generate_signer_test.go
+++ b/internal/controller/rekor/actions/server/generate_signer_test.go
@@ -268,7 +268,7 @@ func TestGenerateSigner_Handle(t *testing.T) {
 				status: rhtasv1alpha1.RekorSigner{},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
 					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.Signer.KeyRef.Name).Should(Equal("secret"))
@@ -286,7 +286,7 @@ func TestGenerateSigner_Handle(t *testing.T) {
 				status: rhtasv1alpha1.RekorSigner{},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
 					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.Signer.KeyRef.Name).Should(ContainSubstring("rekor-signer-rekor-"))
@@ -307,7 +307,7 @@ func TestGenerateSigner_Handle(t *testing.T) {
 				status: rhtasv1alpha1.RekorSigner{},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
 					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.Signer.KeyRef.Name).Should(Equal("new_secret"))
@@ -333,7 +333,7 @@ func TestGenerateSigner_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
 					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.Signer.KeyRef.Name).Should(Equal("secret"))
@@ -353,7 +353,7 @@ func TestGenerateSigner_Handle(t *testing.T) {
 				status: rhtasv1alpha1.RekorSigner{},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
 					g.Expect(instance.Status.Signer.KMS).ShouldNot(BeNil())
 					g.Expect(instance.Status.Signer.KMS).Should(Equal("awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1"))
@@ -377,7 +377,7 @@ func TestGenerateSigner_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
 					g.Expect(instance.Status.Signer.KMS).ShouldNot(BeNil())
 					g.Expect(instance.Status.Signer.KMS).Should(Equal("new-kms"))
@@ -400,7 +400,7 @@ func TestGenerateSigner_Handle(t *testing.T) {
 				status: rhtasv1alpha1.RekorSigner{},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.Rekor) {
 					g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.Signer.KeyRef.Name).Should(Equal("secret"))
@@ -494,7 +494,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					rekor := &rhtasv1alpha1.Rekor{}
 					g.Expect(cli.Get(context.TODO(), rekorNN, rekor)).Should(Succeed())
@@ -523,7 +523,7 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					rekor := &rhtasv1alpha1.Rekor{}
 					g.Expect(cli.Get(context.TODO(), rekorNN, rekor)).Should(Succeed())
@@ -579,9 +579,9 @@ func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.want.result)
 			}
 
-			// secound execution should not modify result
+			// second execution should not modify result
 			if got := a.Handle(ctx, instance); !reflect.DeepEqual(got, tt.want.result) {
-				t.Errorf("CanHandle() = %v, want %v", got, tt.want.result)
+				t.Errorf("second Handle() = %v, want %v", got, tt.want.result)
 			}
 
 			watchSecrets.Stop()

--- a/internal/controller/rekor/actions/server/ingress.go
+++ b/internal/controller/rekor/actions/server/ingress.go
@@ -74,7 +74,7 @@ func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor
 			Reason:  state.Creating.String(),
 			Message: "Ingress created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/server/initialize.go
+++ b/internal/controller/rekor/actions/server/initialize.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -53,7 +54,10 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 			Reason:  state.Initialize.String(),
 			Message: "Waiting for deployment to be ready",
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
@@ -61,5 +65,5 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 		Status: metav1.ConditionTrue,
 		Reason: state.Ready.String(),
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/rekor/actions/server/resolve_pub_key.go
+++ b/internal/controller/rekor/actions/server/resolve_pub_key.go
@@ -89,7 +89,7 @@ func (i resolvePubKeyAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 		}
 	}
 	if instance.Status.PublicKeyRef != nil {
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	// Create new secret with public key
@@ -127,7 +127,7 @@ func (i resolvePubKeyAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 	c := meta.FindStatusCondition(instance.Status.Conditions, actions.ServerCondition)
 	c.Message = "Public key resolved"
 	meta.SetStatusCondition(&instance.Status.Conditions, *c)
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }
 
 func (i resolvePubKeyAction) resolvePubKey(instance rhtasv1alpha1.Rekor) ([]byte, error) {

--- a/internal/controller/rekor/actions/server/resolve_pub_key_test.go
+++ b/internal/controller/rekor/actions/server/resolve_pub_key_test.go
@@ -104,7 +104,7 @@ func TestResolvePubKey_Handle(t *testing.T) {
 				objects: []client.Object{},
 			},
 			want: want{
-				result:    testAction.StatusUpdate(),
+				result:    testAction.Return(),
 				publicKey: testPublicKey,
 			},
 		},
@@ -127,7 +127,7 @@ func TestResolvePubKey_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result:    testAction.StatusUpdate(),
+				result:    testAction.Return(),
 				publicKey: testPublicKey,
 			},
 		},
@@ -150,7 +150,7 @@ func TestResolvePubKey_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result:    testAction.StatusUpdate(),
+				result:    testAction.Return(),
 				publicKey: testPublicKey,
 			},
 		},
@@ -197,7 +197,7 @@ func TestResolvePubKey_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result:    testAction.StatusUpdate(),
+				result:    testAction.Return(),
 				publicKey: testPublicKey,
 			},
 		},

--- a/internal/controller/rekor/actions/server/sharding_config.go
+++ b/internal/controller/rekor/actions/server/sharding_config.go
@@ -51,7 +51,7 @@ func (i shardingConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.Reko
 
 	content, err := createShardingConfigData(instance.Spec.Sharding)
 	if err != nil {
-		i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create sharding config: %w", err)), instance)
+		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create sharding config: %w", err)), instance)
 	}
 
 	// verify existing config
@@ -102,11 +102,15 @@ func (i shardingConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.Reko
 		Message: "Sharding config created",
 	})
 
-	result := i.StatusUpdate(ctx, instance)
-	if action.IsSuccess(result) {
-		i.cleanup(ctx, instance, labels)
+	changed, err := i.PersistStatus(ctx, instance)
+	if err != nil {
+		return i.Error(ctx, err, instance)
 	}
-	return result
+	i.cleanup(ctx, instance, labels)
+	if changed {
+		return i.Return()
+	}
+	return i.Continue()
 }
 
 func (i shardingConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.Rekor, configLabels map[string]string) {

--- a/internal/controller/rekor/actions/server/sharding_config_test.go
+++ b/internal/controller/rekor/actions/server/sharding_config_test.go
@@ -116,7 +116,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
 					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
@@ -155,7 +155,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
 					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
@@ -213,7 +213,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
 					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
@@ -268,7 +268,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
 					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
@@ -391,7 +391,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
 					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
@@ -429,7 +429,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
 					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
@@ -475,7 +475,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1alpha1.Rekor{}
 					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())

--- a/internal/controller/rekor/actions/server/status_url.go
+++ b/internal/controller/rekor/actions/server/status_url.go
@@ -52,5 +52,5 @@ func (i statusUrlAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rek
 	}
 
 	instance.Status.Url = url
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/rekor/actions/server/svc.go
+++ b/internal/controller/rekor/actions/server/svc.go
@@ -82,7 +82,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Reason:  state.Creating.String(),
 			Message: "Service created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/ui/deployment.go
+++ b/internal/controller/rekor/actions/ui/deployment.go
@@ -77,7 +77,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 			Reason:  state.Creating.String(),
 			Message: "Deployment created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/ui/ingress.go
+++ b/internal/controller/rekor/actions/ui/ingress.go
@@ -82,7 +82,7 @@ func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor
 			Reason:  state.Creating.String(),
 			Message: "Ingress created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/rekor/actions/ui/initialize.go
+++ b/internal/controller/rekor/actions/ui/initialize.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -51,11 +52,14 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Re
 			Reason:  state.Initialize.String(),
 			Message: "Waiting for deployment to be ready",
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: actions.UICondition,
 		Status: metav1.ConditionTrue, Reason: state.Ready.String()})
 
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/rekor/actions/ui/status_url.go
+++ b/internal/controller/rekor/actions/ui/status_url.go
@@ -50,5 +50,5 @@ func (i statusUrlAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rek
 	}
 
 	instance.Status.RekorSearchUIUrl = url
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/rekor/actions/ui/svc.go
+++ b/internal/controller/rekor/actions/ui/svc.go
@@ -70,7 +70,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Reason:  state.Creating.String(),
 			Message: "Service created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/securesign/actions/ensure_ctlog.go
+++ b/internal/controller/securesign/actions/ensure_ctlog.go
@@ -76,7 +76,7 @@ func (i ctlogAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Secures
 			Reason:  state.Creating.String(),
 			Message: "CTLog resource updated " + ctl.Name,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	return i.CopyStatus(ctx, ctl, instance)
@@ -94,7 +94,7 @@ func (i ctlogAction) CopyStatus(ctx context.Context, ctl *rhtasv1alpha1.CTlog, i
 			Status: objectStatus.Status,
 			Reason: objectStatus.Reason,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 	return i.Continue()
 }

--- a/internal/controller/securesign/actions/ensure_fulcio.go
+++ b/internal/controller/securesign/actions/ensure_fulcio.go
@@ -75,7 +75,7 @@ func (i fulcioAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Secure
 			Reason:  state.Creating.String(),
 			Message: "Fulcio resource created " + fulcio.Name,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	return i.CopyStatus(ctx, fulcio, instance)
@@ -100,5 +100,5 @@ func (i fulcioAction) CopyStatus(ctx context.Context, object *rhtasv1alpha1.Fulc
 		return i.Continue()
 	}
 
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/securesign/actions/ensure_rekor.go
+++ b/internal/controller/securesign/actions/ensure_rekor.go
@@ -75,7 +75,7 @@ func (i rekorAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Secures
 			Reason:  state.Creating.String(),
 			Message: "Rekor resource created " + rekor.Name,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	return i.CopyStatus(ctx, rekor, instance)
@@ -100,5 +100,5 @@ func (i rekorAction) CopyStatus(ctx context.Context, object *rhtasv1alpha1.Rekor
 		return i.Continue()
 	}
 
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/securesign/actions/ensure_trillian.go
+++ b/internal/controller/securesign/actions/ensure_trillian.go
@@ -75,7 +75,7 @@ func (i trillianAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Secu
 			Reason:  state.Creating.String(),
 			Message: "Trillian resource created " + trillian.Name,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	return i.CopyStatus(ctx, trillian, instance)
@@ -93,7 +93,7 @@ func (i trillianAction) CopyStatus(ctx context.Context, object *rhtasv1alpha1.Tr
 			Status: objectStatus.Status,
 			Reason: objectStatus.Reason,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 	return i.Continue()
 }

--- a/internal/controller/securesign/actions/ensure_tsa.go
+++ b/internal/controller/securesign/actions/ensure_tsa.go
@@ -60,7 +60,7 @@ func (i tsaAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesig
 			Reason:  state.NotDefined.String(),
 			Message: "TSA resource is undefined",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client,
@@ -89,7 +89,7 @@ func (i tsaAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesig
 			Reason:  state.Creating.String(),
 			Message: "TSA resource created " + tsa.Name,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	return i.CopyStatus(ctx, tsa, instance)
@@ -114,5 +114,5 @@ func (i tsaAction) CopyStatus(ctx context.Context, object *rhtasv1alpha1.Timesta
 		return i.Continue()
 	}
 
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/securesign/actions/ensure_tuf.go
+++ b/internal/controller/securesign/actions/ensure_tuf.go
@@ -76,7 +76,7 @@ func (i tufAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesig
 			Reason:  state.Creating.String(),
 			Message: "Tuf resource created " + tuf.Name,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	return i.CopyStatus(ctx, tuf, instance)
@@ -102,5 +102,5 @@ func (i tufAction) CopyStatus(ctx context.Context, object *rhtasv1alpha1.Tuf, in
 		return i.Continue()
 	}
 
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/securesign/actions/initialize_status.go
+++ b/internal/controller/securesign/actions/initialize_status.go
@@ -46,5 +46,5 @@ func (i initializeStatus) Handle(ctx context.Context, instance *rhtasv1alpha1.Se
 			})
 		}
 	}
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/securesign/actions/segment_backup_cronjob.go
+++ b/internal/controller/securesign/actions/segment_backup_cronjob.go
@@ -57,5 +57,5 @@ func (i segmentBackupCronJob) Handle(ctx context.Context, instance *rhtasv1alpha
 		Reason:  "Removed",
 		Message: "Segment backup Cron Job removed",
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/securesign/actions/update_status.go
+++ b/internal/controller/securesign/actions/update_status.go
@@ -38,7 +38,7 @@ func (i updateStatusAction) Handle(ctx context.Context, instance *rhtasv1alpha1.
 			Reason:             meta.FindStatusCondition(instance.Status.Conditions, sorted[0]).Reason,
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 	if !meta.IsStatusConditionTrue(instance.Status.Conditions, constants.ReadyCondition) {
 		meta.SetStatusCondition(&instance.Status.Conditions, v1.Condition{
@@ -47,7 +47,7 @@ func (i updateStatusAction) Handle(ctx context.Context, instance *rhtasv1alpha1.
 			Reason:             state.Ready.String(),
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 	return i.Continue()
 }

--- a/internal/controller/testonly/suite.go
+++ b/internal/controller/testonly/suite.go
@@ -18,14 +18,13 @@ package testonly
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
-	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/controller"
+	testenvhelper "github.com/securesign/operator/internal/testing/envtest"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
@@ -64,14 +63,7 @@ func (t *controllerSuite) BeforeSuite() {
 	t.testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
-
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
-			fmt.Sprintf("1.29.1-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		BinaryAssetsDirectory: testenvhelper.FindBinaryAssetsDir(),
 	}
 
 	var err error

--- a/internal/controller/trillian/actions/db/deployment.go
+++ b/internal/controller/trillian/actions/db/deployment.go
@@ -87,7 +87,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trilli
 			Reason:  state.Creating.String(),
 			Message: "Database deployment created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/trillian/actions/db/handle_secret.go
+++ b/internal/controller/trillian/actions/db/handle_secret.go
@@ -75,7 +75,7 @@ func (i handleSecretAction) Handle(ctx context.Context, instance *rhtasv1alpha1.
 			Reason:  state.Ready.String(),
 			Message: "Working with external DB",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	// managed database
@@ -90,7 +90,7 @@ func (i handleSecretAction) Handle(ctx context.Context, instance *rhtasv1alpha1.
 
 		// update database connection by spec
 		instance.Status.Db.DatabaseSecretRef = instance.Spec.Db.DatabaseSecretRef
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	// skip if status exists
@@ -127,7 +127,7 @@ func (i handleSecretAction) Handle(ctx context.Context, instance *rhtasv1alpha1.
 	}
 
 	if instance.Status.Db.DatabaseSecretRef != nil {
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	dbSecret := &corev1.Secret{
@@ -154,7 +154,7 @@ func (i handleSecretAction) Handle(ctx context.Context, instance *rhtasv1alpha1.
 	instance.Status.Db.DatabaseSecretRef = &rhtasv1alpha1.LocalObjectReference{
 		Name: dbSecret.Name,
 	}
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }
 func (i handleSecretAction) defaultDBData() map[string][]byte {
 	// Define a new Secret object

--- a/internal/controller/trillian/actions/db/handle_secret_test.go
+++ b/internal/controller/trillian/actions/db/handle_secret_test.go
@@ -180,7 +180,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -206,7 +206,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -239,7 +239,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -272,7 +272,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -296,7 +296,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -323,7 +323,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -359,7 +359,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -477,7 +477,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -544,7 +544,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
@@ -631,7 +631,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 				},
 			},
 			want: want{
-				result: testAction.StatusUpdate(),
+				result: testAction.Return(),
 				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1alpha1.Trillian{}
 					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())

--- a/internal/controller/trillian/actions/db/initialize.go
+++ b/internal/controller/trillian/actions/db/initialize.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/labels"
@@ -49,10 +50,13 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tr
 			Reason:  state.Initialize.String(),
 			Message: "Waiting for deployment to be ready",
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: actions.DbCondition,
 		Status: metav1.ConditionTrue, Reason: state.Ready.String()})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/trillian/actions/db/svc.go
+++ b/internal/controller/trillian/actions/db/svc.go
@@ -79,7 +79,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Reason:  state.Creating.String(),
 			Message: "Service created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/trillian/actions/db/tls.go
+++ b/internal/controller/trillian/actions/db/tls.go
@@ -70,5 +70,5 @@ func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian)
 		Reason:  "TLSResolved",
 		Message: "TLS configuration resolved",
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/trillian/actions/logserver/deployment.go
+++ b/internal/controller/trillian/actions/logserver/deployment.go
@@ -82,7 +82,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trilli
 			Reason:  state.Creating.String(),
 			Message: "Deployment created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/trillian/actions/logserver/initialize.go
+++ b/internal/controller/trillian/actions/logserver/initialize.go
@@ -3,6 +3,7 @@ package logserver
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -47,10 +48,13 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tr
 			Reason:  state.Initialize.String(),
 			Message: "Waiting for deployment to be ready",
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: actions.ServerCondition,
 		Status: metav1.ConditionTrue, Reason: state.Ready.String()})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/trillian/actions/logserver/service.go
+++ b/internal/controller/trillian/actions/logserver/service.go
@@ -89,7 +89,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Reason:  state.Creating.String(),
 			Message: "Service created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/trillian/actions/logserver/tls.go
+++ b/internal/controller/trillian/actions/logserver/tls.go
@@ -67,5 +67,5 @@ func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian)
 		Reason:  "TLSResolved",
 		Message: "TLS configuration resolved",
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/trillian/actions/logsigner/deployment.go
+++ b/internal/controller/trillian/actions/logsigner/deployment.go
@@ -83,7 +83,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trilli
 			Reason:  state.Creating.String(),
 			Message: "Deployment created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/trillian/actions/logsigner/initialize.go
+++ b/internal/controller/trillian/actions/logsigner/initialize.go
@@ -3,6 +3,7 @@ package logsigner
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -47,9 +48,12 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tr
 			Reason:  state.Initialize.String(),
 			Message: "Waiting for deployment to be ready",
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: actions.SignerCondition,
 		Status: metav1.ConditionTrue, Reason: state.Ready.String()})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/trillian/actions/logsigner/service.go
+++ b/internal/controller/trillian/actions/logsigner/service.go
@@ -90,7 +90,7 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Reason:  state.Creating.String(),
 			Message: "Service created",
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/trillian/actions/logsigner/tls.go
+++ b/internal/controller/trillian/actions/logsigner/tls.go
@@ -67,5 +67,5 @@ func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Trillian)
 		Reason:  "TLSResolved",
 		Message: "TLS configuration resolved",
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/tsa/actions/deployment.go
+++ b/internal/controller/tsa/actions/deployment.go
@@ -87,7 +87,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Timest
 			Message:            "TSA server deployment created",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	"github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -72,7 +73,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 			Reason:             state.Creating.String(),
 			ObservedGeneration: instance.Generation,
 		})
-		return g.StatusUpdate(ctx, instance)
+		return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 	}
 
 	anno, err := g.secretAnnotations(instance.Spec.Signer)
@@ -94,7 +95,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 					Reason:             "Resolved",
 					ObservedGeneration: instance.Generation,
 				})
-				return g.StatusUpdate(ctx, instance)
+				return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 			}
 			return g.Continue()
 		}
@@ -129,7 +130,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 		g.Logger.Info(message)
 	}
 	if meta.IsStatusConditionTrue(instance.GetConditions(), TSASignerCondition) {
-		return g.StatusUpdate(ctx, instance)
+		return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 	}
 
 	tsaCertChainConfig := &tsaUtils.TsaCertChainConfig{}
@@ -151,9 +152,11 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 				Message:            "Resolving keys",
 				ObservedGeneration: instance.Generation,
 			})
-			g.StatusUpdate(ctx, instance)
+			if _, err := g.PersistStatus(ctx, instance); err != nil {
+				return g.Error(ctx, err, instance)
+			}
 			// swallow error and retry
-			return g.Requeue()
+			return g.RequeueAfter(5 * time.Second)
 		}
 	}
 
@@ -174,9 +177,11 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 			Message:            "Resolving keys",
 			ObservedGeneration: instance.Generation,
 		})
-		g.StatusUpdate(ctx, instance)
+		if _, err := g.PersistStatus(ctx, instance); err != nil {
+			return g.Error(ctx, err, instance)
+		}
 		// swallow error and retry
-		return g.Requeue()
+		return g.RequeueAfter(5 * time.Second)
 	}
 
 	componentLabels := labels.For(ComponentName, DeploymentName, instance.Name)
@@ -214,7 +219,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 		Reason:             "Resolved",
 		ObservedGeneration: instance.Generation,
 	})
-	return g.StatusUpdate(ctx, instance)
+	return g.ReturnOnChange(g.PersistStatus)(ctx, instance)
 }
 
 func (g generateSigner) handleSignerKeys(instance *v1alpha1.TimestampAuthority, config *tsaUtils.TsaCertChainConfig) (*tsaUtils.TsaCertChainConfig, error) {

--- a/internal/controller/tsa/actions/ingress.go
+++ b/internal/controller/tsa/actions/ingress.go
@@ -74,7 +74,7 @@ func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Times
 			Message:            "Ingress created",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/tsa/actions/initialize.go
+++ b/internal/controller/tsa/actions/initialize.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -52,7 +53,10 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Ti
 			Message:            "Waiting for deployment to be ready",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	return i.Continue()

--- a/internal/controller/tsa/actions/ntpMonitoring.go
+++ b/internal/controller/tsa/actions/ntpMonitoring.go
@@ -73,7 +73,7 @@ func (i ntpMonitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Message:            "NTP monitoring configured",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	if instance.Spec.NTPMonitoring.Config.NtpConfigRef != nil {
@@ -86,7 +86,7 @@ func (i ntpMonitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Message:            "NTP monitoring configured",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	var (
@@ -150,7 +150,7 @@ func (i ntpMonitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 		}
 	}
 	if newStatus.Config.NtpConfigRef != nil {
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	}
 
 	configMap := &v1.ConfigMap{
@@ -180,7 +180,7 @@ func (i ntpMonitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 		Message:            "NTP monitoring configured",
 		ObservedGeneration: instance.Generation,
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }
 
 func (i ntpMonitoringAction) marshalNTPMonitoringConfig(instance *rhtasv1alpha1.NtpMonitoringConfig) ([]byte, error) {

--- a/internal/controller/tsa/actions/service.go
+++ b/internal/controller/tsa/actions/service.go
@@ -80,7 +80,7 @@ func (i serviceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Times
 			Message:            "Service created",
 			ObservedGeneration: instance.Generation,
 		})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/tsa/actions/status_url.go
+++ b/internal/controller/tsa/actions/status_url.go
@@ -50,5 +50,5 @@ func (i statusUrlAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tim
 	}
 
 	instance.Status.Url = url
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/tuf/actions/deployment.go
+++ b/internal/controller/tuf/actions/deployment.go
@@ -69,7 +69,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tuf) *
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.ReadyCondition,
 			Status: metav1.ConditionFalse, Reason: state.Creating.String(), Message: "Deployment created",
 			ObservedGeneration: instance.Generation})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/tuf/actions/ingress.go
+++ b/internal/controller/tuf/actions/ingress.go
@@ -70,7 +70,7 @@ func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tuf) 
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.ReadyCondition,
 			Status: metav1.ConditionFalse, Reason: state.Creating.String(), Message: "Ingress created",
 			ObservedGeneration: instance.Generation})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/tuf/actions/initialize.go
+++ b/internal/controller/tuf/actions/initialize.go
@@ -3,6 +3,7 @@ package actions
 import (
 	"context"
 	"errors"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -52,7 +53,10 @@ func (i initializeAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tu
 			Reason:  state.Initialize.String(),
 			Message: "Waiting for deployment to be ready",
 		})
-		return i.StatusUpdate(ctx, instance)
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(5 * time.Second)
 	}
 
 	return i.Continue()

--- a/internal/controller/tuf/actions/migration_job.go
+++ b/internal/controller/tuf/actions/migration_job.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -99,7 +100,7 @@ func (i migrationJobAction) jobPresent(ctx context.Context, job *batchv1.Job, in
 				Reason:  state.Initialize.String(),
 				Message: "migration job passed",
 			})
-			return i.StatusUpdate(ctx, instance)
+			return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 		} else {
 			err := fmt.Errorf("tuf-repository-migration job failed")
 			i.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "TUFMigrationJob", "Failed", err.Error())
@@ -112,12 +113,11 @@ func (i migrationJobAction) jobPresent(ctx context.Context, job *batchv1.Job, in
 			Reason:  state.Initialize.String(),
 			Message: "waiting for migration job to complete",
 		})
-		result := i.StatusUpdate(ctx, instance)
-		if result.Err != nil {
-			return result
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
 		}
 		// ensure that new requeue iteration is triggered even if no status update happened
-		return i.Requeue()
+		return i.RequeueAfter(5 * time.Second)
 	}
 }
 
@@ -166,6 +166,6 @@ func (i migrationJobAction) ensureMigrationJob(ctx context.Context, labels map[s
 		Reason:  state.Initialize.String(),
 		Message: "migration job created",
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 
 }

--- a/internal/controller/tuf/actions/migration_job_test.go
+++ b/internal/controller/tuf/actions/migration_job_test.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/gomega"
@@ -134,7 +135,7 @@ func TestMigrateJob_Succeeded(t *testing.T) {
 	g.Expect(migrateJobTestAction.Client.Create(t.Context(), instance)).To(Succeed())
 	g.Expect(migrateJobTestAction.CanHandle(t.Context(), instance)).To(BeTrue())
 	result := migrateJobTestAction.Handle(t.Context(), instance)
-	g.Expect(result).To(Equal(action.StatusUpdate()))
+	g.Expect(result).To(Equal(action.Return()))
 	g.Expect(instance.Status.Conditions).To(ContainElement(metav1.Condition{
 		Type:    constants.ReadyCondition,
 		Reason:  state.Initialize.String(),
@@ -160,7 +161,7 @@ func TestMigrateJob_Succeeded(t *testing.T) {
 		Status:  metav1.ConditionFalse,
 		Message: "waiting for migration job to complete",
 	}))
-	g.Expect(result).To(Equal(action.Requeue()))
+	g.Expect(result).To(Equal(action.RequeueAfter(5 * time.Second)))
 
 	job.Status.Succeeded = 1
 	job.Status.Failed = 0
@@ -180,7 +181,7 @@ func TestMigrateJob_Succeeded(t *testing.T) {
 		Status:  metav1.ConditionFalse,
 		Message: "migration job passed",
 	}))
-	g.Expect(result).To(Equal(action.StatusUpdate()))
+	g.Expect(result).To(Equal(action.Return()))
 
 	found := &v1alpha1.Tuf{}
 	g.Expect(migrateJobTestAction.Client.Get(t.Context(), client.ObjectKeyFromObject(instance), found)).To(Succeed())
@@ -224,7 +225,7 @@ func TestMigrateJob_Failed(t *testing.T) {
 	g.Expect(migrateJobTestAction.Client.Create(t.Context(), instance)).To(Succeed())
 	g.Expect(migrateJobTestAction.CanHandle(t.Context(), instance)).To(BeTrue())
 	result := migrateJobTestAction.Handle(t.Context(), instance)
-	g.Expect(result).To(Equal(action.StatusUpdate()))
+	g.Expect(result).To(Equal(action.Return()))
 	g.Expect(instance.Status.Conditions).To(ContainElement(metav1.Condition{
 		Type:    constants.ReadyCondition,
 		Reason:  state.Initialize.String(),
@@ -244,7 +245,7 @@ func TestMigrateJob_Failed(t *testing.T) {
 		Status:  metav1.ConditionFalse,
 		Message: "waiting for migration job to complete",
 	}))
-	g.Expect(result).To(Equal(action.Requeue()))
+	g.Expect(result).To(Equal(action.RequeueAfter(5 * time.Second)))
 
 	job.Status.Succeeded = 0
 	job.Status.Failed = 1

--- a/internal/controller/tuf/actions/resolve_keys.go
+++ b/internal/controller/tuf/actions/resolve_keys.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -59,8 +60,10 @@ func (i resolveKeysAction) Handle(ctx context.Context, instance *rhtasv1alpha1.T
 				Reason:  state.Failure.String(),
 				Message: err.Error(),
 			})
-			i.StatusUpdate(ctx, instance)
-			return i.Requeue()
+			if _, err := i.PersistStatus(ctx, instance); err != nil {
+				return i.Error(ctx, err, instance)
+			}
+			return i.RequeueAfter(5 * time.Second)
 		}
 		if len(instance.Status.Keys) < index+1 {
 			instance.Status.Keys = append(instance.Status.Keys, *k)
@@ -80,10 +83,13 @@ func (i resolveKeysAction) Handle(ctx context.Context, instance *rhtasv1alpha1.T
 			}
 		}
 		if index == len(instance.Spec.Keys)-1 {
+			if _, err := i.PersistStatus(ctx, instance); err != nil {
+				return i.Error(ctx, err, instance)
+			}
 			return i.Continue()
 		}
 	}
-	return i.StatusUpdate(ctx, instance)
+	return i.Continue()
 }
 
 func (i resolveKeysAction) handleKey(ctx context.Context, instance *rhtasv1alpha1.Tuf, key *rhtasv1alpha1.TufKey) (*rhtasv1alpha1.TufKey, error) {

--- a/internal/controller/tuf/actions/service.go
+++ b/internal/controller/tuf/actions/service.go
@@ -65,7 +65,7 @@ func (i serviceAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tuf) 
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.ReadyCondition,
 			Status: metav1.ConditionFalse, Reason: state.Creating.String(), Message: "Service created",
 			ObservedGeneration: instance.Generation})
-		return i.StatusUpdate(ctx, instance)
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {
 		return i.Continue()
 	}

--- a/internal/controller/tuf/actions/status-url.go
+++ b/internal/controller/tuf/actions/status-url.go
@@ -51,5 +51,5 @@ func (i statusUrlAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Tuf
 	}
 
 	instance.Status.Url = url
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/controller/tuf/actions/tuf_init_job.go
+++ b/internal/controller/tuf/actions/tuf_init_job.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/action"
@@ -76,7 +77,7 @@ func (i initJobAction) jobPresent(ctx context.Context, job *v2.Job, instance *rh
 					return i.Error(ctx, err, instance)
 				}
 			}
-			return i.StatusUpdate(ctx, instance)
+			return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 		} else {
 			err := fmt.Errorf("tuf-repository-init job failed")
 			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
@@ -94,12 +95,10 @@ func (i initJobAction) jobPresent(ctx context.Context, job *v2.Job, instance *rh
 			Reason:  state.Initialize.String(),
 			Message: "waiting for init-repository job to complete",
 		})
-		result := i.StatusUpdate(ctx, instance)
-		if result.Err != nil {
-			return result
+		if _, err := i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
 		}
-		// ensure that new requeue iteration is triggered even if no status update happened
-		return i.Requeue()
+		return i.RequeueAfter(5 * time.Second)
 	}
 }
 
@@ -147,5 +146,5 @@ func (i initJobAction) ensureInitJob(ctx context.Context, labels map[string]stri
 		Reason:  state.Initialize.String(),
 		Message: msg,
 	})
-	return i.StatusUpdate(ctx, instance)
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }

--- a/internal/testing/action/result.go
+++ b/internal/testing/action/result.go
@@ -1,3 +1,11 @@
+// Package action provides test helpers for constructing [action.Result] values
+// to use as expected outcomes in unit test assertions.
+//
+// These functions construct Result structs directly, without the side effects
+// of their [action.BaseAction] counterparts. For example, [Error] returns a
+// Result with the error set but does NOT log, detect terminal errors, or set
+// status conditions. Use these when comparing the returned Result, and verify
+// side effects separately.
 package action
 
 import (
@@ -7,14 +15,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// Continue returns the expected result for [action.BaseAction.Continue] (nil).
 func Continue() *action.Result {
 	return nil
 }
 
-func StatusUpdate() *action.Result {
-	return &action.Result{Result: reconcile.Result{}}
-}
-
+// Error returns the expected result for [action.BaseAction.Error].
+// Only the error value is set — no logging or condition-setting side effects.
 func Error(err error) *action.Result {
 	return &action.Result{
 		Result: reconcile.Result{},
@@ -22,6 +29,7 @@ func Error(err error) *action.Result {
 	}
 }
 
+// Return returns the expected result for [action.BaseAction.Return].
 func Return() *action.Result {
 	return &action.Result{
 		Result: reconcile.Result{},
@@ -29,9 +37,19 @@ func Return() *action.Result {
 	}
 }
 
+// Requeue returns the expected result for [action.BaseAction.Requeue] (100ms).
 func Requeue() *action.Result {
 	return &action.Result{
-		Result: reconcile.Result{RequeueAfter: 5 * time.Second},
+		Result: reconcile.Result{RequeueAfter: 100 * time.Millisecond},
+		Err:    nil,
+	}
+}
+
+// RequeueAfter returns the expected result for [action.BaseAction.RequeueAfter].
+// Use for polling assertions (typically 5 * time.Second).
+func RequeueAfter(delay time.Duration) *action.Result {
+	return &action.Result{
+		Result: reconcile.Result{RequeueAfter: delay},
 		Err:    nil,
 	}
 }

--- a/internal/testing/envtest/envtest.go
+++ b/internal/testing/envtest/envtest.go
@@ -1,0 +1,50 @@
+package envtest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// FindBinaryAssetsDir locates the envtest binary assets directory under
+// the repository's bin/k8s/ tree. It resolves the repo root relative to
+// this source file (internal/testing/envtest/), then looks for versioned
+// subdirectories matching the current OS and architecture
+// (e.g. "1.32.0-darwin-arm64").
+//
+// Returns the path to the highest version found, or an empty string if
+// none is available (envtest will fall back to KUBEBUILDER_ASSETS or
+// /usr/local/kubebuilder/bin).
+func FindBinaryAssetsDir() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+
+	// This file lives at internal/testing/envtest/envtest.go — repo root is 3 levels up.
+	root := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+
+	suffix := fmt.Sprintf("-%s-%s", runtime.GOOS, runtime.GOARCH)
+	k8sDir := filepath.Join(root, "bin", "k8s")
+
+	entries, err := os.ReadDir(k8sDir)
+	if err != nil {
+		return ""
+	}
+
+	var matches []string
+	for _, e := range entries {
+		if e.IsDir() && strings.HasSuffix(e.Name(), suffix) {
+			matches = append(matches, e.Name())
+		}
+	}
+	if len(matches) == 0 {
+		return ""
+	}
+
+	sort.Strings(matches)
+	return filepath.Join(k8sDir, matches[len(matches)-1])
+}

--- a/test/e2e/custom_install/rolling_upgrade_test.go
+++ b/test/e2e/custom_install/rolling_upgrade_test.go
@@ -111,6 +111,20 @@ var _ = Describe("rolling upgrade with replicas", Ordered, func() {
 
 			By("install operator with modified related images")
 			installOperator(ctx, cli, s.Namespace, withRelatedImages())
+
+			By("waiting for operator to be ready")
+			Eventually(func(g Gomega, ctx context.Context) {
+				pod := &v1.Pod{}
+				g.Expect(cli.Get(ctx, types.NamespacedName{Namespace: s.Namespace, Name: managerPodName}, pod)).To(Succeed())
+				g.Expect(pod.Status.Phase).To(Equal(v1.PodRunning))
+				ready := false
+				for _, c := range pod.Status.Conditions {
+					if c.Type == v1.PodReady && c.Status == v1.ConditionTrue {
+						ready = true
+					}
+				}
+				g.Expect(ready).To(BeTrue())
+			}).WithContext(ctx).Should(Succeed())
 		})
 
 		It("Verify rolling update done", func(ctx SpecContext) {


### PR DESCRIPTION
## Summary

- Replace `StatusUpdate(ctx, obj) *Result` with `PersistStatus(ctx, obj) (bool, error)` — status persistence is now a pure side-effect, flow control is always an explicit separate choice
- `PersistStatus` skips the API call when status is unchanged (no-op optimization) and returns a `changed` flag so callers can react: `changed=true` → watch event will fire → `Return()`; `changed=false` → no event → `Requeue()` as safety net
- Add `RequeueAfter(delay)` for explicit polling delays; change `Requeue()` default from 5s to 100ms (safety-net, not polling); polling sites now use `RequeueAfter(5 * time.Second)`
- Migrate all ~124 call sites across 60+ action files
- Fix pre-existing bug: missing `return` before `Error()` in `rekor/server/sharding_config.go`
- Fix `tuf/actions/resolve_keys.go` to persist status before `Continue()` (action independence)
- Add `internal/action/doc.go` with patterns and anti-patterns
- Add `PersistStatus` test coverage including conflict retry
- Add godoc to all `BaseAction` methods and `Action` interface

## Motivation

The old `StatusUpdate` conflated two concerns: persisting status to the API server AND controlling reconciler flow. It always returned `*Result`, making it impossible to distinguish a successful write from a no-op. With the no-op optimization (skip API call when status unchanged), a `return i.StatusUpdate(ctx, instance)` call could silently stall reconciliation — no API call means no watch event means no re-trigger.

## Migration patterns

**State transition** (set final state, let watch event drive next action):
```go
changed, err := i.PersistStatus(ctx, instance)
if err != nil {
    return i.Error(ctx, err, instance)
}
if !changed {
    return i.Requeue()
}
return i.Return()
```

**Polling loop** (wait for external state):
```go
if _, err := i.PersistStatus(ctx, instance); err != nil {
    return i.Error(ctx, err, instance)
}
return i.RequeueAfter(5 * time.Second)
```

**Persist then continue** (intermediate checkpoint):
```go
if _, err := i.PersistStatus(ctx, instance); err != nil {
    return i.Error(ctx, err, instance)
}
return i.Continue()
```

## Test plan

- [x] Unit tests pass (`go test ./internal/...`)
- [x] PersistStatus tests: changed, unchanged (no-op), not-found, conflict retry
- [x] E2e test "Securesign install with certificate generation" — 13/13 passed
- [x] Full CI suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)