### PR TITLE
fix(ci): detect conversion webhook readiness via dry-run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,7 +260,14 @@ jobs:
         run: |
           kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
           kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
-          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=rhtas-operator -n openshift-rhtas-operator --timeout=60s
+
+      - name: Wait for conversion webhook readiness
+        run: |
+          for i in $(seq 1 60); do
+            kubectl create --dry-run=server -f config/samples/rhtas_v1alpha1_securesign.yaml 2>/dev/null && break
+            echo "Waiting for conversion webhook... ($i/60)"
+            sleep 2
+          done
 
       - name: Add service hosts to /etc/hosts
         run: |
@@ -436,7 +443,14 @@ jobs:
         run: |
           kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
           kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
-          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=rhtas-operator -n openshift-rhtas-operator --timeout=60s
+
+      - name: Wait for conversion webhook readiness
+        run: |
+          for i in $(seq 1 60); do
+            kubectl create --dry-run=server -f config/samples/rhtas_v1alpha1_securesign.yaml 2>/dev/null && break
+            echo "Waiting for conversion webhook... ($i/60)"
+            sleep 2
+          done
 
       - name: Add service hosts to /etc/hosts
         run: |
@@ -618,7 +632,14 @@ jobs:
         run: |
           kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
           kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
-          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=rhtas-operator -n openshift-rhtas-operator --timeout=60s
+
+      - name: Wait for conversion webhook readiness
+        run: |
+          for i in $(seq 1 60); do
+            kubectl create --dry-run=server -f config/samples/rhtas_v1alpha1_securesign.yaml 2>/dev/null && break
+            echo "Waiting for conversion webhook... ($i/60)"
+            sleep 2
+          done
 
       - name: Install securesign
         run: |
@@ -762,7 +783,14 @@ jobs:
         run: |
           kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
           kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
-          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=rhtas-operator -n openshift-rhtas-operator --timeout=60s
+
+      - name: Wait for conversion webhook readiness
+        run: |
+          for i in $(seq 1 60); do
+            kubectl create --dry-run=server -f config/samples/rhtas_v1alpha1_securesign.yaml 2>/dev/null && break
+            echo "Waiting for conversion webhook... ($i/60)"
+            sleep 2
+          done
 
       - name: Add service hosts to /etc/hosts
         run: |


### PR DESCRIPTION
## Summary

Fixes CI instability on Kind clusters introduced by the v1 API conversion webhooks (#1913).

**Two problems replaced with one fix:**

1. `kubectl wait --for=condition=Ready pod -l ...` raced with rolling updates — the label selector matched terminating pods (`Ready=False`), causing spurious timeouts. `kubectl rollout status` already verifies the new pod passes readiness probes (including the webhook `StartedChecker`).

2. `kubectl wait crd --for=jsonpath=caBundle` only checked a static annotation, not actual webhook reachability. The caBundle can be present while the webhook is still unreachable (e.g. kube-proxy routing, cert mismatch during rolling update, API server cache staleness).

**The fix:** A server-side dry-run create of a `v1alpha1` Securesign resource, which tests the entire conversion webhook chain end-to-end:
- cert-manager caBundle injection into CRDs
- Service endpoint resolution
- TLS handshake with the correct CA
- Webhook handler response

Retries every 2s for up to 120s before giving up.

## Test plan

- [ ] test-kind passes without pod readiness or webhook timeout
- [ ] test-ha-install passes without pod readiness or webhook timeout
- [ ] test-e2e (sigstore-e2e) passes without conversion webhook timeout on CR creation
- [ ] test-e2e-coverage passes without pod readiness or webhook timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)