### PR TITLE
fix(workflow): exclude batch PRs from future combine operations

### DIFF
--- a/.github/workflows/batch-nudge-merge.yaml
+++ b/.github/workflows/batch-nudge-merge.yaml
@@ -42,8 +42,8 @@ jobs:
         run: |
           REGEX=$(gh pr list --repo "${{ github.repository }}" \
             --label konflux-nudge --state open --base "${{ matrix.base_branch }}" \
-            --json headRefName \
-            --jq '[.[].headRefName | gsub("(?<x>[.\\\\^$|?*+()\\[\\]{}])"; "\\\(.x)")] | join("|")')
+            --json headRefName,labels \
+            --jq '[.[] | select(.labels | map(.name) | index("skip-batch-combine") | not) | .headRefName | gsub("(?<x>[.\\\\^$|?*+()\\[\\]{}])"; "\\\(.x)")] | join("|")')
           if [ -z "$REGEX" ]; then
             echo "No open nudge PRs found for ${{ matrix.base_branch }}, skipping"
             echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -62,7 +62,7 @@ jobs:
           pr_body_header: '## Batch Container Image Digest Update for `${{ matrix.base_branch }}`'
           ci_required: 'false'
           review_required: 'false'
-          labels: konflux-nudge
+          labels: konflux-nudge,skip-batch-combine
           autoclose: 'true'
           min_combine_number: '2'
           create_from_scratch: 'true'


### PR DESCRIPTION
## Summary
- Adds `skip-batch-combine` label to batch PRs when created by the workflow
- Filters out PRs with this label in the combine step to prevent re-combining batch PRs
- Solves the issue where regenerated batch PRs would try to include old batch PRs, causing merge conflicts

## Why
When batch nudge PRs aren't merged before the next workflow run, the workflow tries to combine them again with newer nudge PRs. This causes the workflow to fail with "left out due to merge conflicts" warnings. By marking batch PRs with an exclusion label, we prevent them from being included in future combines.

## Test plan
- [x] Verify workflow runs without trying to combine old batch PRs
- [x] Verify generated batch PRs have the `skip-batch-combine` label
- [x] Verify workflow excludes labeled PRs from subsequent combines

🤖 Generated with [Claude Code](https://claude.com/claude-code)