### PR TITLE
refactor: consolidate 5 TLS actions into generic action

### DIFF
--- a/internal/action/tls/action.go
+++ b/internal/action/tls/action.go
@@ -1,0 +1,93 @@
+package tls
+
+import (
+	"context"
+	"fmt"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/apis"
+	"github.com/securesign/operator/internal/state"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	tlsutils "github.com/securesign/operator/internal/utils/tls"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewAction[T apis.ConditionsAwareObject](
+	conditionType string,
+	conditionResolvedStatus metav1.ConditionStatus,
+	secretNameFormat string,
+	component string,
+	wrapper func(T) *wrapper[T],
+) action.Action[T] {
+	return &tlsAction[T]{
+		conditionType:           conditionType,
+		conditionResolvedStatus: conditionResolvedStatus,
+		secretNameFormat:        secretNameFormat,
+		component:               component,
+		wrapper:                 wrapper,
+	}
+}
+
+type tlsAction[T apis.ConditionsAwareObject] struct {
+	action.BaseAction
+	conditionType           string
+	conditionResolvedStatus metav1.ConditionStatus
+	secretNameFormat        string
+	component               string
+	wrapper                 func(T) *wrapper[T]
+}
+
+func (i tlsAction[T]) Name() string {
+	return fmt.Sprintf("resolve %s TLS", i.component)
+}
+
+func (i tlsAction[T]) CanHandle(_ context.Context, instance T) bool {
+	w := i.wrapper(instance)
+	c := meta.FindStatusCondition(instance.GetConditions(), i.conditionType)
+
+	switch {
+	case c == nil:
+		return false
+	case !w.IsEnabled():
+		return false
+	case c.Reason == state.Pending.String():
+		return true
+	case !equality.Semantic.DeepDerivative(w.SpecTLS(), w.StatusTLS()):
+		return true
+	default:
+		return kubernetes.IsOpenShift() && w.StatusTLS().CertRef == nil
+	}
+}
+
+func (i tlsAction[T]) Handle(ctx context.Context, instance T) *action.Result {
+	w := i.wrapper(instance)
+
+	switch {
+	case w.SpecTLS().CertRef != nil:
+		w.SetStatusTLS(w.SpecTLS())
+	case kubernetes.IsOpenShift():
+		w.SetStatusTLS(rhtasv1.TLS{
+			CertRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(i.secretNameFormat, instance.GetName())},
+				Key:                  tlsutils.KeyCert,
+			},
+			PrivateKeyRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(i.secretNameFormat, instance.GetName())},
+				Key:                  tlsutils.KeyPrivate,
+			},
+		})
+	default:
+		i.Logger.V(1).Info(fmt.Sprintf("Communication to %s is insecure", i.component))
+	}
+
+	instance.SetCondition(metav1.Condition{
+		Type:    i.conditionType,
+		Status:  i.conditionResolvedStatus,
+		Reason:  ReasonResolved,
+		Message: "TLS configuration resolved",
+	})
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+}

