### PR TITLE
feat(lint): custom action framework linter

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,5 @@
+version: v2.12.2
+plugins:
+  - module: 'github.com/securesign/operator/pkg/analyzer'
+    import: 'github.com/securesign/operator/pkg/analyzer'
+    path: ./pkg/analyzer

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,9 +13,14 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - name: Build custom golangci-lint
+        run: |
+          make custom-golangci-lint
+          install ./bin/custom-gcl /usr/local/bin/golangci-lint
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
+          install-mode: none
           version: v2.12.2
           args: --verbose --timeout=15m
           only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ run:
 linters:
   default: none
   enable:
+    - actionlint
     - copyloopvar
     - errcheck
     - ginkgolinter
@@ -23,6 +24,10 @@ linters:
     - unparam
     - unused
   settings:
+    custom:
+      actionlint:
+        type: "module"
+        description: "Checks action framework patterns (PersistStatus errors, Spec mutations)"
     staticcheck:
       dot-import-whitelist:
         - github.com/onsi/gomega

--- a/Makefile
+++ b/Makefile
@@ -143,12 +143,12 @@ dev-images:
 	fi
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint linter & yamllint
-	$(GOLANGCI_LINT) run
+lint: custom-golangci-lint ## Run golangci-lint linter (includes action framework checks).
+	$(CUSTOM_GOLANGCI_LINT) run
 
 .PHONY: lint-fix
-lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
-	$(GOLANGCI_LINT) run --fix
+lint-fix: custom-golangci-lint ## Run golangci-lint linter and perform fixes
+	$(CUSTOM_GOLANGCI_LINT) run --fix
 
 ##@ Build
 
@@ -240,6 +240,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest-$(ENVTEST_VERSION)
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
+CUSTOM_GOLANGCI_LINT = $(LOCALBIN)/custom-gcl
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.6.0
@@ -266,6 +267,10 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+.PHONY: custom-golangci-lint
+custom-golangci-lint: golangci-lint ## Build golangci-lint with action framework linter plugin.
+	$(GOLANGCI_LINT) custom --destination $(LOCALBIN)
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/internal/controller/ctlog/actions/deployment.go
+++ b/internal/controller/ctlog/actions/deployment.go
@@ -21,7 +21,6 @@ import (
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	"github.com/securesign/operator/internal/controller/ctlog/utils"
-	trillian "github.com/securesign/operator/internal/controller/trillian/actions"
 	v1 "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,11 +56,6 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 	)
 
 	labels := labels.For(ComponentName, DeploymentName, instance.Name)
-
-	switch instance.Spec.Trillian.Address {
-	case "":
-		instance.Spec.Trillian.Address = fmt.Sprintf("%s.%s.svc", trillian.LogserverDeploymentName, instance.Namespace)
-	}
 
 	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client,
 		&v1.Deployment{
@@ -107,7 +101,7 @@ func (i deployAction) ensureDeployment(instance *rhtasv1alpha1.CTlog, sa string,
 			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ErrServerConfigNotSpecified)
 		case instance.Status.TreeID == nil:
 			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ErrTreeNotSpecified)
-		case instance.Spec.Trillian.Address == "":
+		case resolveTrillianAddress(instance) == "":
 			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ErrTrillianAddressNotSpecified)
 		case instance.Spec.Trillian.Port == nil:
 			return fmt.Errorf("CreateCTLogDeployment: %w", utils.ErrTrillianPortNotSpecified)

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -252,6 +252,55 @@ func (i serverConfig) handleCustomConfig(ctx context.Context, instance *rhtasv1a
 	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 }
 
+func (i serverConfig) handleCustomConfig(ctx context.Context, instance *rhtasv1alpha1.CTlog) *action.Result {
+	secret, err := kubernetes.GetSecret(i.Client, instance.Namespace, instance.Spec.ServerConfigRef.Name)
+	if err != nil {
+		return i.Error(ctx, fmt.Errorf("error accessing custom server config secret: %w", err), instance,
+			metav1.Condition{
+				Type:               ConfigCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Failure.String(),
+				Message:            fmt.Sprintf("Error accessing custom server config secret: %s", instance.Spec.ServerConfigRef.Name),
+				ObservedGeneration: instance.Generation,
+			})
+	}
+	if secret.Data == nil || secret.Data[ctlogUtils.ConfigKey] == nil {
+		return i.Error(ctx, fmt.Errorf("custom server config secret is invalid"), instance,
+			metav1.Condition{
+				Type:               ConfigCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Failure.String(),
+				Message:            fmt.Sprintf("Custom server config secret is missing '%s' key: %s", ctlogUtils.ConfigKey, instance.Spec.ServerConfigRef.Name),
+				ObservedGeneration: instance.Generation,
+			})
+	}
+
+	c := meta.FindStatusCondition(instance.Status.Conditions, ConfigCondition)
+	if c != nil && c.Status == metav1.ConditionTrue &&
+		c.ObservedGeneration == instance.Generation &&
+		equality.Semantic.DeepEqual(instance.Status.ServerConfigRef, instance.Spec.ServerConfigRef) {
+		return i.Continue()
+	}
+
+	instance.Status.ServerConfigRef = instance.Spec.ServerConfigRef
+	i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "CTLogConfigUpdated", "Updated", "CTLog config updated: %s", instance.Spec.ServerConfigRef.Name)
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:               ConfigCondition,
+		Status:             metav1.ConditionTrue,
+		Reason:             state.Ready.String(),
+		Message:            "Using custom server config",
+		ObservedGeneration: instance.Generation,
+	})
+	changed, err := i.PersistStatus(ctx, instance)
+	if err != nil {
+		return i.Error(ctx, err, instance)
+	}
+	if !changed {
+		return i.Requeue()
+	}
+	return i.Return()
+}
+
 func (i serverConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.CTlog, configLabels map[string]string) {
 	if instance.Status.ServerConfigRef == nil || instance.Status.ServerConfigRef.Name == "" {
 		i.Logger.Error(errors.New("new Secret name is empty"), "unable to clean old objects", "namespace", instance.Namespace)
@@ -367,4 +416,11 @@ func (i serverConfig) configMatchingAnnotations(instance *rhtasv1alpha1.CTlog, t
 	}
 
 	return annotations
+}
+
+func resolveTrillianAddress(instance *rhtasv1alpha1.CTlog) string {
+	if instance.Spec.Trillian.Address != "" {
+		return instance.Spec.Trillian.Address
+	}
+	return fmt.Sprintf("%s.%s.svc", trillian.LogserverDeploymentName, instance.Namespace)
 }

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -76,11 +76,9 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 		return i.Error(ctx, fmt.Errorf("%s: %v", i.Name(), ctlogUtils.ErrPrivateKeyNotSpecified), instance)
 	case instance.Spec.Trillian.Port == nil:
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("%s: %v", i.Name(), ctlogUtils.ErrTrillianPortNotSpecified)), instance)
-	case instance.Spec.Trillian.Address == "":
-		instance.Spec.Trillian.Address = fmt.Sprintf("%s.%s.svc", trillian.LogserverDeploymentName, instance.Namespace)
 	}
 
