### PR TITLE
chore: initialise 1.4.2 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
   IMG: ghcr.io/securesign/secure-sign-operator:dev-${{ github.sha }}
   BUNDLE_IMG: ghcr.io/securesign/secure-sign-operator-bundle:dev-${{ github.sha }}
   CATALOG_IMG: ghcr.io/securesign/secure-sign-operator-fbc:dev-${{ github.sha }}
-  NEW_OLM_CHANNEL: rhtas-operator.v1.4.1
+  NEW_OLM_CHANNEL: rhtas-operator.v1.4.2
   OCP_VERSION: ${{ vars.OLM_INDEX_VERSION }}
 
 jobs:
@@ -339,6 +339,7 @@ jobs:
         env:
           TEST_BASE_CATALOG: registry.redhat.io/redhat/redhat-operator-index:${{ vars.OLM_INDEX_VERSION }}
           TEST_TARGET_CATALOG: ${{ env.CATALOG_IMG }}
+          TEST_UPGRADE_CHANNEL: stable-v1.4
         run: go test -p 1 ./test/e2e/... -tags=upgrade -timeout 20m
 
       - name: Archive test artifacts

--- a/.tekton/rhtas-operator-bundle-pull-request.yaml
+++ b/.tekton/rhtas-operator-bundle-pull-request.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.1"
+    value: "1.4.2"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rhtas-operator-bundle-push.yaml
+++ b/.tekton/rhtas-operator-bundle-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.1"
+    value: "1.4.2"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.1"
+    value: "1.4.2"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rhtas-operator-push.yaml
+++ b/.tekton/rhtas-operator-push.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.4.1"
+    value: "1.4.2"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/Dockerfile.rhtas-operator.rh
+++ b/Dockerfile.rhtas-operator.rh
@@ -1,4 +1,4 @@
-ARG VERSION="1.4.1"
+ARG VERSION="1.4.2"
 
 # Build the manager binary
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1777889793@sha256:1c1259373e6feb4b57de490452379c40888cf6e876154cd2ace17eae9c64a7ea AS builder

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.4.1
+VERSION ?= 1.4.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION="1.4.1"
+ARG VERSION="1.4.2"
 ARG CHANNELS="stable,stable-v1.4"
 ARG DEFAULT_CHANNEL="stable"
 ARG BUNDLE_GEN_FLAGS="-q --overwrite=false --version $VERSION --channels=$CHANNELS --default-channel=$DEFAULT_CHANNEL"

--- a/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["Red Hat Trusted Artifact Signer"]'
     repository: https://github.com/securesign/secure-sign-operator
     support: Red Hat
-  name: rhtas-operator.v1.4.1
+  name: rhtas-operator.v1.4.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -112,4 +112,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/securesign/secure-sign-operator
-  version: 1.4.1
+  version: 1.4.2


### PR DESCRIPTION
Initialize 1.4.2 release.

Updates VERSION to `1.4.2` and sets TEST_UPGRADE_CHANNEL to `stable-v1.4`.