--- a/internal/action/tls/action_test.go
+++ b/internal/action/tls/action_test.go
@@ -1,0 +1,352 @@
+package tls
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/config"
+	"github.com/securesign/operator/internal/state"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const testCondition = "TestCondition"
+const testSecretFormat = "%s-test-tls"
+const testComponent = "test component"
+
+func testWrapper() func(*rhtasv1.Trillian) *wrapper[*rhtasv1.Trillian] {
+	return Wrapper(
+		func(t *rhtasv1.Trillian) rhtasv1.TLS { return t.Spec.LogServer.TLS },
+		func(t *rhtasv1.Trillian) rhtasv1.TLS { return t.Status.LogServer.TLS },
+		func(t *rhtasv1.Trillian, tls rhtasv1.TLS) { t.Status.LogServer.TLS = tls },
+		nil,
+	)
+}
+
+func TestCanHandle(t *testing.T) {
+	type env struct {
+		conditions  []metav1.Condition
+		specTLS     rhtasv1.TLS
+		statusTLS   rhtasv1.TLS
+		isOpenShift bool
+		isEnabled   func(*rhtasv1.Trillian) bool
+	}
+	tests := []struct {
+		name      string
+		env       env
+		canHandle bool
+	}{
+		{
+			name: "no condition — cannot handle",
+			env: env{
+				conditions: []metav1.Condition{},
+			},
+			canHandle: false,
+		},
+		{
+			name: "condition Pending — can handle",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionFalse,
+						Reason: state.Pending.String(),
+					},
+				},
+			},
+			canHandle: true,
+		},
+		{
+			name: "spec and status TLS differ — can handle",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionTrue,
+						Reason: state.Ready.String(),
+					},
+				},
+				specTLS: rhtasv1.TLS{
+					CertRef: &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "new-cert"},
+						Key:                  "tls.crt",
+					},
+				},
+				statusTLS: rhtasv1.TLS{},
+			},
+			canHandle: true,
+		},
+		{
+			name: "spec and status TLS identical — cannot handle",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionTrue,
+						Reason: state.Ready.String(),
+					},
+				},
+				specTLS: rhtasv1.TLS{
+					CertRef: &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "same-cert"},
+						Key:                  "tls.crt",
+					},
+				},
+				statusTLS: rhtasv1.TLS{
+					CertRef: &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "same-cert"},
+						Key:                  "tls.crt",
+					},
+				},
+			},
+			canHandle: false,
+		},
+		{
+			name: "OpenShift, Ready, no cert in status — can handle (auto TLS)",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionTrue,
+						Reason: state.Ready.String(),
+					},
+				},
+				isOpenShift: true,
+			},
+			canHandle: true,
+		},
+		{
+			name: "OpenShift, Ready, cert exists in status — cannot handle",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionTrue,
+						Reason: state.Ready.String(),
+					},
+				},
+				statusTLS: rhtasv1.TLS{
+					CertRef: &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "existing-cert"},
+						Key:                  "tls.crt",
+					},
+				},
+				isOpenShift: true,
+			},
+			canHandle: false,
+		},
+		{
+			name: "non-OpenShift, Ready, no cert — cannot handle",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionTrue,
+						Reason: state.Ready.String(),
+					},
+				},
+				isOpenShift: false,
+			},
+			canHandle: false,
+		},
+		{
+			name: "OpenShift, Creating, no cert in status — can handle (auto TLS regardless of reason)",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionFalse,
+						Reason: state.Creating.String(),
+					},
+				},
+				isOpenShift: true,
+			},
+			canHandle: true,
+		},
+		{
+			name: "disabled — cannot handle",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionFalse,
+						Reason: state.Pending.String(),
+					},
+				},
+				isEnabled: func(_ *rhtasv1.Trillian) bool { return false },
+			},
+			canHandle: false,
+		},
+		{
+			name: "nil isEnabled defaults to enabled — can handle",
+			env: env{
+				conditions: []metav1.Condition{
+					{
+						Type:   testCondition,
+						Status: metav1.ConditionFalse,
+						Reason: state.Pending.String(),
+					},
+				},
+			},
+			canHandle: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			instance := &rhtasv1.Trillian{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "default",
+				},
+				Spec: rhtasv1.TrillianSpec{
+					LogServer: rhtasv1.TrillianLogServer{
+						TLS: tt.env.specTLS,
+					},
+				},
+				Status: rhtasv1.TrillianStatus{
+					LogServer: rhtasv1.TrillianLogServer{
+						TLS: tt.env.statusTLS,
+					},
+					Conditions: tt.env.conditions,
+				},
+			}
+
+			w := Wrapper(
+				func(t *rhtasv1.Trillian) rhtasv1.TLS { return t.Spec.LogServer.TLS },
+				func(t *rhtasv1.Trillian) rhtasv1.TLS { return t.Status.LogServer.TLS },
+				func(t *rhtasv1.Trillian, tls rhtasv1.TLS) { t.Status.LogServer.TLS = tls },
+				tt.env.isEnabled,
+			)
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				Build()
+
+			a := testAction.PrepareAction(c, NewAction(
+				testCondition, metav1.ConditionFalse, testSecretFormat, testComponent, w,
+			))
+			config.Openshift = tt.env.isOpenShift
+
+			g.Expect(a.CanHandle(t.Context(), instance)).To(Equal(tt.canHandle))
+		})
+	}
+}
+
+func TestHandle(t *testing.T) {
+	tests := []struct {
+		name              string
+		specTLS           rhtasv1.TLS
+		isOpenShift       bool
+		conditionStatus   metav1.ConditionStatus
+		expectedStatusTLS rhtasv1.TLS
+	}{
+		{
+			name: "user cert specified — copies spec to status",
+			specTLS: rhtasv1.TLS{
+				CertRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-cert"},
+					Key:                  "tls.crt",
+				},
+				PrivateKeyRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-key"},
+					Key:                  "tls.key",
+				},
+			},
+			conditionStatus: metav1.ConditionFalse,
+			expectedStatusTLS: rhtasv1.TLS{
+				CertRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-cert"},
+					Key:                  "tls.crt",
+				},
+				PrivateKeyRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-key"},
+					Key:                  "tls.key",
+				},
+			},
+		},
+		{
+			name:            "OpenShift, no user cert — auto-provisions",
+			isOpenShift:     true,
+			conditionStatus: metav1.ConditionFalse,
+			expectedStatusTLS: rhtasv1.TLS{
+				CertRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "test-instance-test-tls"},
+					Key:                  "tls.crt",
+				},
+				PrivateKeyRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "test-instance-test-tls"},
+					Key:                  "tls.key",
+				},
+			},
+		},
+		{
+			name:              "vanilla K8s, no user cert — insecure",
+			isOpenShift:       false,
+			conditionStatus:   metav1.ConditionFalse,
+			expectedStatusTLS: rhtasv1.TLS{},
+		},
+		{
+			name:            "condition status matches configured resolved status (ConditionTrue)",
+			conditionStatus: metav1.ConditionTrue,
+			specTLS: rhtasv1.TLS{
+				CertRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "cert"},
+					Key:                  "tls.crt",
+				},
+			},
+			expectedStatusTLS: rhtasv1.TLS{
+				CertRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "cert"},
+					Key:                  "tls.crt",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			instance := &rhtasv1.Trillian{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-instance",
+					Namespace: "default",
+				},
+				Spec: rhtasv1.TrillianSpec{
+					LogServer: rhtasv1.TrillianLogServer{
+						TLS: tt.specTLS,
+					},
+				},
+			}
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				Build()
+
+			a := testAction.PrepareAction(c, NewAction(
+				testCondition, tt.conditionStatus, testSecretFormat, testComponent, testWrapper(),
+			))
+			config.Openshift = tt.isOpenShift
+
+			result := a.Handle(t.Context(), instance)
+
+			g.Expect(result).To(Equal(testAction.Return()))
+			g.Expect(instance.Status.LogServer.TLS).To(Equal(tt.expectedStatusTLS))
+
+			con := meta.FindStatusCondition(instance.GetConditions(), testCondition)
+			g.Expect(con).To(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Type":   Equal(testCondition),
+				"Status": Equal(tt.conditionStatus),
+				"Reason": Equal(ReasonResolved),
+			})))
+		})
+	}
+}