-	trillianUrl := fmt.Sprintf("%s:%d", instance.Spec.Trillian.Address, *instance.Spec.Trillian.Port)
+	trillianUrl := fmt.Sprintf("%s:%d", resolveTrillianAddress(instance), *instance.Spec.Trillian.Port)
 
 	// Validate existing secret before attempting recreation
 	if instance.Status.ServerConfigRef != nil && instance.Status.ServerConfigRef.Name != "" {
@@ -250,55 +248,6 @@ func (i serverConfig) handleCustomConfig(ctx context.Context, instance *rhtasv1a
 		ObservedGeneration: instance.Generation,
 	})
 	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
-}
-
-func (i serverConfig) handleCustomConfig(ctx context.Context, instance *rhtasv1alpha1.CTlog) *action.Result {
-	secret, err := kubernetes.GetSecret(i.Client, instance.Namespace, instance.Spec.ServerConfigRef.Name)
-	if err != nil {
-		return i.Error(ctx, fmt.Errorf("error accessing custom server config secret: %w", err), instance,
-			metav1.Condition{
-				Type:               ConfigCondition,
-				Status:             metav1.ConditionFalse,
-				Reason:             state.Failure.String(),
-				Message:            fmt.Sprintf("Error accessing custom server config secret: %s", instance.Spec.ServerConfigRef.Name),
-				ObservedGeneration: instance.Generation,
-			})
-	}
-	if secret.Data == nil || secret.Data[ctlogUtils.ConfigKey] == nil {
-		return i.Error(ctx, fmt.Errorf("custom server config secret is invalid"), instance,
-			metav1.Condition{
-				Type:               ConfigCondition,
-				Status:             metav1.ConditionFalse,
-				Reason:             state.Failure.String(),
-				Message:            fmt.Sprintf("Custom server config secret is missing '%s' key: %s", ctlogUtils.ConfigKey, instance.Spec.ServerConfigRef.Name),
-				ObservedGeneration: instance.Generation,
-			})
-	}
-
-	c := meta.FindStatusCondition(instance.Status.Conditions, ConfigCondition)
-	if c != nil && c.Status == metav1.ConditionTrue &&
-		c.ObservedGeneration == instance.Generation &&
-		equality.Semantic.DeepEqual(instance.Status.ServerConfigRef, instance.Spec.ServerConfigRef) {
-		return i.Continue()
-	}
-
-	instance.Status.ServerConfigRef = instance.Spec.ServerConfigRef
-	i.Recorder.Eventf(instance, nil, corev1.EventTypeNormal, "CTLogConfigUpdated", "Updated", "CTLog config updated: %s", instance.Spec.ServerConfigRef.Name)
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:               ConfigCondition,
-		Status:             metav1.ConditionTrue,
-		Reason:             state.Ready.String(),
-		Message:            "Using custom server config",
-		ObservedGeneration: instance.Generation,
-	})
-	changed, err := i.PersistStatus(ctx, instance)
-	if err != nil {
-		return i.Error(ctx, err, instance)
-	}
-	if !changed {
-		return i.Requeue()
-	}
-	return i.Return()
 }
 
 func (i serverConfig) cleanup(ctx context.Context, instance *rhtasv1alpha1.CTlog, configLabels map[string]string) {

--- a/internal/controller/fulcio/actions/generate_cert.go
+++ b/internal/controller/fulcio/actions/generate_cert.go
@@ -297,7 +297,7 @@ func (g handleCert) calculateHostname(ctx context.Context, instance *v1alpha1.Fu
 		return nil
 	}
 
-	instance.Spec.ExternalAccess.Host, err = kubernetes.CalculateHostname(ctx, g.Client, DeploymentName, instance.Namespace)
+	instance.Status.Certificate.CommonName, err = kubernetes.CalculateHostname(ctx, g.Client, DeploymentName, instance.Namespace)
 
 	return err
 }

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -369,10 +369,13 @@ func (g generateSigner) alignStatusFields(secretName string, instance *v1alpha1.
 	if instance.Status.Signer == nil {
 		instance.Status.Signer = new(v1alpha1.TimestampAuthoritySigner)
 	}
-	if instance.Spec.Signer.File == nil && instance.Spec.Signer.CertificateChain.CertificateChainRef == nil {
-		instance.Spec.Signer.File = new(v1alpha1.File)
-	}
 	instance.Spec.Signer.DeepCopyInto(instance.Status.Signer)
+
+	// Default to File-based signer when no signer type (File/Tink/KMS) and no
+	// external cert chain are configured.
+	if instance.Spec.Signer.File == nil && instance.Spec.Signer.CertificateChain.CertificateChainRef == nil {
+		instance.Status.Signer.File = new(v1alpha1.File)
+	}
 
 	if instance.Spec.Signer.CertificateChain.CertificateChainRef == nil {
 		instance.Status.Signer.CertificateChain.CertificateChainRef = &v1alpha1.SecretKeySelector{
@@ -382,7 +385,7 @@ func (g generateSigner) alignStatusFields(secretName string, instance *v1alpha1.
 			},
 		}
 
-		if instance.Spec.Signer.File.PrivateKeyRef == nil {
+		if instance.Spec.Signer.File == nil || instance.Spec.Signer.File.PrivateKeyRef == nil {
 			instance.Status.Signer.File.PrivateKeyRef = &v1alpha1.SecretKeySelector{
 				Key: "leafPrivateKey",
 				LocalObjectReference: v1alpha1.LocalObjectReference{
@@ -391,7 +394,7 @@ func (g generateSigner) alignStatusFields(secretName string, instance *v1alpha1.
 			}
 		}
 
-		if instance.Spec.Signer.File.PasswordRef == nil {
+		if instance.Spec.Signer.File == nil || instance.Spec.Signer.File.PasswordRef == nil {
 			instance.Status.Signer.File.PasswordRef = &v1alpha1.SecretKeySelector{
 				Key: "leafPrivateKeyPassword",
 				LocalObjectReference: v1alpha1.LocalObjectReference{

--- a/internal/controller/tsa/actions/generate_signer_test.go
+++ b/internal/controller/tsa/actions/generate_signer_test.go
@@ -463,3 +463,181 @@ func generateSecretAnnotations(signer rhtasv1alpha1.TimestampAuthoritySigner) ma
 	annotations[labels.LabelNamespace+"/signerConfiguration"] = string(bytes)
 	return annotations
 }
+
+func Test_AlignStatusFields(t *testing.T) {
+	const userSecret = "user-signer-secret"
+
+	tests := []struct {
+		name     string
+		signer   rhtasv1alpha1.TimestampAuthoritySigner
+		testCase func(Gomega, *rhtasv1alpha1.TimestampAuthority)
+	}{
+		{
+			name: "default signer (no File, no ChainRef) — defaults to File-based",
+			signer: rhtasv1alpha1.TimestampAuthoritySigner{
+				CertificateChain: rhtasv1alpha1.CertificateChain{
+					RootCA:         &rhtasv1alpha1.TsaCertificateAuthority{OrganizationName: "Red Hat"},
+					IntermediateCA: []*rhtasv1alpha1.TsaCertificateAuthority{{OrganizationName: "Red Hat"}},
+					LeafCA:         &rhtasv1alpha1.TsaCertificateAuthority{OrganizationName: "Red Hat"},
+				},
+			},
+			testCase: func(g Gomega, instance *rhtasv1alpha1.TimestampAuthority) {
+				g.Expect(instance.Status.Signer).NotTo(BeNil())
+				g.Expect(instance.Status.Signer.File).NotTo(BeNil(), "File should be defaulted on Status")
+				g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef).NotTo(BeNil())
+				g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef.Name).To(Equal("test-secret"))
+				g.Expect(instance.Status.Signer.File.PrivateKeyRef).NotTo(BeNil(), "PrivateKeyRef should be defaulted")
+				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Key).To(Equal("leafPrivateKey"))
+				g.Expect(instance.Status.Signer.File.PasswordRef).NotTo(BeNil(), "PasswordRef should be defaulted")
+				g.Expect(instance.Status.Signer.File.PasswordRef.Key).To(Equal("leafPrivateKeyPassword"))
+			},
+		},
+		{
+			name: "File signer with user-provided keys — preserves refs",
+			signer: rhtasv1alpha1.TimestampAuthoritySigner{
+				CertificateChain: rhtasv1alpha1.CertificateChain{
+					RootCA:         &rhtasv1alpha1.TsaCertificateAuthority{OrganizationName: "Red Hat"},
+					IntermediateCA: []*rhtasv1alpha1.TsaCertificateAuthority{{OrganizationName: "Red Hat"}},
+					LeafCA:         &rhtasv1alpha1.TsaCertificateAuthority{OrganizationName: "Red Hat"},
+				},
+				File: &rhtasv1alpha1.File{
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						Key:                  "myKey",
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: userSecret},
+					},
+					PasswordRef: &rhtasv1alpha1.SecretKeySelector{
+						Key:                  "myPassword",
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: userSecret},
+					},
+				},
+			},
+			testCase: func(g Gomega, instance *rhtasv1alpha1.TimestampAuthority) {
+				g.Expect(instance.Status.Signer.File).NotTo(BeNil())
+				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Name).To(Equal(userSecret), "should preserve user-provided PrivateKeyRef")
+				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Key).To(Equal("myKey"))
+				g.Expect(instance.Status.Signer.File.PasswordRef.Name).To(Equal(userSecret), "should preserve user-provided PasswordRef")
+				g.Expect(instance.Status.Signer.File.PasswordRef.Key).To(Equal("myPassword"))
+				g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef.Name).To(Equal("test-secret"))
+			},
+		},
+		{
+			name: "File signer with partial refs — defaults missing",
+			signer: rhtasv1alpha1.TimestampAuthoritySigner{
+				CertificateChain: rhtasv1alpha1.CertificateChain{
+					RootCA:         &rhtasv1alpha1.TsaCertificateAuthority{OrganizationName: "Red Hat"},
+					IntermediateCA: []*rhtasv1alpha1.TsaCertificateAuthority{{OrganizationName: "Red Hat"}},
+					LeafCA:         &rhtasv1alpha1.TsaCertificateAuthority{OrganizationName: "Red Hat"},
+				},
+				File: &rhtasv1alpha1.File{
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						Key:                  "myKey",
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: userSecret},
+					},
+					// PasswordRef intentionally nil
+				},
+			},
+			testCase: func(g Gomega, instance *rhtasv1alpha1.TimestampAuthority) {
+				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Name).To(Equal(userSecret), "should keep user-provided PrivateKeyRef")
+				g.Expect(instance.Status.Signer.File.PasswordRef).NotTo(BeNil(), "should default missing PasswordRef")
+				g.Expect(instance.Status.Signer.File.PasswordRef.Key).To(Equal("leafPrivateKeyPassword"))
+				g.Expect(instance.Status.Signer.File.PasswordRef.Name).To(Equal("test-secret"))
+			},
+		},
+		{
+			name: "external CertificateChainRef with File signer — skips defaults",
+			signer: rhtasv1alpha1.TimestampAuthoritySigner{
+				CertificateChain: rhtasv1alpha1.CertificateChain{
+					CertificateChainRef: &rhtasv1alpha1.SecretKeySelector{
+						Key:                  "chain",
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "external-secret"},
+					},
+				},
+				File: &rhtasv1alpha1.File{
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{
+						Key:                  "key",
+						LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "external-secret"},
+					},
+				},
+			},
+			testCase: func(g Gomega, instance *rhtasv1alpha1.TimestampAuthority) {
+				g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef.Name).To(Equal("external-secret"), "should preserve external ChainRef")
+				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Name).To(Equal("external-secret"), "should preserve external PrivateKeyRef")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			instance := &rhtasv1alpha1.TimestampAuthority{
+				Spec: rhtasv1alpha1.TimestampAuthoritySpec{
+					Signer: tt.signer,
+				},
+			}
+			a := generateSigner{}
+			a.alignStatusFields("test-secret", instance)
+			tt.testCase(g, instance)
+		})
+	}
+}
+
+func Test_SignerHandle_KMS(t *testing.T) {
+	g := NewWithT(t)
+	instance := common.GenerateTSAInstance()
+	instance.Status.Conditions[0].Reason = state.Pending.String()
+	instance.Spec.Signer = rhtasv1alpha1.TimestampAuthoritySigner{
+		CertificateChain: rhtasv1alpha1.CertificateChain{
+			CertificateChainRef: &rhtasv1alpha1.SecretKeySelector{
+				Key:                  "certificateChain",
+				LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "kms-secret"},
+			},
+		},
+		Kms: &rhtasv1alpha1.KMS{
+			KeyResource: "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1",
+		},
+	}
+
+	secret := tsa.CreateSecrets(instance.Namespace, "kms-secret")
+	cli, act := common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), secret)
+	g.Expect(cli).NotTo(BeNil())
+	g.Expect(act).NotTo(BeNil())
+	g.Expect(cli.Get(context.TODO(), client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+
+	g.Expect(instance.Status.Signer).NotTo(BeNil())
+	g.Expect(instance.Status.Signer.Kms).NotTo(BeNil(), "KMS config should be preserved in Status")
+	g.Expect(instance.Status.Signer.File).To(BeNil(), "File should be nil for KMS signer")
+	g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef.Name).To(Equal("kms-secret"))
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, TSASignerCondition)).To(BeTrue())
+}
+
+func Test_SignerHandle_Tink(t *testing.T) {
+	g := NewWithT(t)
+	instance := common.GenerateTSAInstance()
+	instance.Status.Conditions[0].Reason = state.Pending.String()
+	instance.Spec.Signer = rhtasv1alpha1.TimestampAuthoritySigner{
+		CertificateChain: rhtasv1alpha1.CertificateChain{
+			CertificateChainRef: &rhtasv1alpha1.SecretKeySelector{
+				Key:                  "certificateChain",
+				LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "tink-secret"},
+			},
+		},
+		Tink: &rhtasv1alpha1.Tink{
+			KeysetRef: &rhtasv1alpha1.SecretKeySelector{
+				Key:                  "keySet",
+				LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "tink-secret"},
+			},
+		},
+	}
+
+	secret := tsa.CreateSecrets(instance.Namespace, "tink-secret")
+	cli, act := common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), secret)
+	g.Expect(cli).NotTo(BeNil())
+	g.Expect(act).NotTo(BeNil())
+	g.Expect(cli.Get(context.TODO(), client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+
+	g.Expect(instance.Status.Signer).NotTo(BeNil())
+	g.Expect(instance.Status.Signer.Tink).NotTo(BeNil(), "Tink config should be preserved in Status")
+	g.Expect(instance.Status.Signer.File).To(BeNil(), "File should be nil for Tink signer")
+	g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef.Name).To(Equal("tink-secret"))
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, TSASignerCondition)).To(BeTrue())
+}

