### PR TITLE
fix(e2e): resolve ctlog monitor corruption test flakiness

### DIFF
--- a/test/e2e/ctlog_monitor_log_test.go
+++ b/test/e2e/ctlog_monitor_log_test.go
@@ -352,6 +352,10 @@ var _ = Describe("Ctlog Monitor Log", Ordered, func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(verifyContent)).ToNot(Equal(string(originalContent)), "File content should be different after tampering")
 
+		By("Signing another image to force the CT log tree to grow beyond the corrupted checkpoint")
+		s = securesign.Get(ctx, cli, namespace.Name, s.Name)
+		tas.VerifyByCosign(ctx, signedImageName, s.Status.TufStatus.Url, s.Status.FulcioStatus.Url, s.Status.RekorStatus.Url, s.Status.TSAStatus.Url)
+
 		By("Waiting for monitor to detect the corruption and increment failure metrics")
 		Eventually(func(g Gomega) {
 			_, verFailure := support.GetMonitorMetricValues(ctx, cli, namespace.Name, actions.MonitorComponentName, g)


### PR DESCRIPTION
## Summary
- The ctlog monitor corruption detection test (`ctlog_monitor_log_test.go`) was flaky because it depended on the CT log tree growing between checkpoint corruption and the monitor's next consistency check
- When the tree size stayed the same, the monitor's same-size consistency path silently passed without catching the corrupted root hash
- Added a cosign sign operation after corrupting the checkpoint to guarantee a new CT log entry, forcing a real consistency proof that detects the corruption

## Root Cause
The monitor uses `GetSTHConsistency(prev_size, current_size)` to verify consistency. When both sizes are equal (no new CT log entries), the proof is trivial and doesn't compare root hashes — so the corrupted checkpoint passes undetected. The fix ensures the tree always grows after corruption by signing another image.

## Test plan
- [ ] CI e2e tests pass — specifically the `should detect subtle corruption when checkpoint file hash is slightly modified` test
- [ ] No regressions in other ctlog monitor tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)