### PR TITLE
fix(ci): resolve kind cluster cleanup race condition with NFS mounts

### DIFF
--- a/.github/actions/kind-cluster-cleanup/action.yml
+++ b/.github/actions/kind-cluster-cleanup/action.yml
@@ -9,10 +9,18 @@ runs:
   using: 'composite'
   steps:
     - name: Uninstall NFS-CSI and cleanup volumes
-      if: always() && ${{ inputs.nfs-csi == true }}
+      if: always() && inputs.nfs-csi == 'true'
       shell: bash
       run: |
         kubectl delete pvc --all -A --ignore-not-found --wait=false || true
         kubectl delete pv --all --ignore-not-found --wait=false || true
         kustomize build --enable-helm ./ci/nfs/overlay/ | kubectl delete -f - --ignore-not-found || true
-        sudo systemctl restart docker || sudo service docker restart || true
+        # let NFS mounts release inside the kind node before cluster deletion
+        sleep 5
+
+    - name: Delete Kind cluster
+      if: always()
+      shell: bash
+      run: |
+        # delete before kind-action's post step to avoid Docker race with lingering NFS mounts
+        kind delete cluster --name kind || true

--- a/.github/actions/kind-cluster/action.yml
+++ b/.github/actions/kind-cluster/action.yml
@@ -38,6 +38,7 @@ runs:
         kubectl_version: v1.35.0
         cluster_name: kind
         config: ${{ inputs.config }}
+        ignore_failed_clean: true
 
     - name: Configure ingress
       shell: bash


### PR DESCRIPTION
## Summary
- Fix NFS cleanup step that never ran due to boolean/string comparison bug (`inputs.nfs-csi == true` → `== 'true'`)
- Replace Docker restart with `sleep 5` to let NFS kernel mounts release before cluster deletion
- Add explicit `kind delete cluster` step before kind-action's post step to avoid Docker race condition
- Set `ignore_failed_clean: true` on kind-action as a safety net

## Root Cause
Two interacting bugs caused spurious HA/custom-install workflow failures:

1. **Boolean comparison bug**: In composite actions, all inputs are strings. `inputs.nfs-csi == true` (string vs boolean) was always false, so NFS PVC/PV cleanup never ran.
2. **Docker race condition**: Without NFS cleanup, lingering NFS kernel mounts inside the kind node container prevented Docker from killing it during `kind delete cluster`, causing `could not kill: tried to kill container, but did not receive an exit event`.

## Test plan
- [ ] HA test job completes without cleanup failure
- [ ] Custom-install test job completes without cleanup failure
- [ ] Non-NFS jobs (kind deployment, upgrade, e2e) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)