### PR TITLE
fix: add startup probes and standardize probe timing across all components

### DIFF
--- a/internal/controller/ctlog/actions/deployment.go
+++ b/internal/controller/ctlog/actions/deployment.go
@@ -165,8 +165,10 @@ func (i deployAction) ensureDeployment(instance *rhtasv1alpha1.CTlog, sa string,
 		}
 		container.LivenessProbe.HTTPGet.Path = "/healthz"
 		container.LivenessProbe.HTTPGet.Port = intstr.FromInt32(ServerTargetPort)
-		container.LivenessProbe.InitialDelaySeconds = 10
+		container.LivenessProbe.InitialDelaySeconds = 0
 		container.LivenessProbe.PeriodSeconds = 10
+		container.LivenessProbe.TimeoutSeconds = 1
+		container.LivenessProbe.FailureThreshold = 3
 
 		if container.ReadinessProbe == nil {
 			container.ReadinessProbe = &core.Probe{}
@@ -174,12 +176,24 @@ func (i deployAction) ensureDeployment(instance *rhtasv1alpha1.CTlog, sa string,
 		if container.ReadinessProbe.HTTPGet == nil {
 			container.ReadinessProbe.HTTPGet = &core.HTTPGetAction{}
 		}
-
 		container.ReadinessProbe.HTTPGet.Path = "/healthz"
 		container.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(ServerTargetPort)
-
-		container.ReadinessProbe.InitialDelaySeconds = 10
+		container.ReadinessProbe.InitialDelaySeconds = 0
 		container.ReadinessProbe.PeriodSeconds = 10
+		container.ReadinessProbe.TimeoutSeconds = 1
+		container.ReadinessProbe.FailureThreshold = 3
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &core.Probe{}
+		}
+		if container.StartupProbe.HTTPGet == nil {
+			container.StartupProbe.HTTPGet = &core.HTTPGetAction{}
+		}
+		container.StartupProbe.HTTPGet.Path = "/healthz"
+		container.StartupProbe.HTTPGet.Port = intstr.FromInt32(ServerTargetPort)
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 12
 
 		return nil
 	}
