### PR TITLE
chore: add comments to images.env to reduce merge conflicts

### DIFF
--- a/config/default/images.env
+++ b/config/default/images.env
@@ -1,17 +1,50 @@
+# Trillian - Log Signer
 RELATED_IMAGE_TRILLIAN_LOG_SIGNER=registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:9a030d26d3328738b1df20eeca44b28ebf0a16e1d7fa4aa34a1fb380fb19cea3
+
+# Trillian - Database
 RELATED_IMAGE_TRILLIAN_DB=registry.redhat.io/rhtas/trillian-database-rhel9@sha256:12f385fd99a7bfd1db23749aa1bac14db709a3845ac2c5779addae40fd69cac1
+
+# Trillian - Log Server
 RELATED_IMAGE_TRILLIAN_LOG_SERVER=registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:6426ae757e473c7a3a7a43e4c22ddbed86a0912c2517f7e7d6276f006e0413be
+
+# Trillian - Netcat (ose-tools)
 RELATED_IMAGE_TRILLIAN_NETCAT=registry.redhat.io/openshift4/ose-tools-rhel9@sha256:b36f5d41474c89f950cd3630343e15bd16efdb52e27fbed963cf19467c428266
+
+# Trillian - CreateTree
 RELATED_IMAGE_CREATETREE=registry.redhat.io/rhtas/createtree-rhel9@sha256:e3b69b74644c119c649b8b63af07a77e6e60aaf873ffab6406662b245ce43e89
+
+# Fulcio - Server
 RELATED_IMAGE_FULCIO_SERVER=registry.redhat.io/rhtas/fulcio-rhel9@sha256:a063b375fbd8cc662712fdcd40b8185c33a73de54bb43b5a2118a0a41ada93ee
+
+# Rekor - Server
 RELATED_IMAGE_REKOR_SERVER=registry.redhat.io/rhtas/rekor-server-rhel9@sha256:872350f23d5963cec320f5b3dcdd2c0bce38538a6b1f18b789127769f227196f
+
+# Rekor - Redis
 RELATED_IMAGE_REKOR_REDIS=registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:487eb4f630346e8e35664eadfd0fa3c930e3235c3c2f592c69e8f959ba528eb7
+
+# Rekor - Search UI
 RELATED_IMAGE_REKOR_SEARCH_UI=registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:0cc8588e1844e2a58cfe5d7c16e5bf00a401bbcfddd15bbdb448ed0a1df14246
+
+# Rekor - Backfill Redis
 RELATED_IMAGE_BACKFILL_REDIS=registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:040b292652a08a99cd89115c6782fc171c25cc88963f7ee9532ab1b2164c9320
+
+# TUF - Server
 RELATED_IMAGE_TUF=registry.redhat.io/rhtas/tuffer-rhel9@sha256:c405870cbbb381627c7ea0794b9afc51ad3d04274e8707ba6646b1c2d48f97aa
+
+# CTlog - Server
 RELATED_IMAGE_CTLOG=registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:414334f1507b75a4c6e0c4fe4fea17acccab41d3f076163dd65c43c55d60dc7c
+
+# HTTP Server (httpd)
 RELATED_IMAGE_HTTP_SERVER=registry.redhat.io/ubi9/httpd-24@sha256:e44ddd84a5d86c800f758ae0f09ebe321ec997d0e546c80db6ea8263c6a054d8
+
+# Timestamp Authority - Server
 RELATED_IMAGE_TIMESTAMP_AUTHORITY=registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:b8be0554d55198f65f76bf3a2985697e7f166940c2aec9ef7544e6d81575804c
+
+# Client Server - CLI tools
 RELATED_IMAGE_CLIENT_SERVER=registry.redhat.io/rhtas/client-server-rhel9@sha256:932b1025dd816bbe3534f51093a21f2fe8a1eeddccf3f4af00803eeb2d7b62df
+
+# Rekor - Monitor
 RELATED_IMAGE_REKOR_MONITOR=registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:17bef26899087b5e7fdca0f5a929b2ebaf1134372c188c9b7e123ad30c01c1aa
+
+# CTlog - Monitor
 RELATED_IMAGE_CTLOG_MONITOR=registry.redhat.io/rhtas/ctlog-monitor-rhel9@sha256:ed0589f6fb0eb1d83ad7144e4c61752de7e010d9066c1039c1c76a029521616a


### PR DESCRIPTION
Each component image entry now has a unique comment header and blank line separator, giving Git enough context to merge concurrent nudge PRs without conflicts in the batch-nudge-merge workflow.