--- a/pkg/analyzer/actionlint.go
+++ b/pkg/analyzer/actionlint.go
@@ -1,0 +1,8 @@
+package analyzer
+
+import "golang.org/x/tools/go/analysis"
+
+var Analyzers = []*analysis.Analyzer{
+	PersistStatusErr,
+	SpecMutation,
+}

--- a/pkg/analyzer/go.mod
+++ b/pkg/analyzer/go.mod
@@ -1,0 +1,13 @@
+module github.com/securesign/operator/pkg/analyzer
+
+go 1.25.7
+
+require (
+	github.com/golangci/plugin-module-register v0.1.2
+	golang.org/x/tools v0.43.0
+)
+
+require (
+	golang.org/x/mod v0.34.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+)

--- a/pkg/analyzer/go.sum
+++ b/pkg/analyzer/go.sum
@@ -1,0 +1,10 @@
+github.com/golangci/plugin-module-register v0.1.2 h1:e5WM6PO6NIAEcij3B053CohVp3HIYbzSuP53UAYgOpg=
+github.com/golangci/plugin-module-register v0.1.2/go.mod h1:1+QGTsKBvAIvPvoY/os+G5eoqxWn70HYDm2uvUyGuVw=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
+golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
+golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=

--- a/pkg/analyzer/persiststatuserr.go
+++ b/pkg/analyzer/persiststatuserr.go
@@ -1,0 +1,96 @@
+package analyzer
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+var PersistStatusErr = &analysis.Analyzer{
+	Name:     "persiststatuserr",
+	Doc:      "checks that PersistStatus error return value is not discarded",
+	Run:      runPersistStatusErr,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+func runPersistStatusErr(pass *analysis.Pass) (interface{}, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.AssignStmt)(nil),
+		(*ast.ExprStmt)(nil),
+	}
+
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			if len(stmt.Rhs) != 1 {
+				return
+			}
+			call, ok := stmt.Rhs[0].(*ast.CallExpr)
+			if !ok || !isPersistStatusCall(pass, call) {
+				return
+			}
+			if len(stmt.Lhs) >= 2 {
+				if ident, ok := stmt.Lhs[1].(*ast.Ident); ok && ident.Name == "_" {
+					pass.Reportf(stmt.Pos(), "PersistStatus error return value must not be discarded")
+				}
+			}
+
+		case *ast.ExprStmt:
+			call, ok := stmt.X.(*ast.CallExpr)
+			if !ok || !isPersistStatusCall(pass, call) {
+				return
+			}
+			pass.Reportf(stmt.Pos(), "PersistStatus return values must not be discarded")
+		}
+	})
+
+	return nil, nil
+}
+
+func isPersistStatusCall(pass *analysis.Pass, call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "PersistStatus" {
+		return false
+	}
+
+	obj := pass.TypesInfo.ObjectOf(sel.Sel)
+	if obj == nil {
+		return false
+	}
+
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return false
+	}
+
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+
+	results := sig.Results()
+	if results.Len() != 2 {
+		return false
+	}
+
+	// Second return must be error
+	if !types.Implements(results.At(1).Type(), errorInterface()) {
+		return false
+	}
+
+	return true
+}
+
+var cachedErrorInterface *types.Interface
+
+func errorInterface() *types.Interface {
+	if cachedErrorInterface == nil {
+		cachedErrorInterface = types.Universe.Lookup("error").Type().Underlying().(*types.Interface)
+	}
+	return cachedErrorInterface
+}