@@ -216,6 +230,10 @@ func (i deployAction) ensureTLS(tlsConfig rhtasv1alpha1.TLS, name string) func(d
 
 		if container.LivenessProbe != nil {
 			container.LivenessProbe.HTTPGet.Scheme = core.URISchemeHTTPS
+		}
+
+		if container.StartupProbe != nil {
+			container.StartupProbe.HTTPGet.Scheme = core.URISchemeHTTPS
 		}
 
 		return nil

--- a/internal/controller/fulcio/actions/deployment.go
+++ b/internal/controller/fulcio/actions/deployment.go
@@ -264,6 +264,10 @@ func (i deployAction) ensureDeployment(instance *rhtasv1alpha1.Fulcio, sa string
 		}
 		container.LivenessProbe.HTTPGet.Path = "/healthz"
 		container.LivenessProbe.HTTPGet.Port = intstr.FromInt32(5555)
+		container.LivenessProbe.InitialDelaySeconds = 0
+		container.LivenessProbe.PeriodSeconds = 10
+		container.LivenessProbe.TimeoutSeconds = 1
+		container.LivenessProbe.FailureThreshold = 3
 
 		if container.ReadinessProbe == nil {
 			container.ReadinessProbe = &core.Probe{}
@@ -271,9 +275,24 @@ func (i deployAction) ensureDeployment(instance *rhtasv1alpha1.Fulcio, sa string
 		if container.ReadinessProbe.HTTPGet == nil {
 			container.ReadinessProbe.HTTPGet = &core.HTTPGetAction{}
 		}
-
 		container.ReadinessProbe.HTTPGet.Path = "/healthz"
 		container.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(5555)
+		container.ReadinessProbe.InitialDelaySeconds = 0
+		container.ReadinessProbe.PeriodSeconds = 10
+		container.ReadinessProbe.TimeoutSeconds = 1
+		container.ReadinessProbe.FailureThreshold = 3
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &core.Probe{}
+		}
+		if container.StartupProbe.HTTPGet == nil {
+			container.StartupProbe.HTTPGet = &core.HTTPGetAction{}
+		}
+		container.StartupProbe.HTTPGet.Path = "/healthz"
+		container.StartupProbe.HTTPGet.Port = intstr.FromInt32(5555)
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 12
 
 		return nil
 	}

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/deployment.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/deployment.go
@@ -135,7 +135,10 @@ func (i deployAction) ensureRedisDeployment(instance *rhtasv1alpha1.Rekor, sa st
 			"-i",
 			"test $(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping) = 'PONG'",
 		}
-		container.ReadinessProbe.InitialDelaySeconds = 5
+		container.ReadinessProbe.InitialDelaySeconds = 0
+		container.ReadinessProbe.PeriodSeconds = 10
+		container.ReadinessProbe.TimeoutSeconds = 1
+		container.ReadinessProbe.FailureThreshold = 3
 
 		if container.LivenessProbe == nil {
 			container.LivenessProbe = &core.Probe{}
@@ -149,7 +152,26 @@ func (i deployAction) ensureRedisDeployment(instance *rhtasv1alpha1.Rekor, sa st
 			"-i",
 			"test $(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping) = 'PONG'",
 		}
-		container.LivenessProbe.InitialDelaySeconds = 10
+		container.LivenessProbe.InitialDelaySeconds = 0
+		container.LivenessProbe.PeriodSeconds = 10
+		container.LivenessProbe.TimeoutSeconds = 1
+		container.LivenessProbe.FailureThreshold = 3
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &core.Probe{}
+		}
+		if container.StartupProbe.Exec == nil {
+			container.StartupProbe.Exec = &core.ExecAction{}
+		}
+		container.StartupProbe.Exec.Command = []string{
+			"/bin/sh",
+			"-c",
+			"-i",
+			"test $(redis-cli -h 127.0.0.1 -a $REDIS_PASSWORD ping) = 'PONG'",
+		}
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 12
 
 		volumeMount := kubernetes.FindVolumeMountByNameOrCreate(container, storageVolumeName)
 		volumeMount.MountPath = "/data"
@@ -244,6 +266,19 @@ func (i deployAction) ensureTLS(tlsConfig rhtasv1alpha1.TLS, caPath string) func
 		}
 
 		container.LivenessProbe.Exec.Command = []string{
+			"/bin/sh",
+			"-c",
+			"-i",
+			fmt.Sprintf("test $(redis-cli --tls --cacert %s -h 127.0.0.1 -a $REDIS_PASSWORD ping) = 'PONG'", caPath),
+		}
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &core.Probe{}
+		}
+		if container.StartupProbe.Exec == nil {
+			container.StartupProbe.Exec = &core.ExecAction{}
+		}
+		container.StartupProbe.Exec.Command = []string{
 			"/bin/sh",
 			"-c",
 			"-i",

--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -230,7 +230,10 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 		}
 		container.LivenessProbe.HTTPGet.Path = "/ping"
 		container.LivenessProbe.HTTPGet.Port = intstr.FromInt32(3000)
-		container.LivenessProbe.InitialDelaySeconds = 30
+		container.LivenessProbe.InitialDelaySeconds = 0
+		container.LivenessProbe.PeriodSeconds = 10
+		container.LivenessProbe.TimeoutSeconds = 1
+		container.LivenessProbe.FailureThreshold = 3
 
 		if container.ReadinessProbe == nil {
 			container.ReadinessProbe = &v1.Probe{}
@@ -238,15 +241,24 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1alpha1.Rekor, sa s
 		if container.ReadinessProbe.HTTPGet == nil {
 			container.ReadinessProbe.HTTPGet = &v1.HTTPGetAction{}
 		}
-		// Use /api/v1/log endpoint for readiness probe instead of /ping
-		// This endpoint verifies Trillian connectivity and tree accessibility,
-		// ensuring Rekor can actually process signing requests
 		container.ReadinessProbe.HTTPGet.Path = "/api/v1/log"
 		container.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(3000)
-		container.ReadinessProbe.InitialDelaySeconds = 10
+		container.ReadinessProbe.InitialDelaySeconds = 0
 		container.ReadinessProbe.PeriodSeconds = 10
 		container.ReadinessProbe.TimeoutSeconds = 5
 		container.ReadinessProbe.FailureThreshold = 3
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &v1.Probe{}
+		}
+		if container.StartupProbe.HTTPGet == nil {
+			container.StartupProbe.HTTPGet = &v1.HTTPGetAction{}
+		}
+		container.StartupProbe.HTTPGet.Path = "/api/v1/log"
+		container.StartupProbe.HTTPGet.Port = intstr.FromInt32(3000)
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 12
 
 		return nil
 	}

