### PR TITLE
ci: add workflow to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/needs-rebase.yaml
+++ b/.github/workflows/needs-rebase.yaml
@@ -1,0 +1,20 @@
+name: Label PRs needing rebase
+
+on:
+  push:
+    branches: [main, release-*]
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
+        with:
+          dirtyLabel: needs-rebase
+          repoToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically labels open PRs with `needs-rebase` when they have merge conflicts against their base branch
- Removes the label when conflicts are resolved
- Uses [eps1lon/actions-label-merge-conflict](https://github.com/eps1lon/actions-label-merge-conflict) (pinned to SHA) — maintained by a React core team member, used by 470+ projects including Material UI, matplotlib, and Pi-hole
- Triggers on push to `main`/`release-*` and on PR synchronize events

## Test plan
- [ ] Merge a PR that causes conflicts in another open PR — verify `needs-rebase` label is added
- [ ] Push a rebase fix to the conflicting PR — verify `needs-rebase` label is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)