--- a/pkg/analyzer/persiststatuserr_test.go
+++ b/pkg/analyzer/persiststatuserr_test.go
@@ -1,0 +1,13 @@
+package analyzer_test
+
+import (
+	"testing"
+
+	"github.com/securesign/operator/pkg/analyzer"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestPersistStatusErr(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, analyzer.PersistStatusErr, "persiststatuserr")
+}

--- a/pkg/analyzer/plugin.go
+++ b/pkg/analyzer/plugin.go
@@ -1,0 +1,24 @@
+package analyzer
+
+import (
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+)
+
+func init() {
+	register.Plugin("actionlint", newPlugin)
+}
+
+func newPlugin(any) (register.LinterPlugin, error) {
+	return &actionLintPlugin{}, nil
+}
+
+type actionLintPlugin struct{}
+
+func (*actionLintPlugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	return Analyzers, nil
+}
+
+func (*actionLintPlugin) GetLoadMode() string {
+	return register.LoadModeSyntax
+}

--- a/pkg/analyzer/specmutation.go
+++ b/pkg/analyzer/specmutation.go
@@ -1,0 +1,499 @@
+package analyzer
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// MutatesParam is an analysis fact exported on *types.Func objects.
+// Indices records which pointer parameters a function writes through (any field).
+// SpecIndices records which parameters have their .Spec field specifically mutated.
+type MutatesParam struct {
+	Indices     []int
+	SpecIndices []int
+}
+
+func (*MutatesParam) AFact() {}
+func (f *MutatesParam) String() string {
+	return "mutatesParam"
+}
+
+var SpecMutation = &analysis.Analyzer{
+	Name:      "specmutation",
+	Doc:       "checks that action types do not mutate instance.Spec (only Status is persisted)",
+	Run:       runSpecMutation,
+	Requires:  []*analysis.Analyzer{inspect.Analyzer},
+	FactTypes: []analysis.Fact{(*MutatesParam)(nil)},
+}
+
+func runSpecMutation(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	nodeFilter := []ast.Node{
+		(*ast.FuncDecl)(nil),
+	}
+
+	// Phase 1: export mutation facts for every function in this package.
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if fn.Body == nil {
+			return
+		}
+		indices, specIndices := mutatedParamIndices(pass, fn)
+		if len(indices) == 0 && len(specIndices) == 0 {
+			return
+		}
+		obj := pass.TypesInfo.ObjectOf(fn.Name)
+		if obj == nil {
+			return
+		}
+		funcObj, ok := obj.(*types.Func)
+		if !ok {
+			return
+		}
+		pass.ExportObjectFact(funcObj, &MutatesParam{Indices: indices, SpecIndices: specIndices})
+	})
+
+	// Phase 2: collect action types.
+	actionTypes := map[types.Type]bool{}
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if rt := actionReceiverType(pass, fn); rt != nil {
+			actionTypes[rt] = true
+		}
+	})
+
+	if len(actionTypes) == 0 {
+		return nil, nil
+	}
+
+	// Phase 3: in any method on an action type, flag spec mutations.
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		fn := n.(*ast.FuncDecl)
+		if fn.Recv == nil || fn.Body == nil {
+			return
+		}
+
+		recvType := receiverBaseType(pass, fn)
+		if recvType == nil || !actionTypes[recvType] {
+			return
+		}
+
+		instanceParams := specBearingParams(pass, fn)
+		if len(instanceParams) == 0 {
+			return
+		}
+
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.AssignStmt:
+				for _, lhs := range node.Lhs {
+					for _, param := range instanceParams {
+						if isSpecFieldAccess(pass, lhs, param) {
+							pass.Reportf(node.Pos(), "action type must not mutate instance.Spec; only Status is persisted by the action framework")
+						}
+					}
+				}
+			case *ast.CallExpr:
+				checkIndirectSpecMutation(pass, node, instanceParams)
+			}
+			return true
+		})
+	})
+
+	return nil, nil
+}
+
+// mutatedParamIndices returns two sets of 0-based parameter indices:
+//   - indices: pointer parameters written through (any field, e.g. param.Field = ...)
+//   - specIndices: parameters where .Spec specifically is mutated (e.g. param.Spec.Field = ...)
+func mutatedParamIndices(pass *analysis.Pass, fn *ast.FuncDecl) (indices []int, specIndices []int) {
+	if fn.Type.Params == nil {
+		return nil, nil
+	}
+
+	paramVars := collectParamVars(pass, fn)
+	if len(paramVars) == 0 {
+		return nil, nil
+	}
+
+	ptrParams := map[*types.Var]int{}
+	for idx, v := range paramVars {
+		if v == nil {
+			continue
+		}
+		t := v.Type()
+		if _, ok := t.(*types.Pointer); ok {
+			ptrParams[v] = idx
+		}
+	}
+	if len(ptrParams) == 0 {
+		return nil, nil
+	}
+
+	mutated := map[int]bool{}
+	specMutated := map[int]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			if v := rootVar(pass, lhs); v != nil {
+				if idx, ok := ptrParams[v]; ok {
+					mutated[idx] = true
+					if containsSpecSelector(lhs, v, pass) {
+						specMutated[idx] = true
+					}
+				}
+			}
+			if star, ok := lhs.(*ast.StarExpr); ok {
+				if v := rootVar(pass, star.X); v != nil {
+					if idx, ok := ptrParams[v]; ok {
+						mutated[idx] = true
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	for idx := range mutated {
+		indices = append(indices, idx)
+	}
+	for idx := range specMutated {
+		specIndices = append(specIndices, idx)
+	}
+	return indices, specIndices
+}
+
+// containsSpecSelector returns true if the selector chain from expr back to
+// paramVar passes through a field named "Spec" (e.g. param.Spec.Field).
+func containsSpecSelector(expr ast.Expr, paramVar *types.Var, pass *analysis.Pass) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	cur := sel
+	for {
+		if cur.Sel.Name == "Spec" {
+			if v := resolveToVar(pass, cur.X); v == paramVar {
+				return true
+			}
+		}
+		parent, ok := cur.X.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		cur = parent
+	}
+}
+
+// collectParamVars returns the *types.Var for each parameter position.
+// Unnamed parameters get a nil entry.
+func collectParamVars(pass *analysis.Pass, fn *ast.FuncDecl) []*types.Var {
+	var vars []*types.Var
+	for _, field := range fn.Type.Params.List {
+		if len(field.Names) == 0 {
+			vars = append(vars, nil)
+			continue
+		}
+		for _, name := range field.Names {
+			obj := pass.TypesInfo.ObjectOf(name)
+			if obj == nil {
+				vars = append(vars, nil)
+				continue
+			}
+			v, ok := obj.(*types.Var)
+			if !ok {
+				vars = append(vars, nil)
+				continue
+			}
+			vars = append(vars, v)
+		}
+	}
+	return vars
+}
+
+// rootVar walks a selector chain (a.b.c) back to the root identifier
+// and returns its *types.Var if it is a local variable/parameter.
+func rootVar(pass *analysis.Pass, expr ast.Expr) *types.Var {
+	for {
+		switch e := expr.(type) {
+		case *ast.SelectorExpr:
+			expr = e.X
+		case *ast.Ident:
+			obj := pass.TypesInfo.ObjectOf(e)
+			if obj == nil {
+				return nil
+			}
+			v, ok := obj.(*types.Var)
+			if !ok {
+				return nil
+			}
+			return v
+		case *ast.IndexExpr:
+			expr = e.X
+		default:
+			return nil
+		}
+	}
+}
+
+// checkIndirectSpecMutation flags a call if it passes a spec-bearing
+// expression to a parameter position that the callee mutates.
+func checkIndirectSpecMutation(pass *analysis.Pass, call *ast.CallExpr, instanceParams []*types.Var) {
+	callee := resolveCallee(pass, call)
+	if callee == nil {
+		return
+	}
+
+	var fact MutatesParam
+	if !pass.ImportObjectFact(callee, &fact) {
+		return
+	}
+
+	sig, ok := callee.Type().(*types.Signature)
+	if !ok {
+		return
+	}
+
+	// Check Indices: callee mutates param — is the argument a Spec pointer?
+	for _, idx := range fact.Indices {
+		if idx >= len(call.Args) || idx >= sig.Params().Len() {
+			continue
+		}
+		if isSpecArgument(pass, call.Args[idx], instanceParams) {
+			pass.Reportf(call.Pos(), "action type must not mutate instance.Spec; only Status is persisted by the action framework")
+			return
+		}
+	}
+
+	// Check SpecIndices: callee mutates param.Spec — is the argument the instance object?
+	for _, idx := range fact.SpecIndices {
+		if idx >= len(call.Args) || idx >= sig.Params().Len() {
+			continue
+		}
+		if isInstanceArgument(pass, call.Args[idx], instanceParams) {
+			pass.Reportf(call.Pos(), "action type must not mutate instance.Spec; only Status is persisted by the action framework")
+			return
+		}
+	}
+}
+
+// isInstanceArgument returns true if expr is one of the spec-bearing
+// instance parameters (the whole object, not just &instance.Spec).
+func isInstanceArgument(pass *analysis.Pass, expr ast.Expr, instanceParams []*types.Var) bool {
+	v := resolveToVar(pass, expr)
+	if v == nil {
+		return false
+	}
+	for _, param := range instanceParams {
+		if v == param {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveCallee resolves a call expression to a *types.Func.
+func resolveCallee(pass *analysis.Pass, call *ast.CallExpr) *types.Func {
+	var id *ast.Ident
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		id = fn
+	case *ast.SelectorExpr:
+		id = fn.Sel
+	default:
+		return nil
+	}
+
+	obj := pass.TypesInfo.ObjectOf(id)
+	if obj == nil {
+		return nil
+	}
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return nil
+	}
+	return fn
+}
+
+// isSpecArgument returns true if expr is a pointer to a spec field:
+//   - &instance.Spec or &instance.Spec.SubField
+//   - instance.Spec.PointerField (already a pointer type)
+func isSpecArgument(pass *analysis.Pass, expr ast.Expr, instanceParams []*types.Var) bool {
+	// Handle &instance.Spec... expressions.
+	if unary, ok := expr.(*ast.UnaryExpr); ok {
+		return isSpecOrSpecChild(pass, unary.X, instanceParams)
+	}
+
+	// Handle instance.Spec.PointerField — the field is already a pointer.
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	t := pass.TypesInfo.TypeOf(expr)
+	if t == nil {
+		return false
+	}
+	if _, isPtr := t.(*types.Pointer); !isPtr {
+		return false
+	}
+	return isSpecOrSpecChild(pass, sel, instanceParams)
+}
+
+// isSpecOrSpecChild returns true if expr is instance.Spec or
+// instance.Spec.SubField.SubField... (any depth under Spec).
+func isSpecOrSpecChild(pass *analysis.Pass, expr ast.Expr, instanceParams []*types.Var) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	cur := sel
+	for {
+		if cur.Sel.Name == "Spec" {
+			obj := resolveToVar(pass, cur.X)
+			for _, param := range instanceParams {
+				if obj == param {
+					return true
+				}
+			}
+			return false
+		}
+		parent, ok := cur.X.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		cur = parent
+	}
+}
+
+// actionReceiverType returns the named receiver base type if fn is a Handle
+// method with signature Handle(context.Context, T) *Result. Returns nil otherwise.
+func actionReceiverType(pass *analysis.Pass, fn *ast.FuncDecl) types.Type {
+	if fn.Name.Name != "Handle" || fn.Recv == nil {
+		return nil
+	}
+
+	fnType := fn.Type
+	if fnType.Params == nil || len(fnType.Params.List) < 2 {
+		return nil
+	}
+	if fnType.Results == nil || len(fnType.Results.List) != 1 {
+		return nil
+	}
+
+	resultType := pass.TypesInfo.TypeOf(fnType.Results.List[0].Type)
+	if resultType == nil {
+		return nil
+	}
+	ptr, ok := resultType.(*types.Pointer)
+	if !ok {
+		return nil
+	}
+	named, ok := ptr.Elem().(*types.Named)
+	if !ok || named.Obj().Name() != "Result" {
+		return nil
+	}
+
+	return receiverBaseType(pass, fn)
+}
+
+// receiverBaseType returns the underlying named type of the receiver,
+// stripping the pointer if present.
+func receiverBaseType(pass *analysis.Pass, fn *ast.FuncDecl) types.Type {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return nil
+	}
+	t := pass.TypesInfo.TypeOf(fn.Recv.List[0].Type)
+	if t == nil {
+		return nil
+	}
+	if p, ok := t.(*types.Pointer); ok {
+		t = p.Elem()
+	}
+	return t
+}
+
+// specBearingParams returns all parameters whose underlying struct type has a "Spec" field.
+func specBearingParams(pass *analysis.Pass, fn *ast.FuncDecl) []*types.Var {
+	if fn.Type.Params == nil {
+		return nil
+	}
+	var result []*types.Var
+	for _, field := range fn.Type.Params.List {
+		for _, name := range field.Names {
+			obj := pass.TypesInfo.ObjectOf(name)
+			if obj == nil {
+				continue
+			}
+			v, ok := obj.(*types.Var)
+			if !ok {
+				continue
+			}
+			if hasSpecField(v.Type()) {
+				result = append(result, v)
+			}
+		}
+	}
+	return result
+}
+
+func hasSpecField(t types.Type) bool {
+	if p, ok := t.(*types.Pointer); ok {
+		t = p.Elem()
+	}
+	st, ok := t.Underlying().(*types.Struct)
+	if !ok {
+		return false
+	}
+	for i := 0; i < st.NumFields(); i++ {
+		if st.Field(i).Name() == "Spec" {
+			return true
+		}
+	}
+	return false
+}
+
+// isSpecFieldAccess checks if expr is an assignment target of the form instance.Spec.* or instance.Spec
+func isSpecFieldAccess(pass *analysis.Pass, expr ast.Expr, instanceParam *types.Var) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	cur := sel
+	for {
+		if cur.Sel.Name == "Spec" {
+			obj := resolveToVar(pass, cur.X)
+			return obj == instanceParam
+		}
+		parent, ok := cur.X.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		cur = parent
+	}
+}
+
+func resolveToVar(pass *analysis.Pass, expr ast.Expr) *types.Var {
+	ident, ok := expr.(*ast.Ident)
+	if !ok {
+		return nil
+	}
+	obj := pass.TypesInfo.ObjectOf(ident)
+	if obj == nil {
+		return nil
+	}
+	v, ok := obj.(*types.Var)
+	if !ok {
+		return nil
+	}
+	return v
+}