--- a/internal/action/tls/doc.go
+++ b/internal/action/tls/doc.go
@@ -1,0 +1,31 @@
+/*
+Package tls implements a generic action for resolving TLS configuration.
+
+This action handles TLS resolution for any custom resource that satisfies
+the [apis.ConditionsAwareObject] interface. It uses a wrapper to abstract
+the details of how to access the TLS specification and status fields from
+the custom resource object.
+
+Workflow:
+
+ 1. If the user has provided a certificate reference in spec, copy it to status.
+ 2. On OpenShift, auto-provision a serving certificate by generating a secret
+    reference using the configured name format.
+ 3. On vanilla Kubernetes with no user certificate, log that communication
+    is insecure and leave status TLS empty.
+ 4. Set the resolved condition and persist the status.
+
+The isEnabled parameter to [Wrapper] controls whether the action runs at all.
+Pass nil to indicate the component is always enabled.
+
+Usage:
+
+	tlsAction.NewAction[*v1.Trillian](
+	    actions.ServerCondition,
+	    metav1.ConditionFalse,
+	    actions.LogServerTLSSecret,
+	    "trillian log server",
+	    tlsAction.Wrapper(specTLS, statusTLS, setStatusTLS, nil),
+	)
+*/
+package tls

--- a/internal/action/tls/types.go
+++ b/internal/action/tls/types.go
@@ -1,0 +1,55 @@
+package tls
+
+import (
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/apis"
+)
+
+const (
+	ReasonResolved = "TLSResolved"
+)
+
+func Wrapper[T apis.ConditionsAwareObject](
+	specTLS func(T) rhtasv1.TLS,
+	statusTLS func(T) rhtasv1.TLS,
+	setStatusTLS func(T, rhtasv1.TLS),
+	isEnabled func(T) bool,
+) func(T) *wrapper[T] {
+	return func(obj T) *wrapper[T] {
+		return &wrapper[T]{
+			object:           obj,
+			callSpecTLS:      specTLS,
+			callStatusTLS:    statusTLS,
+			callSetStatusTLS: setStatusTLS,
+			callIsEnabled:    isEnabled,
+		}
+	}
+}
+
+type wrapper[T apis.ConditionsAwareObject] struct {
+	object T
+
+	callSpecTLS      func(T) rhtasv1.TLS
+	callStatusTLS    func(T) rhtasv1.TLS
+	callSetStatusTLS func(T, rhtasv1.TLS)
+	callIsEnabled    func(T) bool
+}
+
+func (w *wrapper[T]) SpecTLS() rhtasv1.TLS {
+	return w.callSpecTLS(w.object)
+}
+
+func (w *wrapper[T]) StatusTLS() rhtasv1.TLS {
+	return w.callStatusTLS(w.object)
+}
+
+func (w *wrapper[T]) SetStatusTLS(tls rhtasv1.TLS) {
+	w.callSetStatusTLS(w.object, tls)
+}
+
+func (w *wrapper[T]) IsEnabled() bool {
+	if w.callIsEnabled == nil {
+		return true
+	}
+	return w.callIsEnabled(w.object)
+}

