### PR TITLE
fix: exclude PVC from label-based cache filter (#1812)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -185,15 +185,14 @@ func main() {
 
 	cacheOpts := cache.Options{
 		ByObject: map[client.Object]cache.ByObject{
-			&appsv1.Deployment{}:            operatorCacheSelector,
-			&appsv1.ReplicaSet{}:            operatorCacheSelector,
-			&appsv1.StatefulSet{}:           operatorCacheSelector,
-			&corev1.Pod{}:                   operatorCacheSelector,
-			&corev1.Service{}:               operatorCacheSelector,
-			&networkingv1.Ingress{}:         operatorCacheSelector,
-			&batchv1.CronJob{}:              operatorCacheSelector,
-			&batchv1.Job{}:                  operatorCacheSelector,
-			&corev1.PersistentVolumeClaim{}: operatorCacheSelector,
+			&appsv1.Deployment{}:    operatorCacheSelector,
+			&appsv1.ReplicaSet{}:    operatorCacheSelector,
+			&appsv1.StatefulSet{}:   operatorCacheSelector,
+			&corev1.Pod{}:           operatorCacheSelector,
+			&corev1.Service{}:       operatorCacheSelector,
+			&networkingv1.Ingress{}: operatorCacheSelector,
+			&batchv1.CronJob{}:      operatorCacheSelector,
+			&batchv1.Job{}:          operatorCacheSelector,
 		},
 	}
 


### PR DESCRIPTION
PVC discovery path uses client.Get() to find existing PVCs by default name. With label-based cache filtering, unlabeled PVCs are invisible to the cached client, causing AlreadyExists errors on reconciliation.

Forward port

https://github.com/securesign/secure-sign-operator/pull/1812