### PR TITLE
feat: add Coverport instrumentation and parallel CI jobs for E2E coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -645,3 +645,159 @@ jobs:
         run: |
           kubectl logs -n openshift-rhtas-operator deployment/rhtas-operator-controller-manager
         if: failure()
+
+  build-operator-coverage:
+    name: Build-operator-coverage
+    runs-on: ubuntu-24.04
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          auth_file_path: /tmp/config.json
+
+      - name: Replace images
+        run: make dev-images && cat config/default/images.env
+
+      - name: Build coverage-instrumented operator container
+        run: make docker-build-coverage
+
+      - name: Push coverage image
+        run: podman push ${{ env.IMG }}-coverage
+
+  test-kind-coverage:
+    name: Test E2E with coverage
+    runs-on: ubuntu-24.04
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main')
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+    needs:
+      - build-operator-coverage
+      - build-tuftool
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install coverport CLI
+        run: |
+          go install github.com/konflux-ci/coverport/cli@latest
+          mv "$(go env GOPATH)/bin/cli" "$(go env GOPATH)/bin/coverport"
+
+      - name: Download tuftool
+        uses: actions/download-artifact@v4
+        with:
+          name: tuftool
+          path: /tmp/tuftool
+      - run: echo "/tmp/tuftool" >> $GITHUB_PATH
+
+      - name: Log in to GitHub Container Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          auth_file_path: /tmp/config.json
+
+      - name: Log in to registry.redhat.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: registry.redhat.io
+          auth_file_path: /tmp/config.json
+
+      - name: Install Cluster
+        uses: ./.github/actions/kind-cluster
+        with:
+          config: ./ci/config.yaml
+          prometheus: 'true'
+          keycloak: 'true'
+          olm: 'true'
+
+      - name: Pull coverage image from GHCR
+        run: podman pull ${{ env.IMG }}-coverage
+
+      - name: Load coverage image into Kind cluster
+        run: |
+          podman save ${{ env.IMG }}-coverage -o operator-coverage-oci.tar
+          kind load image-archive operator-coverage-oci.tar
+
+      - name: Replace images
+        run: make dev-images && cat config/default/images.env
+
+      - name: Deploy operator with coverage image
+        run: make deploy
+        env:
+          IMG: ${{ env.IMG }}-coverage
+
+      - name: Wait for operator to be ready
+        run: |
+          kubectl wait --for=condition=available deployment/rhtas-operator-controller-manager --timeout=120s -n openshift-rhtas-operator
+
+      - name: Configure Ingress hostname template
+        run: |
+          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
+          kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
+
+      - name: Add service hosts to /etc/hosts
+        run: |
+          sudo echo "127.0.0.1 keycloak-internal.keycloak-system.svc" | sudo tee -a /etc/hosts
+
+      - name: Install cosign
+        run: go install github.com/sigstore/cosign/v3/cmd/cosign@v3.0.5
+
+      - name: Run E2E tests
+        run: make test-e2e
+
+      - name: Collect coverage from operator pod via Coverport
+        if: always()
+        run: |
+          coverport collect \
+            --namespace=openshift-rhtas-operator \
+            --label-selector=control-plane=operator-controller-manager \
+            --test-name=e2e \
+            --output=./e2e-coverage-data \
+            --source-dir=. \
+            --auto-process
+          find ./e2e-coverage-data -name '*.out' -type f || true
+
+      - name: Upload E2E coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v6
+        with:
+          directory: ./e2e-coverage-data
+          flags: e2e
+          use_oidc: true
+          fail_ci_if_error: false
+
+      - name: Archive test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-kind-coverage
+          path: test/**/k8s-dump-*.tar.gz
+          if-no-files-found: ignore
+
+      - name: dump the logs of the operator
+        run: kubectl logs -n openshift-rhtas-operator deployment/rhtas-operator-controller-manager
+        if: always()

