### PR TITLE
ci: improve needs-rebase workflow configuration

### DIFF
--- a/.github/workflows/needs-rebase.yaml
+++ b/.github/workflows/needs-rebase.yaml
@@ -4,17 +4,26 @@ on:
   push:
     branches: [main, release-*]
   pull_request_target:
-    types: [synchronize]
+    types: [opened, synchronize, reopened]
+    branches: [main, release-*]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
         with:
           dirtyLabel: needs-rebase
           repoToken: ${{ secrets.GITHUB_TOKEN }}
+          continueOnMissingPermissions: true
+          retryAfter: 60
+          retryMax: 5


### PR DESCRIPTION
## Summary
- Scope `pull_request_target` to `main`/`release-*` branches to avoid running on every branch push
- Add `opened` and `reopened` event types for immediate conflict detection on new/reopened PRs
- Add `concurrency` with `cancel-in-progress` to prevent parallel runs from stacking up
- Add `continueOnMissingPermissions` for fork PR safety
- Tune retry to 60s interval / max 5 retries (default 120s was too slow)
- Use least-privilege permissions pattern (top-level `permissions: {}`, scoped at job level)

## Test plan
- [ ] Push to main — verify workflow runs and checks all open PRs
- [ ] Open a new PR with conflicts — verify `needs-rebase` label is added immediately
- [ ] Rebase conflicting PR — verify label is removed on synchronize event
- [ ] Verify concurrent pushes cancel stale runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)