--- a/pkg/analyzer/specmutation_test.go
+++ b/pkg/analyzer/specmutation_test.go
@@ -1,0 +1,18 @@
+package analyzer_test
+
+import (
+	"testing"
+
+	"github.com/securesign/operator/pkg/analyzer"
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestSpecMutation(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, analyzer.SpecMutation, "specmutation")
+}
+
+func TestSpecMutationCrossPackage(t *testing.T) {
+	testdata := analysistest.TestData()
+	analysistest.Run(t, testdata, analyzer.SpecMutation, "specmutation_crosspackage")
+}

--- a/pkg/analyzer/testdata/src/persiststatuserr/persiststatuserr.go
+++ b/pkg/analyzer/testdata/src/persiststatuserr/persiststatuserr.go
@@ -1,0 +1,55 @@
+package persiststatuserr
+
+import "context"
+
+type Result struct{}
+
+type BaseAction struct{}
+
+func (*BaseAction) PersistStatus(ctx context.Context, obj any) (bool, error) {
+	return false, nil
+}
+
+func (*BaseAction) Error(ctx context.Context, err error, obj any) *Result { return nil }
+func (*BaseAction) Return() *Result                                       { return nil }
+func (*BaseAction) Requeue() *Result                                      { return nil }
+
+type myAction struct {
+	BaseAction
+}
+
+func good_both(a *myAction) *Result {
+	changed, err := a.PersistStatus(context.TODO(), nil)
+	if err != nil {
+		return a.Error(context.TODO(), err, nil)
+	}
+	_ = changed
+	return a.Return()
+}
+
+func good_err_named(a *myAction) *Result {
+	_, err := a.PersistStatus(context.TODO(), nil)
+	if err != nil {
+		return a.Error(context.TODO(), err, nil)
+	}
+	return a.Requeue()
+}
+
+func bad_err_blank(a *myAction) *Result {
+	_, _ = a.PersistStatus(context.TODO(), nil) // want "PersistStatus error return value must not be discarded"
+	return a.Requeue()
+}
+
+func bad_all_discarded(a *myAction) *Result {
+	a.PersistStatus(context.TODO(), nil) // want "PersistStatus return values must not be discarded"
+	return a.Return()
+}
+
+// Unrelated method with same name but different signature — should NOT be flagged.
+type otherService struct{}
+
+func (*otherService) PersistStatus(ctx context.Context) error { return nil }
+
+func no_false_positive(s *otherService) {
+	_ = s.PersistStatus(context.TODO())
+}