--- a/internal/controller/ctlog/actions/tls.go
+++ b/internal/controller/ctlog/actions/tls.go
@@ -1,65 +1,23 @@
 package actions
 
 import (
-	"context"
-	"fmt"
-
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/action"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/meta"
+	tlsAction "github.com/securesign/operator/internal/action/tls"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewTlsAction() action.Action[*rhtasv1.CTlog] {
-	return &tlsAction{}
-}
-
-type tlsAction struct {
-	action.BaseAction
-}
-
-func (i tlsAction) Name() string {
-	return "resolve server TLS"
-}
-
-func (i tlsAction) CanHandle(_ context.Context, instance *rhtasv1.CTlog) bool {
-	return !meta.IsStatusConditionTrue(instance.Status.Conditions, TLSCondition) || !equality.Semantic.DeepDerivative(instance.Spec.TLS, instance.Status.TLS)
-}
-
-func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1.CTlog) *action.Result {
-	// TLS
-	switch {
-	case instance.Spec.TLS.CertRef != nil:
-		instance.Status.TLS = instance.Spec.TLS
-	case kubernetes.IsOpenShift():
-		instance.Status.TLS = rhtasv1.TLS{
-			CertRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(TLSSecret, instance.Name)},
-				Key:                  "tls.crt",
-			},
-			PrivateKeyRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(TLSSecret, instance.Name)},
-				Key:                  "tls.key",
-			},
-		}
-	default:
-		i.Logger.V(1).Info("Communication to CTLog is insecure")
-		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    TLSCondition,
-			Status:  metav1.ConditionTrue,
-			Reason:  "NotProvided",
-			Message: "Communication to CTLog is insecure",
-		})
-		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
-	}
-
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:    TLSCondition,
-		Status:  metav1.ConditionTrue,
-		Reason:  "TLSResolved",
-		Message: "TLS configuration resolved",
-	})
-	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+	return tlsAction.NewAction(
+		TLSCondition,
+		metav1.ConditionTrue,
+		TLSSecret,
+		"CTLog",
+		tlsAction.Wrapper(
+			func(c *rhtasv1.CTlog) rhtasv1.TLS { return c.Spec.TLS },
+			func(c *rhtasv1.CTlog) rhtasv1.TLS { return c.Status.TLS },
+			func(c *rhtasv1.CTlog, tls rhtasv1.TLS) { c.Status.TLS = tls },
+			nil,
+		),
+	)
 }

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/tls.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/tls.go
@@ -1,73 +1,19 @@
 package actions
 
 import (
-	"context"
-	"fmt"
-
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/action"
+	tlsAction "github.com/securesign/operator/internal/action/tls"
 	actions2 "github.com/securesign/operator/internal/controller/rekor/actions"
-	"github.com/securesign/operator/internal/state"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewTlsAction() action.Action[*rhtasv1.Rekor] {
-	return &tlsAction{}
-}
-
-type tlsAction struct {
-	action.BaseAction
-}
-
-func (i tlsAction) Name() string {
-	return "resolve TLS"
-}
-
-func (i tlsAction) CanHandle(_ context.Context, instance *rhtasv1.Rekor) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, actions2.RedisCondition)
-
-	switch {
-	case c == nil:
-		return false
-	case !enabled(instance):
-		return false
-	case c.Reason == state.Pending.String():
-		return true
-	case !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)):
-		return true
-	default:
-		// enable TLS on OCP by default
-		return c.Reason == state.Ready.String() && kubernetes.IsOpenShift() && statusTLS(instance).CertRef == nil
-	}
-}
-
-func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1.Rekor) *action.Result {
-	switch {
-	case specTLS(instance).CertRef != nil:
-		setStatusTLS(instance, specTLS(instance))
-	case kubernetes.IsOpenShift():
-		setStatusTLS(instance, rhtasv1.TLS{
-			CertRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(actions2.RedisTlsSecret, instance.Name)},
-				Key:                  "tls.crt",
-			},
-			PrivateKeyRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(actions2.RedisTlsSecret, instance.Name)},
-				Key:                  "tls.key",
-			},
-		})
-	default:
-		i.Logger.V(1).Info("Communication to redis server is insecure")
-	}
-
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:    actions2.RedisCondition,
-		Status:  metav1.ConditionFalse,
-		Reason:  "TLSResolved",
-		Message: "TLS configuration resolved",
-	})
-	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+	return tlsAction.NewAction(
+		actions2.RedisCondition,
+		metav1.ConditionFalse,
+		actions2.RedisTlsSecret,
+		"redis server",
+		tlsAction.Wrapper(specTLS, statusTLS, setStatusTLS, enabled),
+	)
 }

