### PR TITLE
fix: add capabilities.drop=[ALL] for Pod Security restricted:latest compliance

### DIFF
--- a/internal/action/tree/action.go
+++ b/internal/action/tree/action.go
@@ -256,6 +256,9 @@ func (i resolveTree[T]) handleJob(ctx context.Context, instance T) *action.Resul
 			return nil
 		},
 		func(object *batchv1.Job) error {
+			return ensure.PodSecurityContext(&object.Spec.Template.Spec)
+		},
+		func(object *batchv1.Job) error {
 			return ensureTls.TrustedCA(instance.GetTrustedCA(), createTreeContainerName)(&object.Spec.Template)
 		},
 	); err != nil {

--- a/internal/controller/ctlog/actions/deployment.go
+++ b/internal/controller/ctlog/actions/deployment.go
@@ -76,6 +76,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 		deployment.Proxy(),
 		deployment.TrustedCA(instance.GetTrustedCA(), containerName),
 		deployment.PodRequirements(instance.Spec.PodRequirements, containerName),
+		deployment.PodSecurityContext(),
 		ensure.Optional(
 			utils.TlsEnabled(instance),
 			i.ensureTLS(instance.Status.TLS, containerName),

--- a/internal/controller/fulcio/actions/deployment.go
+++ b/internal/controller/fulcio/actions/deployment.go
@@ -71,6 +71,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulcio
 		deployment.Proxy("@fulcio-legacy-grpc-socket"),
 		deployment.TrustedCA(instance.GetTrustedCA(), containerName),
 		deployment.PodRequirements(instance.Spec.PodRequirements, containerName),
+		deployment.PodSecurityContext(),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create Fulcio: %w", err), instance)
 	}

--- a/internal/controller/rekor/actions/backfillRedis/backfill_redis_cronjob.go
+++ b/internal/controller/rekor/actions/backfillRedis/backfill_redis_cronjob.go
@@ -71,6 +71,9 @@ func (i backfillRedisCronJob) Handle(ctx context.Context, instance *rhtasv1alpha
 		},
 		i.ensureBacfillCronJob(instance),
 		func(object *batchv1.CronJob) error {
+			return ensure.PodSecurityContext(&object.Spec.JobTemplate.Spec.Template.Spec)
+		},
+		func(object *batchv1.CronJob) error {
 			ref := &object.Spec.JobTemplate.Spec.Template.Spec
 			return ensure.Auth(actions.BackfillRedisCronJobName, instance.Spec.Auth)(ref)
 		},

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/deployment.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/deployment.go
@@ -73,6 +73,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 		ensure.ControllerReference[*v1.Deployment](instance, i.Client),
 		ensure.Labels[*v1.Deployment](slices.Collect(maps.Keys(labels)), labels),
 		deployment.Proxy(),
+		deployment.PodSecurityContext(),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create %s deployment: %w", actions.RedisDeploymentName, err), instance,
 			metav1.Condition{

--- a/internal/controller/rekor/actions/ui/deployment.go
+++ b/internal/controller/rekor/actions/ui/deployment.go
@@ -57,6 +57,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Rekor)
 		},
 		i.ensureUIDeployment(instance, actions.RBACUIName, labels),
 		deployment.PodRequirements(instance.Spec.RekorSearchUI.PodRequirements, actions.SearchUiDeploymentName),