--- a/pkg/analyzer/testdata/src/specmutation/specmutation.go
+++ b/pkg/analyzer/testdata/src/specmutation/specmutation.go
@@ -1,0 +1,160 @@
+package specmutation
+
+import "context"
+
+type Result struct{}
+
+type BaseAction struct{}
+
+func (*BaseAction) PersistStatus(ctx context.Context, obj any) (bool, error) {
+	return false, nil
+}
+func (*BaseAction) Return() *Result { return nil }
+
+type MySpec struct {
+	Host    string
+	Address string
+}
+
+type MyStatus struct {
+	Ready bool
+}
+
+type MyInstance struct {
+	Spec   MySpec
+	Status MyStatus
+}
+
+type myAction struct {
+	BaseAction
+}
+
+func (a *myAction) Handle(ctx context.Context, instance *MyInstance) *Result { // want Handle:"mutatesParam"
+	instance.Spec.Host = "bad" // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+
+	instance.Status.Ready = true // OK — Status is persisted
+
+	return a.Return()
+}
+
+type deepAction struct {
+	BaseAction
+}
+
+func (a *deepAction) Handle(ctx context.Context, instance *MyInstance) *Result { // want Handle:"mutatesParam"
+	instance.Spec.Address = "also bad" // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+	return a.Return()
+}
+
+// Helper method on action type — SHOULD be flagged.
+func (a *myAction) helper(instance *MyInstance) { // want helper:"mutatesParam"
+	instance.Spec.Host = "bad in helper" // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+}
+
+// Handle with wrong return type — not an action type, should not be flagged.
+type notAnAction struct {
+	BaseAction
+}
+
+func (a *notAnAction) HandleOther(ctx context.Context, instance *MyInstance) error { // want HandleOther:"mutatesParam"
+	instance.Spec.Host = "not an action Handle"
+	return nil
+}
+
+// Method on non-action type — should not be flagged.
+type plainType struct{}
+
+func (p *plainType) DoSomething(instance *MyInstance) { // want DoSomething:"mutatesParam"
+	instance.Spec.Host = "ok on non-action type"
+}
+
+// --- Indirect spec mutation tests ---
+
+// Free function that mutates its pointer parameter.
+func mutateSpec(spec *MySpec) { // want mutateSpec:"mutatesParam"
+	spec.Host = "mutated"
+}
+
+// Free function that only reads its pointer parameter.
+func readSpec(spec *MySpec) string {
+	return spec.Host
+}
+
+// Action that calls a mutating free function with &instance.Spec — SHOULD be flagged.
+type indirectAction struct {
+	BaseAction
+}
+
+func (a *indirectAction) Handle(ctx context.Context, instance *MyInstance) *Result {
+	mutateSpec(&instance.Spec) // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+
+	readSpec(&instance.Spec) // OK — readSpec does not mutate
+
+	return a.Return()
+}
+
+// Action helper method that mutates via pointer param — calling it SHOULD be flagged.
+func (a *indirectAction) mutateHelper(spec *MySpec) { // want mutateHelper:"mutatesParam"
+	spec.Address = "mutated by helper"
+}
+
+func (a *indirectAction) HandleWithHelper(ctx context.Context, instance *MyInstance) *Result {
+	a.mutateHelper(&instance.Spec) // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+	return a.Return()
+}
+
+// Non-action type calling a mutating function — NOT flagged.
+func (p *plainType) CallMutate(instance *MyInstance) {
+	mutateSpec(&instance.Spec) // OK — plainType is not an action
+}
+
+// Action passing a spec sub-field pointer to a mutating function.
+type SubField struct {
+	Value string
+}
+
+type InstanceWithPtrSpec struct {
+	Spec   SpecWithPtr
+	Status MyStatus
+}
+
+type SpecWithPtr struct {
+	Sub *SubField
+}
+
+func mutateSubField(s *SubField) { // want mutateSubField:"mutatesParam"
+	s.Value = "mutated"
+}
+
+type subFieldAction struct {
+	BaseAction
+}
+
+func (a *subFieldAction) Handle(ctx context.Context, instance *InstanceWithPtrSpec) *Result {
+	mutateSubField(instance.Spec.Sub) // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+	return a.Return()
+}
+
+// --- Whole-object passing tests ---
+
+// Helper that receives the whole object and mutates its Spec.
+func mutateViaObject(obj *MyInstance) { // want mutateViaObject:"mutatesParam"
+	obj.Spec.Host = "mutated through object"
+}
+
+// Helper that receives the whole object but only mutates Status.
+func mutateStatusOnly(obj *MyInstance) { // want mutateStatusOnly:"mutatesParam"
+	obj.Status.Ready = true
+}
+
+type wholeObjectAction struct {
+	BaseAction
+}
+
+func (a *wholeObjectAction) Handle(ctx context.Context, instance *MyInstance) *Result {
+	mutateViaObject(instance) // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+
+	mutateStatusOnly(instance) // OK — only Status is mutated, not Spec
+
+	return a.Return()
+}

--- a/pkg/analyzer/testdata/src/specmutation_crosspackage/actions.go
+++ b/pkg/analyzer/testdata/src/specmutation_crosspackage/actions.go
@@ -1,0 +1,51 @@
+package specmutation_crosspackage
+
+import (
+	"context"
+
+	"specmutation_crosspackage/helpers"
+)
+
+type Result struct{}
+
+type BaseAction struct{}
+
+func (*BaseAction) Return() *Result { return nil }
+
+type MySpec struct {
+	Config *helpers.Config
+}
+
+type MyStatus struct {
+	Ready bool
+}
+
+type MyInstance struct {
+	Spec   MySpec
+	Status MyStatus
+}
+
+type crossPkgAction struct {
+	BaseAction
+}
+
+func (a *crossPkgAction) Handle(ctx context.Context, instance *MyInstance) *Result {
+	helpers.MutateConfig(instance.Spec.Config) // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+
+	helpers.ReadConfig(instance.Spec.Config) // OK — ReadConfig does not mutate
+
+	return a.Return()
+}
+
+// Whole-object cross-package test: action type uses helpers.Instance.
+type crossPkgObjectAction struct {
+	BaseAction
+}
+
+func (a *crossPkgObjectAction) Handle(ctx context.Context, instance *helpers.Instance) *Result {
+	helpers.MutateSpecViaObject(instance) // want "action type must not mutate instance.Spec; only Status is persisted by the action framework"
+
+	helpers.MutateStatusViaObject(instance) // OK — only Status is mutated
+
+	return a.Return()
+}

--- a/pkg/analyzer/testdata/src/specmutation_crosspackage/helpers/helpers.go
+++ b/pkg/analyzer/testdata/src/specmutation_crosspackage/helpers/helpers.go
@@ -1,0 +1,39 @@
+package helpers
+
+type Config struct {
+	Host string
+	Port int
+}
+
+type Spec struct {
+	Config *Config
+}
+
+type Status struct {
+	Ready bool
+}
+
+type Instance struct {
+	Spec   Spec
+	Status Status
+}
+
+// MutateConfig writes through its pointer parameter.
+func MutateConfig(cfg *Config) {
+	cfg.Host = "mutated"
+}
+
+// ReadConfig only reads from the pointer parameter.
+func ReadConfig(cfg *Config) string {
+	return cfg.Host
+}
+
+// MutateSpecViaObject receives a whole object and mutates Spec.
+func MutateSpecViaObject(obj *Instance) {
+	obj.Spec.Config.Host = "mutated"
+}
+
+// MutateStatusViaObject receives a whole object but only mutates Status.
+func MutateStatusViaObject(obj *Instance) {
+	obj.Status.Ready = true
+}


### PR DESCRIPTION
## Summary
- Adds custom golangci-lint v2 module plugin with two analyzers for the action framework:
  - **persiststatuserr**: flags `PersistStatus()` calls where the error return is discarded
  - **specmutation**: flags `instance.Spec` mutations inside action types (only Status is persisted)
- The specmutation analyzer detects **direct** and **indirect** Spec mutations:
  - Direct: `instance.Spec.Field = value` in action methods
  - Indirect via Spec pointer: `helper(&instance.Spec)` where helper writes through the pointer
  - Indirect via whole object: `helper(instance)` where helper writes `instance.Spec.Field`
  - Cross-package: uses `go/analysis` facts to track parameter mutations across package boundaries
- Linter is a separate Go module (`pkg/analyzer/`) to keep operator deps clean
- CI workflow updated to build and run the custom binary via `golangci-lint-action` with `install-mode: none` for inline PR annotations
- Fixes all existing spec mutation violations in ctlog, fulcio, and tsa actions
- Adds unit test coverage for TSA `alignStatusFields` (default signer, user-provided keys, partial refs, external chain) and KMS/Tink signer Handle paths

## Test plan
- [x] Analyzer unit tests pass — intra-package and cross-package (`go test ./pkg/analyzer/...`)
- [x] Controller tests pass for modified ctlog, fulcio, and tsa packages
- [x] Custom linter reports 0 new issues after fixes
- [x] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)