--- a/internal/controller/trillian/actions/db/tls.go
+++ b/internal/controller/trillian/actions/db/tls.go
@@ -1,74 +1,19 @@
 package db
 
 import (
-	"context"
-	"fmt"
-
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/action"
+	tlsAction "github.com/securesign/operator/internal/action/tls"
 	"github.com/securesign/operator/internal/controller/trillian/actions"
-	"github.com/securesign/operator/internal/state"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewTlsAction() action.Action[*rhtasv1.Trillian] {
-	return &tlsAction{}
-}
-
-type tlsAction struct {
-	action.BaseAction
-}
-
-func (i tlsAction) Name() string {
-	return "resolve DB TLS"
-}
-
-func (i tlsAction) CanHandle(_ context.Context, instance *rhtasv1.Trillian) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, actions.DbCondition)
-
-	switch {
-	case c == nil:
-		return false
-	case !enabled(instance):
-		return false
-	case c.Reason == state.Pending.String():
-		return true
-	case !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)):
-		return true
-	default:
-		// enable TLS on OCP by default
-		return c.Reason == state.Ready.String() && kubernetes.IsOpenShift() && statusTLS(instance).CertRef == nil
-	}
-}
-
-func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1.Trillian) *action.Result {
-	// TLS
-	switch {
-	case specTLS(instance).CertRef != nil:
-		setStatusTLS(instance, specTLS(instance))
-	case kubernetes.IsOpenShift():
-		setStatusTLS(instance, rhtasv1.TLS{
-			CertRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(actions.DatabaseTLSSecret, instance.Name)},
-				Key:                  "tls.crt",
-			},
-			PrivateKeyRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(actions.DatabaseTLSSecret, instance.Name)},
-				Key:                  "tls.key",
-			},
-		})
-	default:
-		i.Logger.V(1).Info("Communication to trillian database is insecure")
-	}
-
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:    actions.DbCondition,
-		Status:  metav1.ConditionFalse,
-		Reason:  "TLSResolved",
-		Message: "TLS configuration resolved",
-	})
-	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+	return tlsAction.NewAction(
+		actions.DbCondition,
+		metav1.ConditionFalse,
+		actions.DatabaseTLSSecret,
+		"trillian database",
+		tlsAction.Wrapper(specTLS, statusTLS, setStatusTLS, enabled),
+	)
 }