--- a/internal/controller/rekor/actions/ui/deployment.go
+++ b/internal/controller/rekor/actions/ui/deployment.go
@@ -111,8 +111,10 @@ func (i deployAction) ensureUIDeployment(instance *rhtasv1alpha1.Rekor, sa strin
 		}
 		container.ReadinessProbe.HTTPGet.Path = "/"
 		container.ReadinessProbe.HTTPGet.Port = intstr.FromInt(3000)
-		container.ReadinessProbe.InitialDelaySeconds = 10
+		container.ReadinessProbe.InitialDelaySeconds = 0
+		container.ReadinessProbe.PeriodSeconds = 10
 		container.ReadinessProbe.TimeoutSeconds = 5
+		container.ReadinessProbe.FailureThreshold = 3
 
 		if container.LivenessProbe == nil {
 			container.LivenessProbe = &core.Probe{}
@@ -122,8 +124,22 @@ func (i deployAction) ensureUIDeployment(instance *rhtasv1alpha1.Rekor, sa strin
 		}
 		container.LivenessProbe.HTTPGet.Path = "/"
 		container.LivenessProbe.HTTPGet.Port = intstr.FromInt(3000)
-		container.LivenessProbe.InitialDelaySeconds = 30
+		container.LivenessProbe.InitialDelaySeconds = 0
+		container.LivenessProbe.PeriodSeconds = 10
 		container.LivenessProbe.TimeoutSeconds = 5
+		container.LivenessProbe.FailureThreshold = 3
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &core.Probe{}
+		}
+		if container.StartupProbe.HTTPGet == nil {
+			container.StartupProbe.HTTPGet = &core.HTTPGetAction{}
+		}
+		container.StartupProbe.HTTPGet.Path = "/"
+		container.StartupProbe.HTTPGet.Port = intstr.FromInt(3000)
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 12
 
 		return nil
 	}

--- a/internal/controller/trillian/actions/db/deployment.go
+++ b/internal/controller/trillian/actions/db/deployment.go
@@ -165,7 +165,10 @@ func (i deployAction) ensureDbDeployment(instance *rhtasv1alpha1.Trillian, sa st
 		}
 
 		container.ReadinessProbe.Exec.Command = []string{"bash", "-c", readinessCommand}
-		container.ReadinessProbe.InitialDelaySeconds = 10
+		container.ReadinessProbe.InitialDelaySeconds = 0
+		container.ReadinessProbe.PeriodSeconds = 10
+		container.ReadinessProbe.TimeoutSeconds = 1
+		container.ReadinessProbe.FailureThreshold = 3
 
 		if container.LivenessProbe == nil {
 			container.LivenessProbe = &v1.Probe{}
@@ -173,9 +176,23 @@ func (i deployAction) ensureDbDeployment(instance *rhtasv1alpha1.Trillian, sa st
 		if container.LivenessProbe.Exec == nil {
 			container.LivenessProbe.Exec = &v1.ExecAction{}
 		}
-
 		container.LivenessProbe.Exec.Command = []string{"bash", "-c", livenessCommand}
-		container.LivenessProbe.InitialDelaySeconds = 30
+		container.LivenessProbe.InitialDelaySeconds = 0
+		container.LivenessProbe.PeriodSeconds = 10
+		container.LivenessProbe.TimeoutSeconds = 1
+		container.LivenessProbe.FailureThreshold = 3
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &v1.Probe{}
+		}
+		if container.StartupProbe.Exec == nil {
+			container.StartupProbe.Exec = &v1.ExecAction{}
+		}
+		container.StartupProbe.Exec.Command = []string{"bash", "-c", readinessCommand}
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 24
+
 		return nil
 	}
 }
