### PR TITLE
docs: add upstream development images guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,6 +49,33 @@ make bundle-build bundle-push BUNDLE_IMG=<registry>/operator-bundle:tag
 operator-sdk run bundle <registry>/operator-bundle:tag --namespace openshift-rhtas-operator --timeout 5m
 ```
 
+## Upstream Development Images
+
+The operator's `config/default/images.env` references images from `registry.redhat.io`, which requires a Red Hat subscription and only contains released versions. During development, the latest builds from `main` are published to `quay.io/securesign` and can be used instead.
+
+### Option 1: Rewrite images.env (recommended)
+
+Switch all image references from `registry.redhat.io/rhtas` to `quay.io/securesign`:
+
+```sh
+make dev-images
+```
+
+This is a local modification that affects `make run`, `make deploy`, and `make bundle`. The transformation is defined in [`ci/dev-images.sed`](ci/dev-images.sed).
+
+> **Note:** Do not commit the modified `images.env`. To revert: `git checkout config/default/images.env`.
+
+### Option 2: Cluster-level registry mirroring
+
+Configure the cluster's container runtime to transparently redirect image pulls from `registry.redhat.io` to `quay.io/securesign`. No operator code changes are needed — the same digests exist in both registries.
+
+- **OpenShift** — apply the [`ImageDigestMirrorSet`](.tekton/images-mirror-set.yaml). The Machine Config Operator will propagate this to all nodes (may trigger a rolling reboot on older OpenShift versions):
+  ```sh
+  kubectl apply -f .tekton/images-mirror-set.yaml
+  ```
+- **CRI-O** — copy [`ci/registries.conf`](ci/registries.conf) to `/etc/containers/registries.conf.d/rhtas-dev-mirrors.conf` on each node and restart CRI-O.
+- **containerd** (e.g., EKS) — configure mirror hosts under `/etc/containerd/certs.d/`. See the [containerd hosts documentation](https://github.com/containerd/containerd/blob/main/docs/hosts.md) for details.
+
 ## Cleanup
 
 | Method | Uninstall command |

--- a/ci/registries.conf
+++ b/ci/registries.conf
@@ -1,0 +1,92 @@
+# Mirror registry.redhat.io/rhtas images to quay.io/securesign for development.
+# Copy to /etc/containers/registries.conf.d/rhtas-dev-mirrors.conf on each node.
+
+[[registry]]
+location = "registry.redhat.io/rhtas/certificate-transparency-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/certificate-transparency-go"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/client-server-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/client-server"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/rhtas-operator-bundle"
+[[registry.mirror]]
+location = "quay.io/securesign/rhtas-operator-bundle"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/rhtas-rhel9-operator"
+[[registry.mirror]]
+location = "quay.io/securesign/rhtas-operator"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/fulcio-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/fulcio-server"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/rekor-server-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/rekor-server"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/rekor-backfill-redis-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/rekor-backfill-redis"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/rekor-search-ui-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/rekor-search-ui"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/trillian-logserver-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/trillian-logserver"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/trillian-logsigner-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/trillian-logsigner"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/trillian-database-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/trillian-database"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/trillian-redis-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/trillian-redis"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/createtree-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/trillian-createtree"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/segment-reporting-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/segment-backup-job"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/timestamp-authority-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/timestamp-authority"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/rekor-monitor-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/rekor-monitor"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/tuffer-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/tuffer"
+
+[[registry]]
+location = "registry.redhat.io/rhtas/ctlog-monitor-rhel9"
+[[registry.mirror]]
+location = "quay.io/securesign/ctlog-monitor"


### PR DESCRIPTION
## Summary
- Add "Upstream Development Images" section to `DEVELOPMENT.md` documenting how to use `quay.io/securesign` images during development when `registry.redhat.io` images are not yet released
- Two options documented: `make dev-images` (rewrites `images.env`) and cluster-level registry mirroring (OpenShift IDMS, CRI-O, containerd)
- Add `ci/registries.conf` with all RHTAS mirror entries for CRI-O-based clusters, matching the existing `.tekton/images-mirror-set.yaml`

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify `make dev-images` still works as described
- [ ] Verify links to referenced files (`.tekton/images-mirror-set.yaml`, `ci/dev-images.sed`, `ci/registries.conf`) resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)