+		deployment.PodSecurityContext(),
 		ensure.ControllerReference[*v2.Deployment](instance, i.Client),
 		ensure.Labels[*v2.Deployment](slices.Collect(maps.Keys(labels)), labels),
 	); err != nil {

--- a/internal/controller/trillian/utils/server-deployment.go
+++ b/internal/controller/trillian/utils/server-deployment.go
@@ -19,7 +19,7 @@ import (
 )
 
 func EnsureServerDeployment(instance *v1alpha1.Trillian, labels map[string]string, caPath string) []func(*apps.Deployment) error {
-	return append([]func(deployment *apps.Deployment) error{
+	return append(append([]func(deployment *apps.Deployment) error{
 		ensureDeployment(instance,
 			images.Registry.Get(images.TrillianServer),
 			actions.LogserverDeploymentName,
@@ -29,11 +29,12 @@ func EnsureServerDeployment(instance *v1alpha1.Trillian, labels map[string]strin
 		deployment.PodRequirements(instance.Spec.LogServer.PodRequirements, actions.LogserverDeploymentName),
 		deployment.Proxy(),
 		deployment.TrustedCA(instance.GetTrustedCA(), actions.LogserverDeploymentName)},
-		EnsureDB(instance, actions.LogserverDeploymentName, caPath)...)
+		EnsureDB(instance, actions.LogserverDeploymentName, caPath)...),
+		deployment.PodSecurityContext())
 }
 
 func EnsureSignerDeployment(instance *v1alpha1.Trillian, labels map[string]string, caPath string) []func(*apps.Deployment) error {
-	return append([]func(deployment *apps.Deployment) error{
+	return append(append([]func(deployment *apps.Deployment) error{
 		ensureDeployment(instance,
 			images.Registry.Get(images.TrillianLogSigner),
 			actions.LogsignerDeploymentName,
@@ -45,7 +46,8 @@ func EnsureSignerDeployment(instance *v1alpha1.Trillian, labels map[string]strin
 		deployment.Proxy(),
 		deployment.TrustedCA(instance.GetTrustedCA(), actions.LogsignerDeploymentName),
 	},
-		EnsureDB(instance, actions.LogsignerDeploymentName, caPath)...)
+		EnsureDB(instance, actions.LogsignerDeploymentName, caPath)...),
+		deployment.PodSecurityContext())
 }
 
 func ensureProbes(containerName string) func(*apps.Deployment) error {

--- a/internal/controller/tsa/actions/deployment.go
+++ b/internal/controller/tsa/actions/deployment.go
@@ -75,6 +75,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Timest
 		deployment.Proxy(),
 		deployment.TrustedCA(instance.GetTrustedCA(), DeploymentName),
 		deployment.PodRequirements(instance.Spec.PodRequirements, DeploymentName),
+		deployment.PodSecurityContext(),
 	); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create TSA Server: %w", err), instance)
 	}

--- a/internal/utils/kubernetes/ensure/pod_spec.go
+++ b/internal/utils/kubernetes/ensure/pod_spec.go
@@ -28,40 +28,34 @@ func PodSecurityContext(spec *core.PodSpec) error {
 	}
 
 	for i := range spec.InitContainers {
-		container := &spec.InitContainers[i]
-
-		if container.SecurityContext == nil {
-			container.SecurityContext = &core.SecurityContext{}
-		}
-
-		if container.SecurityContext.RunAsNonRoot == nil {
-			container.SecurityContext.RunAsNonRoot = ptr.To(true)
-		}
-		if container.SecurityContext.AllowPrivilegeEscalation == nil {
-			container.SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
-		}
-		if !kubernetes.IsOpenShift() && container.SecurityContext.RunAsUser == nil {
-			container.SecurityContext.RunAsUser = ptr.To(runAsUser)
-		}
+		ensureContainerSecurityContext(&spec.InitContainers[i])
 	}
 
 	for i := range spec.Containers {
-		container := &spec.Containers[i]
-
-		if container.SecurityContext == nil {
-			container.SecurityContext = &core.SecurityContext{}
-		}
-
-		if container.SecurityContext.RunAsNonRoot == nil {
-			container.SecurityContext.RunAsNonRoot = ptr.To(true)
-		}
-		if container.SecurityContext.AllowPrivilegeEscalation == nil {
-			container.SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
-		}
-		if !kubernetes.IsOpenShift() && container.SecurityContext.RunAsUser == nil {
-			container.SecurityContext.RunAsUser = ptr.To(runAsUser)
-		}
+		ensureContainerSecurityContext(&spec.Containers[i])
 	}
 
 	return nil
+}
+
+func ensureContainerSecurityContext(container *core.Container) {
+	if container.SecurityContext == nil {
+		container.SecurityContext = &core.SecurityContext{}
+	}
+
+	if container.SecurityContext.RunAsNonRoot == nil {
+		container.SecurityContext.RunAsNonRoot = ptr.To(true)
+	}
+	if container.SecurityContext.AllowPrivilegeEscalation == nil {
+		container.SecurityContext.AllowPrivilegeEscalation = ptr.To(false)
+	}
+	if container.SecurityContext.Capabilities == nil {
+		container.SecurityContext.Capabilities = &core.Capabilities{}
+	}
+	if container.SecurityContext.Capabilities.Drop == nil {
+		container.SecurityContext.Capabilities.Drop = []core.Capability{"ALL"}
+	}
+	if !kubernetes.IsOpenShift() && container.SecurityContext.RunAsUser == nil {
+		container.SecurityContext.RunAsUser = ptr.To(runAsUser)
+	}
 }

--- a/internal/utils/kubernetes/ensure/pod_spec_test.go
+++ b/internal/utils/kubernetes/ensure/pod_spec_test.go
@@ -1,0 +1,109 @@
+package ensure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	core "k8s.io/api/core/v1"
+)
+
+const testContainerName = "app"
+
+func TestPodSecurityContext(t *testing.T) {
+	tests := []struct {
+		name   string
+		spec   core.PodSpec
+		verify func(Gomega, *core.PodSpec)
+	}{
+		{
+			name: "sets all required fields on empty containers",
+			spec: core.PodSpec{
+				Containers:     []core.Container{{Name: testContainerName}},
+				InitContainers: []core.Container{{Name: "init"}},
+			},
+			verify: func(g Gomega, spec *core.PodSpec) {
+				g.Expect(spec.SecurityContext).ToNot(BeNil())
+				g.Expect(*spec.SecurityContext.RunAsNonRoot).To(BeTrue())
+				g.Expect(spec.SecurityContext.SeccompProfile.Type).To(Equal(core.SeccompProfileTypeRuntimeDefault))
+
+				for _, c := range append(spec.Containers, spec.InitContainers...) {
+					g.Expect(c.SecurityContext).ToNot(BeNil())
+					g.Expect(*c.SecurityContext.RunAsNonRoot).To(BeTrue())
+					g.Expect(*c.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+					g.Expect(c.SecurityContext.Capabilities).ToNot(BeNil())
+					g.Expect(c.SecurityContext.Capabilities.Drop).To(ConsistOf(core.Capability("ALL")))
+				}
+			},
+		},
+		{
+			name: "does not overwrite existing capabilities.drop",
+			spec: core.PodSpec{
+				Containers: []core.Container{{
+					Name: testContainerName,
+					SecurityContext: &core.SecurityContext{
+						Capabilities: &core.Capabilities{
+							Drop: []core.Capability{"NET_RAW"},
+						},
+					},
+				}},
+			},
+			verify: func(g Gomega, spec *core.PodSpec) {
+				g.Expect(spec.Containers[0].SecurityContext.Capabilities.Drop).To(ConsistOf(core.Capability("NET_RAW")))
+			},
+		},
+		{
+			name: "does not overwrite existing RunAsNonRoot on container",
+			spec: core.PodSpec{
+				Containers: []core.Container{{
+					Name: testContainerName,
+					SecurityContext: &core.SecurityContext{
+						RunAsNonRoot: ptrBool(false),
+					},
+				}},
+			},
+			verify: func(g Gomega, spec *core.PodSpec) {
+				g.Expect(*spec.Containers[0].SecurityContext.RunAsNonRoot).To(BeFalse())
+				g.Expect(spec.Containers[0].SecurityContext.Capabilities.Drop).To(ConsistOf(core.Capability("ALL")))
+			},
+		},
+		{
+			name: "handles multiple containers and init containers",
+			spec: core.PodSpec{
+				Containers:     []core.Container{{Name: "c1"}, {Name: "c2"}},
+				InitContainers: []core.Container{{Name: "i1"}, {Name: "i2"}},
+			},
+			verify: func(g Gomega, spec *core.PodSpec) {
+				for _, c := range spec.Containers {
+					g.Expect(c.SecurityContext.Capabilities).ToNot(BeNil())
+					g.Expect(c.SecurityContext.Capabilities.Drop).To(ConsistOf(core.Capability("ALL")))
+				}
+				for _, c := range spec.InitContainers {
+					g.Expect(c.SecurityContext.Capabilities).ToNot(BeNil())
+					g.Expect(c.SecurityContext.Capabilities.Drop).To(ConsistOf(core.Capability("ALL")))
+				}
+			},
+		},
+		{
+			name: "handles empty pod spec",
+			spec: core.PodSpec{},
+			verify: func(g Gomega, spec *core.PodSpec) {
+				g.Expect(spec.SecurityContext).ToNot(BeNil())
+				g.Expect(*spec.SecurityContext.RunAsNonRoot).To(BeTrue())
+				g.Expect(spec.SecurityContext.SeccompProfile.Type).To(Equal(core.SeccompProfileTypeRuntimeDefault))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := PodSecurityContext(&tt.spec)
+			g.Expect(err).ToNot(HaveOccurred())
+			tt.verify(g, &tt.spec)
+		})
+	}
+}
+
+func ptrBool(b bool) *bool {
+	return &b
+}

--- a/test/e2e/custom_install/suite_test.go
+++ b/test/e2e/custom_install/suite_test.go
@@ -94,6 +94,12 @@ func managerPod(ns string, opts ...optManagerPod) *v1.Pod {
 					Name:    "manager",
 					Image:   image,
 					Command: []string{"/manager"},
+					SecurityContext: &v1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{"ALL"},
+						},
+					},
 					Env: []v1.EnvVar{
 						{
 							Name:  "OPENSHIFT",

--- a/test/e2e/custom_install/testdata/proxy.yaml
+++ b/test/e2e/custom_install/testdata/proxy.yaml
@@ -24,6 +24,9 @@ spec:
     image: mirror.gcr.io/httpd:2.4.46
     securityContext:
       runAsUser: 1001
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
     command:
      - httpd
     args:

--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -60,6 +60,26 @@ func CreateClient() (client.Client, error) {
 
 }
 func CreateTestNamespace(ctx context.Context, cli client.Client) *v1.Namespace {
+	return createTestNamespace(ctx, cli, true)
+}
+
+func CreateTestNamespaceWithoutPSA(ctx context.Context, cli client.Client) *v1.Namespace {
+	return createTestNamespace(ctx, cli, false)
+}
+
+func EnforcePSARestricted(ctx context.Context, cli client.Client, ns *v1.Namespace) {
+	Eventually(func(g Gomega) {
+		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(ns), ns)).To(Succeed())
+		if ns.Labels == nil {
+			ns.Labels = map[string]string{}
+		}
+		ns.Labels["pod-security.kubernetes.io/enforce"] = "restricted"
+		ns.Labels["pod-security.kubernetes.io/enforce-version"] = "latest"
+		g.Expect(cli.Update(ctx, ns)).To(Succeed())
+	}).Should(Succeed())
+}
+
+func createTestNamespace(ctx context.Context, cli client.Client, withPSA bool) *v1.Namespace {
 	sp := ginkgo.CurrentSpecReport()
 	fn := filepath.Base(sp.LeafNodeLocation.FileName)
 	// Replace invalid characters with '-'
@@ -69,7 +89,12 @@ func CreateTestNamespace(ctx context.Context, cli client.Client) *v1.Namespace {
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name + "-",
+			Labels:       map[string]string{},
 		},
+	}
+	if withPSA {
+		ns.Labels["pod-security.kubernetes.io/enforce"] = "restricted"
+		ns.Labels["pod-security.kubernetes.io/enforce-version"] = "latest"
 	}
 	Expect(cli.Create(ctx, ns)).To(Succeed())
 	core.GinkgoWriter.Println("Created test namespace: " + ns.Name)

--- a/test/e2e/support/kubernetes/pvc.go
+++ b/test/e2e/support/kubernetes/pvc.go
@@ -41,6 +41,15 @@ func CreatePVCCopyJob(namespace, srcPVC, destPVC string) *batchv1.Job {
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					RestartPolicy: v1.RestartPolicyOnFailure,
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(true),
+						RunAsUser:    ptr.To(int64(1001)),
+						RunAsGroup:   ptr.To(int64(1001)),
+						FSGroup:      ptr.To(int64(1001)),
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{
 						{
 							Name:    "pvc-copy",
@@ -51,6 +60,12 @@ func CreatePVCCopyJob(namespace, srcPVC, destPVC string) *batchv1.Job {
 								echo "Copying from /src to /dest..."
 								rsync -rlH --no-perms --no-owner --no-group --numeric-ids /src/ /dest/
 								echo "Done."`,
+							},
+							SecurityContext: &v1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &v1.Capabilities{
+									Drop: []v1.Capability{"ALL"},
+								},
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{

--- a/test/e2e/support/steps/namespace.go
+++ b/test/e2e/support/steps/namespace.go
@@ -22,6 +22,17 @@ func CreateNamespace(cli client.Client, callback func(*v1.Namespace)) func(ctx g
 	}
 }
 
+func CreateNamespaceWithoutPSA(cli client.Client, callback func(*v1.Namespace)) func(ctx ginkgo.SpecContext) {
+	return func(ctx ginkgo.SpecContext) {
+		namespace := support.CreateTestNamespaceWithoutPSA(ctx, cli)
+		ginkgo.DeferCleanup(func(ctx ginkgo.SpecContext) {
+			_ = cli.Delete(ctx, namespace)
+		})
+		ginkgo.DeferCleanup(DumpNamespace(cli, namespace))
+		callback(namespace)
+	}
+}
+
 func DumpNamespace(cli client.Client, namespace *v1.Namespace) func(ctx ginkgo.SpecContext) {
 	return func(ctx ginkgo.SpecContext) {
 		report := ctx.SpecReport()

--- a/test/e2e/support/tas/cosign/cosign_inCluster.go
+++ b/test/e2e/support/tas/cosign/cosign_inCluster.go
@@ -75,12 +75,24 @@ func (c *InClusterCosign) executeInJob(ctx context.Context, script string) error
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
 					RestartPolicy: v1.RestartPolicyNever,
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(true),
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{
 						{
 							Name:    "cosign",
 							Image:   cosignImage,
 							Command: []string{"/bin/sh", "-c"},
 							Args:    []string{script},
+							SecurityContext: &v1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &v1.Capabilities{
+									Drop: []v1.Capability{"ALL"},
+								},
+							},
 						},
 					},
 				},

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Operator upgrade", Ordered, func() {
 		cosign                                 cosignSupport.Cosign
 	)
 
-	BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+	BeforeAll(steps.CreateNamespaceWithoutPSA(cli, func(new *v1.Namespace) {
 		namespace = new
 	}))
 	BeforeAll(func(ctx SpecContext) {
@@ -223,6 +223,10 @@ var _ = Describe("Operator upgrade", Ordered, func() {
 		}
 
 		tas.VerifyAllComponents(ctx, cli, securesignDeployment, true)
+	})
+
+	It("Enforce PSA restricted:latest after upgrade", func(ctx SpecContext) {
+		support.EnforcePSARestricted(ctx, cli, namespace)
 	})
 
 	It("Verify image signature after upgrade", func(ctx SpecContext) {


### PR DESCRIPTION
## Summary

- Adds `securityContext.capabilities.drop: ["ALL"]` to the shared `PodSecurityContext()` helper, fixing admission failures on clusters enforcing Pod Security `restricted:latest`
- Adds `PodSecurityContext()` call to 8 workloads that were missing it entirely: Fulcio, CTlog, TSA, Trillian logserver/logsigner, Rekor UI/Redis, backfill Redis CronJob
- Enforces `restricted:latest` on all e2e test namespaces so future regressions are caught by existing tests

Implements [SECURESIGN-4504](https://redhat.atlassian.net/browse/SECURESIGN-4504)

## Test plan

- [x] Unit tests for `PodSecurityContext()` verify `capabilities.drop=["ALL"]` is set on all containers/init containers
- [x] All existing unit tests pass
- [ ] E2e tests run in namespaces with `pod-security.kubernetes.io/enforce=restricted` — any non-compliant pod template will be rejected by admission

🤖 Generated with [Claude Code](https://claude.com/claude-code)