### PR TITLE
fix: exclude PVC from label-based cache filter

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -183,15 +183,14 @@ func main() {
 
 	cacheOpts := cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
-			&appsv1.Deployment{}:            operatorCacheSelector,
-			&appsv1.ReplicaSet{}:            operatorCacheSelector,
-			&appsv1.StatefulSet{}:           operatorCacheSelector,
-			&corev1.Pod{}:                   operatorCacheSelector,
-			&corev1.Service{}:               operatorCacheSelector,
-			&networkingv1.Ingress{}:         operatorCacheSelector,
-			&batchv1.CronJob{}:              operatorCacheSelector,
-			&batchv1.Job{}:                  operatorCacheSelector,
-			&corev1.PersistentVolumeClaim{}: operatorCacheSelector,
+			&appsv1.Deployment{}:    operatorCacheSelector,
+			&appsv1.ReplicaSet{}:    operatorCacheSelector,
+			&appsv1.StatefulSet{}:   operatorCacheSelector,
+			&corev1.Pod{}:           operatorCacheSelector,
+			&corev1.Service{}:       operatorCacheSelector,
+			&networkingv1.Ingress{}: operatorCacheSelector,
+			&batchv1.CronJob{}:      operatorCacheSelector,
+			&batchv1.Job{}:          operatorCacheSelector,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Removes `PersistentVolumeClaim` from the label-based cache filter introduced in #1755
- PVC discovery path (`internal/action/pvc/action.go:101`) uses `client.Get()` through the cached client to find existing PVCs by default name. With label filtering, unlabeled PVCs (e.g., customer pre-created or retained from previous installs) are invisible to the cache, causing `AlreadyExists` errors on reconciliation

## Test plan
- [ ] Deploy RHTAS without specifying `pvc.name` — operator creates PVCs normally
- [ ] Pre-create a PVC with default name (`trillian-mysql`) without operator labels, deploy RHTAS — operator discovers and uses it
- [ ] BYO PVC with explicit `spec.pvc.name` — works as before
- [ ] Retained PVC after CR deletion/re-creation — operator rediscovers it
- [ ] Memory usage remains within limits on busy clusters

Fixes: SECURESIGN-4123

🤖 Generated with [Claude Code](https://claude.com/claude-code)