--- a/internal/controller/trillian/actions/logserver/tls.go
+++ b/internal/controller/trillian/actions/logserver/tls.go
@@ -1,72 +1,19 @@
 package logserver
 
 import (
-	"context"
-	"fmt"
-
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/action"
+	tlsAction "github.com/securesign/operator/internal/action/tls"
 	"github.com/securesign/operator/internal/controller/trillian/actions"
-	"github.com/securesign/operator/internal/state"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/tls"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewTlsAction() action.Action[*rhtasv1.Trillian] {
-	return &tlsAction{}
-}
-
-type tlsAction struct {
-	action.BaseAction
-}
-
-func (i tlsAction) Name() string {
-	return "resolve TLS"
-}
-
-func (i tlsAction) CanHandle(_ context.Context, instance *rhtasv1.Trillian) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, actions.ServerCondition)
-
-	switch {
-	case c == nil:
-		return false
-	case c.Reason == state.Pending.String():
-		return true
-	case !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)):
-		return true
-	default:
-		// enable TLS on OCP by default
-		return c.Reason == state.Ready.String() && kubernetes.IsOpenShift() && statusTLS(instance).CertRef == nil
-	}
-}
-
-func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1.Trillian) *action.Result {
-	switch {
-	case specTLS(instance).CertRef != nil:
-		setStatusTLS(instance, specTLS(instance))
-	case kubernetes.IsOpenShift():
-		setStatusTLS(instance, rhtasv1.TLS{
-			CertRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(actions.LogServerTLSSecret, instance.Name)},
-				Key:                  tls.KeyCert,
-			},
-			PrivateKeyRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(actions.LogServerTLSSecret, instance.Name)},
-				Key:                  tls.KeyPrivate,
-			},
-		})
-	default:
-		i.Logger.V(1).Info("Communication to trillian log server is insecure")
-	}
-
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:    actions.ServerCondition,
-		Status:  metav1.ConditionFalse,
-		Reason:  "TLSResolved",
-		Message: "TLS configuration resolved",
-	})
-	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+	return tlsAction.NewAction(
+		actions.ServerCondition,
+		metav1.ConditionFalse,
+		actions.LogServerTLSSecret,
+		"trillian log server",
+		tlsAction.Wrapper(specTLS, statusTLS, setStatusTLS, nil),
+	)
 }