--- a/Dockerfile.coverage
+++ b/Dockerfile.coverage
@@ -1,0 +1,31 @@
+# Build the coverage-instrumented manager binary
+FROM golang:1.26 AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+
+# Copy ALL of cmd/ (includes coverage.go with Coverport blank import)
+COPY cmd/ cmd/
+COPY api/ api/
+COPY internal/ internal/
+
+COPY config/default/images.env config/default/images.env
+RUN go generate ./...
+
+# -cover enables coverage instrumentation in the binary.
+# -covermode=atomic is required by runtime/coverage.WriteCounters().
+# -tags=coverage includes cmd/coverage.go which embeds the Coverport HTTP server.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
+    go build -cover -covermode=atomic -tags=coverage \
+    -a -o manager ./cmd
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:24650313873554b6ba16c1a1b6b9f9142604f6ab735113e1695faf2dd07fdede
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,10 @@ docker-build: test ## Build docker image with the manager.
 docker-build-skip-test: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build . -t ${IMG}
 
+.PHONY: docker-build-coverage
+docker-build-coverage: ## Build coverage-instrumented docker image for E2E coverage collection.
+	$(CONTAINER_TOOL) build -f Dockerfile.coverage -t ${IMG}-coverage .
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}

--- a/cmd/coverage.go
+++ b/cmd/coverage.go
@@ -1,0 +1,5 @@
+//go:build coverage
+
+package main
+
+import _ "github.com/konflux-ci/coverport/instrumentation/go"

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,19 @@ coverage:
         threshold: 5%
         informational: true
 
+flags:
+  unit:
+    carryforward: true
+    paths:
+      - internal/
+      - api/
+      - cmd/
+  e2e:
+    carryforward: true
+    paths:
+      - internal/controller/
+      - cmd/
+
 flag_management:
   default_rules:
     carryforward: true

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20260526151850-df0340fccd6e // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20260526151850-df0340fccd6e h1:m7vDusLj0QjR+GAE9mXUJ2Hj6NWcrdXD4P6EFChSH+E=
+github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20260526151850-df0340fccd6e/go.mod h1:WVMHU9A2464s/vjH1xOTm4LJDD4xP+VlEiU+KM0gkSU=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
## Summary

- Instruments the operator binary with [Coverport](https://github.com/konflux-ci/coverport) to extract runtime E2E coverage from a live Kind cluster via HTTP port-forwarding
- Adds two new parallel CI jobs (`build-operator-coverage`, `test-kind-coverage`) that run alongside the existing `test-kind` job without affecting it
- Adds `unit` and `e2e` flag definitions to `codecov.yml` with carryforward semantics

## Two-Build Approach

| Build | Dockerfile | CGO | Purpose | Affected by this PR? |
|---|---|---|---|---|
| **Production** | `Dockerfile.rhtas-operator.rh` | CGO=1 (FIPS) | Konflux/Tekton release pipeline | No |
| **Community** | `Dockerfile` | CGO=0 | GitHub Actions dev CI | No |
| **Coverage** | `Dockerfile.coverage` (new) | CGO=0 + `-cover` | E2E coverage collection | Yes (new) |

Production images are safe by design: both production Dockerfiles use `COPY cmd/main.go cmd/main.go` (not `COPY cmd/`), so `cmd/coverage.go` is physically excluded. The `//go:build coverage` tag provides a second layer of protection.

## New CI Jobs

- **`build-operator-coverage`**: Builds the instrumented image using `Dockerfile.coverage` and pushes to GHCR with a `-coverage` tag suffix. Runs in parallel with `build-operator`.
- **`test-kind-coverage`**: Deploys the instrumented image to a Kind cluster, runs the existing E2E suite (`make test-e2e`), then uses `coverport collect` to scrape coverage from the live operator pod and uploads to Codecov under the `e2e` flag. Mirrors the existing `test-kind` job step-for-step.

Both jobs are gated to `main` branch only (pushes + PRs targeting main).

## Test plan

- [ ] `build-operator-coverage` job succeeds and pushes the coverage image to GHCR
- [ ] `test-kind-coverage` job deploys the instrumented operator, E2E tests pass, and Coverport collects coverage
- [ ] Codecov receives E2E coverage upload under the `e2e` flag
- [ ] Existing `build-operator`, `test-kind`, and all other jobs are completely unaffected
- [ ] Production Dockerfiles (`Dockerfile`, `Dockerfile.rhtas-operator.rh`) are not modified

Ref: [COVERPORT-197](https://redhat.atlassian.net/browse/COVERPORT-197)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[COVERPORT-197]: https://redhat.atlassian.net/browse/COVERPORT-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