@@ -205,6 +222,14 @@ func (i deployAction) ensureTLS(tlsConfig rhtasv1alpha1.TLS) func(deployment *v2
 		}
 
 		container.LivenessProbe.Exec.Command = []string{"bash", "-c", livenessCommand + " --ssl"}
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &v1.Probe{}
+		}
+		if container.StartupProbe.Exec == nil {
+			container.StartupProbe.Exec = &v1.ExecAction{}
+		}
+		container.StartupProbe.Exec.Command = []string{"bash", "-c", readinessCommand + " --ssl"}
 
 		if i := slices.Index(container.Args, "--ssl-cert"); i == -1 {
 			container.Args = append(container.Args, "--ssl-cert", tls.TLSCertPath)

--- a/internal/controller/trillian/utils/server-deployment.go
+++ b/internal/controller/trillian/utils/server-deployment.go
@@ -60,6 +60,10 @@ func ensureProbes(containerName string) func(*apps.Deployment) error {
 		}
 		container.LivenessProbe.HTTPGet.Path = "/healthz"
 		container.LivenessProbe.HTTPGet.Port = intstr.FromInt32(actions.MetricsPort)
+		container.LivenessProbe.InitialDelaySeconds = 0
+		container.LivenessProbe.PeriodSeconds = 10
+		container.LivenessProbe.TimeoutSeconds = 1
+		container.LivenessProbe.FailureThreshold = 3
 
 		if container.ReadinessProbe == nil {
 			container.ReadinessProbe = &core.Probe{}
@@ -69,7 +73,23 @@ func ensureProbes(containerName string) func(*apps.Deployment) error {
 		}
 		container.ReadinessProbe.HTTPGet.Path = "/healthz"
 		container.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(actions.MetricsPort)
-		container.ReadinessProbe.InitialDelaySeconds = 10
+		container.ReadinessProbe.InitialDelaySeconds = 0
+		container.ReadinessProbe.PeriodSeconds = 10
+		container.ReadinessProbe.TimeoutSeconds = 1
+		container.ReadinessProbe.FailureThreshold = 3
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &core.Probe{}
+		}
+		if container.StartupProbe.HTTPGet == nil {
+			container.StartupProbe.HTTPGet = &core.HTTPGetAction{}
+		}
+		container.StartupProbe.HTTPGet.Path = "/healthz"
+		container.StartupProbe.HTTPGet.Port = intstr.FromInt32(actions.MetricsPort)
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 12
+
 		return nil
 	}
 }
@@ -149,6 +169,10 @@ func EnsureTLS(tlsConfig v1alpha1.TLS, name string) func(*apps.Deployment) error
 
 		if container.LivenessProbe != nil {
 			container.LivenessProbe.HTTPGet.Scheme = core.URISchemeHTTPS
+		}
+
+		if container.StartupProbe != nil {
+			container.StartupProbe.HTTPGet.Scheme = core.URISchemeHTTPS
 		}
 
 		container.Args = append(container.Args, "--tls_key_file", tls.TLSKeyPath)