--- a/internal/controller/trillian/actions/logsigner/tls.go
+++ b/internal/controller/trillian/actions/logsigner/tls.go
@@ -1,72 +1,19 @@
 package logsigner
 
 import (
-	"context"
-	"fmt"
-
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/action"
+	tlsAction "github.com/securesign/operator/internal/action/tls"
 	"github.com/securesign/operator/internal/controller/trillian/actions"
-	"github.com/securesign/operator/internal/state"
-	"github.com/securesign/operator/internal/utils/kubernetes"
-	"github.com/securesign/operator/internal/utils/tls"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewTlsAction() action.Action[*rhtasv1.Trillian] {
-	return &tlsAction{}
-}
-
-type tlsAction struct {
-	action.BaseAction
-}
-
-func (i tlsAction) Name() string {
-	return "resolve TLS"
-}
-
-func (i tlsAction) CanHandle(_ context.Context, instance *rhtasv1.Trillian) bool {
-	c := meta.FindStatusCondition(instance.Status.Conditions, actions.SignerCondition)
-
-	switch {
-	case c == nil:
-		return false
-	case c.Reason == state.Pending.String():
-		return true
-	case !equality.Semantic.DeepDerivative(specTLS(instance), statusTLS(instance)):
-		return true
-	default:
-		// enable TLS on OCP by default
-		return c.Reason == state.Ready.String() && kubernetes.IsOpenShift() && statusTLS(instance).CertRef == nil
-	}
-}
-
-func (i tlsAction) Handle(ctx context.Context, instance *rhtasv1.Trillian) *action.Result {
-	switch {
-	case specTLS(instance).CertRef != nil:
-		setStatusTLS(instance, specTLS(instance))
-	case kubernetes.IsOpenShift():
-		setStatusTLS(instance, rhtasv1.TLS{
-			CertRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(actions.LogSignerTLSSecret, instance.Name)},
-				Key:                  tls.KeyCert,
-			},
-			PrivateKeyRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{Name: fmt.Sprintf(actions.LogSignerTLSSecret, instance.Name)},
-				Key:                  tls.KeyPrivate,
-			},
-		})
-	default:
-		i.Logger.V(1).Info("Communication to trillian log signer is insecure")
-	}
-
-	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-		Type:    actions.SignerCondition,
-		Status:  metav1.ConditionFalse,
-		Reason:  "TLSResolved",
-		Message: "TLS configuration resolved",
-	})
-	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+	return tlsAction.NewAction(
+		actions.SignerCondition,
+		metav1.ConditionFalse,
+		actions.LogSignerTLSSecret,
+		"trillian log signer",
+		tlsAction.Wrapper(specTLS, statusTLS, setStatusTLS, nil),
+	)
 }


### PR DESCRIPTION
## Summary
- Create generic `internal/action/tls` package following the existing `pvc/action.go` wrapper pattern
- Replace 5 near-identical TLS actions (CTlog, Trillian logserver/logsigner/db, Rekor redis) with thin `NewTlsAction()` registrations
- Simplify OCP auto-provision `CanHandle` to trigger regardless of condition reason when no cert is provisioned

## Behavioral changes
- **CTlog CanHandle**: unified to Pending-aware switch (functionally equivalent — `ToPendingPhaseAction` always sets Pending before TLS runs)
- **CTlog insecure case**: condition reason changes from `"NotProvided"` to `"TLSResolved"`
- **OCP auto-provision**: no longer requires `c.Reason == Ready`, triggers whenever `CertRef == nil` on OpenShift

## Test plan
- [x] Generic action tests: 14 cases covering CanHandle (10) and Handle (4)
- [x] Existing logserver/logsigner CanHandle tests pass unchanged
- [x] `go test ./internal/...` — all pass
- [x] `make lint` — no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)