--- a/internal/controller/tuf/actions/deployment.go
+++ b/internal/controller/tuf/actions/deployment.go
@@ -108,21 +108,19 @@ func (i deployAction) createTufDeployment(instance *rhtasv1alpha1.Tuf, sa string
 		// let user upload manual update using `oc rsync` command
 		volumeMount.ReadOnly = false
 
-		// Liveness probe - verifies HTTP server process is alive
 		if container.LivenessProbe == nil {
 			container.LivenessProbe = &core.Probe{}
 		}
 		if container.LivenessProbe.TCPSocket == nil {
 			container.LivenessProbe.TCPSocket = &core.TCPSocketAction{}
 		}
-		container.LivenessProbe.Exec = nil // Clear any existing exec probe
+		container.LivenessProbe.Exec = nil
 		container.LivenessProbe.TCPSocket.Port = intstr.FromInt32(8080)
-		container.LivenessProbe.InitialDelaySeconds = 15
+		container.LivenessProbe.InitialDelaySeconds = 0
 		container.LivenessProbe.PeriodSeconds = 10
 		container.LivenessProbe.TimeoutSeconds = 1
 		container.LivenessProbe.FailureThreshold = 3
 
-		// Readiness probe - verifies TUF repository is serving content
 		if container.ReadinessProbe == nil {
 			container.ReadinessProbe = &core.Probe{}
 		}
@@ -131,11 +129,22 @@ func (i deployAction) createTufDeployment(instance *rhtasv1alpha1.Tuf, sa string
 		}
 		container.ReadinessProbe.HTTPGet.Path = "/root.json"
 		container.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(8080)
-		container.ReadinessProbe.HTTPGet.Scheme = "HTTP"
-		container.ReadinessProbe.InitialDelaySeconds = 5
+		container.ReadinessProbe.InitialDelaySeconds = 0
 		container.ReadinessProbe.PeriodSeconds = 10
 		container.ReadinessProbe.TimeoutSeconds = 1
 		container.ReadinessProbe.FailureThreshold = 3
+
+		if container.StartupProbe == nil {
+			container.StartupProbe = &core.Probe{}
+		}
+		if container.StartupProbe.HTTPGet == nil {
+			container.StartupProbe.HTTPGet = &core.HTTPGetAction{}
+		}
+		container.StartupProbe.HTTPGet.Path = "/root.json"
+		container.StartupProbe.HTTPGet.Port = intstr.FromInt32(8080)
+		container.StartupProbe.PeriodSeconds = 5
+		container.StartupProbe.TimeoutSeconds = 5
+		container.StartupProbe.FailureThreshold = 12
 
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Add **StartupProbe** to all service components to properly gate liveness/readiness probes during initialization
- Replace `InitialDelaySeconds` workarounds with startup probes (the Kubernetes-recommended pattern)
- Explicitly set `InitialDelaySeconds=0` on liveness/readiness probes to ensure upgrades from previous operator versions clear stale values
- Add explicit `PeriodSeconds`, `TimeoutSeconds`, `FailureThreshold` to all probes for predictable behavior
- Propagate HTTPS scheme / TLS flags to startup probes for TLS-enabled components

## Why

Most components used `InitialDelaySeconds` (10-30s) as a workaround for slow startup. This is a Kubernetes anti-pattern — the delay is either too short (risking premature restarts) or too long (wasting time). Startup probes are the proper mechanism: they allow up to 60s (120s for DB) for initialization while keeping ongoing probes tight.

## Components updated

| Component | Startup endpoint | Budget | TLS handled |
|-----------|-----------------|--------|-------------|
| Rekor Server | `/api/v1/log` (verifies Trillian connectivity) | 60s | N/A |
| Fulcio | `/healthz` (gates OIDC initialization) | 60s | N/A |
| CTlog | `/healthz` (gates Trillian connection) | 60s | HTTPS scheme |
| Trillian LogServer/LogSigner | `/healthz` on metrics port | 60s | HTTPS scheme |
| Trillian DB | `SELECT 1` exec (verifies DB queryable) | 120s | `--ssl` flag |
| Rekor Redis | `redis-cli ping` exec | 60s | `--tls --cacert` flags |
| Rekor UI | `/` (Next.js app root) | 60s | N/A |
| TUF | `/root.json` (verifies metadata served) | 60s | N/A |

**Not changed:** TSA (covered by #1519), CTlog/Rekor monitors (batch processes without HTTP endpoints).

## Standard probe timing

| Probe | PeriodSeconds | TimeoutSeconds | FailureThreshold | InitialDelaySeconds |
|-------|--------------|----------------|-----------------|---------------------|
| Startup | 5 | 5 | 12 (60s) | 0 |
| Liveness | 10 | 1 | 3 | 0 |
| Readiness | 10 | 1 | 3 | 0 |

Exceptions: Trillian DB startup uses FailureThreshold=24 (120s). Rekor Server readiness keeps TimeoutSeconds=5 (Trillian query latency).

## Upgrade safety

All `InitialDelaySeconds` values are explicitly set to 0 (not omitted) to ensure the operator's `CreateOrUpdate` clears stale values from deployments created by previous operator versions.

## Test plan

- [x] `go build ./...` compiles
- [x] `make test` unit tests pass
- [ ] CI e2e tests pass with new probe configuration