### PR TITLE
feat: Reduce usage of deprecated EncryptPEMBlock and DecryptPEMBlock

### DIFF
--- a/api/v1/ctlog_types.go
+++ b/api/v1/ctlog_types.go
@@ -35,8 +35,11 @@ type CTlogSpec struct {
 	//+optional
 	PrivateKeyRef *SecretKeySelector `json:"privateKeyRef,omitempty"`
 
-	// Password to decrypt private key
-	//+optional
+	// Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+	// and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+	// this field is retained only for backward compatibility with existing user-provided
+	// encrypted keys. Kubernetes Secrets provide encryption-at-rest.
+	// +optional
 	PrivateKeyPasswordRef *SecretKeySelector `json:"privateKeyPasswordRef,omitempty"`
 
 	// The public key matching the private key (if both are present). It is

--- a/api/v1/fulcio_types.go
+++ b/api/v1/fulcio_types.go
@@ -39,8 +39,11 @@ type FulcioCert struct {
 	// Reference to CA private key
 	//+optional
 	PrivateKeyRef *SecretKeySelector `json:"privateKeyRef,omitempty"`
-	// Reference to password to encrypt CA private key
-	//+optional
+	// Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+	// and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+	// this field is retained only for backward compatibility with existing user-provided
+	// encrypted keys. Kubernetes Secrets provide encryption-at-rest.
+	// +optional
 	PrivateKeyPasswordRef *SecretKeySelector `json:"privateKeyPasswordRef,omitempty"`
 
 	// Reference to CA certificate

--- a/api/v1/rekor_types.go
+++ b/api/v1/rekor_types.go
@@ -122,9 +122,11 @@ type RekorSigner struct {
 	// +kubebuilder:default:=secret
 	KMS string `json:"kms,omitempty"`
 
-	// Password to decrypt the signer private key.
-	//
-	// Optional field. This should be set only if the private key referenced by `keyRef` is encrypted with a password.
+	// Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+	// and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+	// this field is retained only for backward compatibility with existing user-provided
+	// encrypted keys. Kubernetes Secrets provide encryption-at-rest.
+	// This should be set only if the private key referenced by `keyRef` is encrypted with a password.
 	// If KMS is set to a value other than "secret", this field is ignored.
 	// +optional
 	PasswordRef *SecretKeySelector `json:"passwordRef,omitempty"`

--- a/api/v1/timestampauthority_types.go
+++ b/api/v1/timestampauthority_types.go
@@ -95,8 +95,11 @@ type TsaCertificateAuthority struct {
 	//+optional
 	//Organization Email specifies the Organization Email for the TimeStampAuthorities cert chain.
 	OrganizationEmail string `json:"organizationEmail,omitempty"`
-	//Password to decrypt the signer's root private key
-	//+optional
+	// Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+	// and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+	// this field is retained only for backward compatibility with existing user-provided
+	// encrypted keys. Kubernetes Secrets provide encryption-at-rest.
+	// +optional
 	PasswordRef *SecretKeySelector `json:"passwordRef,omitempty"`
 	// Reference to the signer's root private key
 	//+optional
@@ -105,8 +108,11 @@ type TsaCertificateAuthority struct {
 
 // TSA File signer configuration
 type File struct {
-	//Password to decrypt the signer's root private key
-	//+optional
+	// Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+	// and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+	// this field is retained only for backward compatibility with existing user-provided
+	// encrypted keys. Kubernetes Secrets provide encryption-at-rest.
+	// +optional
 	PasswordRef *SecretKeySelector `json:"passwordRef,omitempty"`
 	//Reference to the signer's root private key
 	//+optional

--- a/config/crd/bases/rhtas.redhat.com_ctlogs.yaml
+++ b/config/crd/bases/rhtas.redhat.com_ctlogs.yaml
@@ -1006,7 +1006,11 @@ spec:
                 - enabled
                 type: object
               privateKeyPasswordRef:
-                description: Password to decrypt private key
+                description: |-
+                  Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                  and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                  this field is retained only for backward compatibility with existing user-provided
+                  encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                 properties:
                   key:
                     description: The key of the secret to select from. Must be a valid

--- a/config/crd/bases/rhtas.redhat.com_fulcios.yaml
+++ b/config/crd/bases/rhtas.redhat.com_fulcios.yaml
@@ -991,7 +991,11 @@ spec:
                   organizationName:
                     type: string
                   privateKeyPasswordRef:
-                    description: Reference to password to encrypt CA private key
+                    description: |-
+                      Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                      and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                      this field is retained only for backward compatibility with existing user-provided
+                      encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                     properties:
                       key:
                         description: The key of the secret to select from. Must be
@@ -1447,7 +1451,11 @@ spec:
                   organizationName:
                     type: string
                   privateKeyPasswordRef:
-                    description: Reference to password to encrypt CA private key
+                    description: |-
+                      Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                      and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                      this field is retained only for backward compatibility with existing user-provided
+                      encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                     properties:
                       key:
                         description: The key of the secret to select from. Must be

--- a/config/crd/bases/rhtas.redhat.com_rekors.yaml
+++ b/config/crd/bases/rhtas.redhat.com_rekors.yaml
@@ -2626,9 +2626,11 @@ spec:
                         || self.matches('^azurekms://.+$') || self.matches('^hashivault://.+$')
                   passwordRef:
                     description: |-
-                      Password to decrypt the signer private key.
-
-                      Optional field. This should be set only if the private key referenced by `keyRef` is encrypted with a password.
+                      Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                      and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                      this field is retained only for backward compatibility with existing user-provided
+                      encrypted keys. Kubernetes Secrets provide encryption-at-rest.
+                      This should be set only if the private key referenced by `keyRef` is encrypted with a password.
                       If KMS is set to a value other than "secret", this field is ignored.
                     properties:
                       key:
@@ -2935,9 +2937,11 @@ spec:
                         || self.matches('^azurekms://.+$') || self.matches('^hashivault://.+$')
                   passwordRef:
                     description: |-
-                      Password to decrypt the signer private key.
-
-                      Optional field. This should be set only if the private key referenced by `keyRef` is encrypted with a password.
+                      Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                      and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                      this field is retained only for backward compatibility with existing user-provided
+                      encrypted keys. Kubernetes Secrets provide encryption-at-rest.
+                      This should be set only if the private key referenced by `keyRef` is encrypted with a password.
                       If KMS is set to a value other than "secret", this field is ignored.
                     properties:
                       key:

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -1029,7 +1029,11 @@ spec:
                     - enabled
                     type: object
                   privateKeyPasswordRef:
-                    description: Password to decrypt private key
+                    description: |-
+                      Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                      and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                      this field is retained only for backward compatibility with existing user-provided
+                      encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                     properties:
                       key:
                         description: The key of the secret to select from. Must be
@@ -2255,7 +2259,11 @@ spec:
                       organizationName:
                         type: string
                       privateKeyPasswordRef:
-                        description: Reference to password to encrypt CA private key
+                        description: |-
+                          Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                          and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                          this field is retained only for backward compatibility with existing user-provided
+                          encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                         properties:
                           key:
                             description: The key of the secret to select from. Must
@@ -5279,9 +5287,11 @@ spec:
                             || self.matches('^azurekms://.+$') || self.matches('^hashivault://.+$')
                       passwordRef:
                         description: |-
-                          Password to decrypt the signer private key.
-
-                          Optional field. This should be set only if the private key referenced by `keyRef` is encrypted with a password.
+                          Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                          and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                          this field is retained only for backward compatibility with existing user-provided
+                          encrypted keys. Kubernetes Secrets provide encryption-at-rest.
+                          This should be set only if the private key referenced by `keyRef` is encrypted with a password.
                           If KMS is set to a value other than "secret", this field is ignored.
                         properties:
                           key:
@@ -9048,8 +9058,11 @@ spec:
                                     Name for the TimeStampAuthorities cert chain.
                                   type: string
                                 passwordRef:
-                                  description: Password to decrypt the signer's root
-                                    private key
+                                  description: |-
+                                    Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                                    and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                                    this field is retained only for backward compatibility with existing user-provided
+                                    encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                                   properties:
                                     key:
                                       description: The key of the secret to select
@@ -9104,8 +9117,11 @@ spec:
                                   Name for the TimeStampAuthorities cert chain.
                                 type: string
                               passwordRef:
-                                description: Password to decrypt the signer's root
-                                  private key
+                                description: |-
+                                  Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                                  and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                                  this field is retained only for backward compatibility with existing user-provided
+                                  encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -9159,8 +9175,11 @@ spec:
                                   Name for the TimeStampAuthorities cert chain.
                                 type: string
                               passwordRef:
-                                description: Password to decrypt the signer's root
-                                  private key
+                                description: |-
+                                  Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                                  and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                                  this field is retained only for backward compatibility with existing user-provided
+                                  encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                                 properties:
                                   key:
                                     description: The key of the secret to select from.
@@ -9219,8 +9238,11 @@ spec:
                         description: Configuration for file-based signer
                         properties:
                           passwordRef:
-                            description: Password to decrypt the signer's root private
-                              key
+                            description: |-
+                              Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                              and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                              this field is retained only for backward compatibility with existing user-provided
+                              encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                             properties:
                               key:
                                 description: The key of the secret to select from.

--- a/config/crd/bases/rhtas.redhat.com_timestampauthorities.yaml
+++ b/config/crd/bases/rhtas.redhat.com_timestampauthorities.yaml
@@ -1172,8 +1172,11 @@ spec:
                                 Name for the TimeStampAuthorities cert chain.
                               type: string
                             passwordRef:
-                              description: Password to decrypt the signer's root private
-                                key
+                              description: |-
+                                Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                                and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                                this field is retained only for backward compatibility with existing user-provided
+                                encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                               properties:
                                 key:
                                   description: The key of the secret to select from.
@@ -1228,8 +1231,11 @@ spec:
                               Name for the TimeStampAuthorities cert chain.
                             type: string
                           passwordRef:
-                            description: Password to decrypt the signer's root private
-                              key
+                            description: |-
+                              Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                              and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                              this field is retained only for backward compatibility with existing user-provided
+                              encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                             properties:
                               key:
                                 description: The key of the secret to select from.
@@ -1282,8 +1288,11 @@ spec:
                               Name for the TimeStampAuthorities cert chain.
                             type: string
                           passwordRef:
-                            description: Password to decrypt the signer's root private
-                              key
+                            description: |-
+                              Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                              and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                              this field is retained only for backward compatibility with existing user-provided
+                              encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                             properties:
                               key:
                                 description: The key of the secret to select from.
@@ -1341,8 +1350,11 @@ spec:
                     description: Configuration for file-based signer
                     properties:
                       passwordRef:
-                        description: Password to decrypt the signer's root private
-                          key
+                        description: |-
+                          Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                          and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                          this field is retained only for backward compatibility with existing user-provided
+                          encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                         properties:
                           key:
                             description: The key of the secret to select from. Must
@@ -2028,8 +2040,11 @@ spec:
                                 Name for the TimeStampAuthorities cert chain.
                               type: string
                             passwordRef:
-                              description: Password to decrypt the signer's root private
-                                key
+                              description: |-
+                                Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                                and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                                this field is retained only for backward compatibility with existing user-provided
+                                encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                               properties:
                                 key:
                                   description: The key of the secret to select from.
@@ -2084,8 +2099,11 @@ spec:
                               Name for the TimeStampAuthorities cert chain.
                             type: string
                           passwordRef:
-                            description: Password to decrypt the signer's root private
-                              key
+                            description: |-
+                              Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                              and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                              this field is retained only for backward compatibility with existing user-provided
+                              encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                             properties:
                               key:
                                 description: The key of the secret to select from.
@@ -2138,8 +2156,11 @@ spec:
                               Name for the TimeStampAuthorities cert chain.
                             type: string
                           passwordRef:
-                            description: Password to decrypt the signer's root private
-                              key
+                            description: |-
+                              Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                              and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                              this field is retained only for backward compatibility with existing user-provided
+                              encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                             properties:
                               key:
                                 description: The key of the secret to select from.
@@ -2197,8 +2218,11 @@ spec:
                     description: Configuration for file-based signer
                     properties:
                       passwordRef:
-                        description: Password to decrypt the signer's root private
-                          key
+                        description: |-
+                          Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design
+                          and not FIPS-compliant. Auto-generated keys are no longer password-encrypted;
+                          this field is retained only for backward compatibility with existing user-provided
+                          encrypted keys. Kubernetes Secrets provide encryption-at-rest.
                         properties:
                           key:
                             description: The key of the secret to select from. Must

--- a/config/default/images.env
+++ b/config/default/images.env
@@ -14,7 +14,7 @@ RELATED_IMAGE_TRILLIAN_NETCAT=registry.redhat.io/openshift4/ose-tools-rhel9@sha2
 RELATED_IMAGE_CREATETREE=registry.redhat.io/rhtas/createtree-rhel9@sha256:d86ff8b3ba34f69e4056fa9b1447149627c53a6eadf6dbf03ce2e7cbc6f962df
 
 # Fulcio - Server
-RELATED_IMAGE_FULCIO_SERVER=registry.redhat.io/rhtas/fulcio-rhel9@sha256:999f9553f6ccea4daee2d657e8a4ceced08a75b0fa13e0fbd92df9e1bb4d6e44
+RELATED_IMAGE_FULCIO_SERVER=registry.redhat.io/rhtas/fulcio-rhel9@sha256:24b3665633b34c8d1609b9eb970edca0237ce3cddfba5f5fe70c9a526d04a78d
 
 # Rekor - Server
 RELATED_IMAGE_REKOR_SERVER=registry.redhat.io/rhtas/rekor-server-rhel9@sha256:f98e372185240df598d0236bda42ffebebdec16e0c0e633b5e3d7832c217d124
@@ -32,7 +32,7 @@ RELATED_IMAGE_BACKFILL_REDIS=registry.redhat.io/rhtas/rekor-backfill-redis-rhel9
 RELATED_IMAGE_TUF=registry.redhat.io/rhtas/tuffer-rhel9@sha256:56e55e2739e586d7d9306a24efc5090025a71a653a823886f847700130ca0362
 
 # CTlog - Server
-RELATED_IMAGE_CTLOG=registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:98cdbca200342cc8a8c7550769a213c0e316fa1786d19b7355b744e1b2e708ad
+RELATED_IMAGE_CTLOG=registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:6fca5e96e975714910e648650ab3db0c70828bded1a249a26104848b033103b4
 
 # HTTP Server (httpd)
 RELATED_IMAGE_HTTP_SERVER=registry.redhat.io/ubi9/httpd-24@sha256:42e093b23eb66a6870fe2659184ef5c8ba24c1bcf4ec3586068cac154749faff

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/go-containerregistry v0.21.6
 	github.com/google/trillian v1.7.3
 	github.com/google/uuid v1.6.0
+	github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20260526151850-df0340fccd6e
 	github.com/onsi/ginkgo/v2 v2.29.0
 	github.com/onsi/gomega v1.41.0
 	github.com/openshift/api v0.0.0-20260528061300-9f553042f9ae
@@ -25,7 +26,6 @@ require (
 	k8s.io/kube-aggregator v0.36.1
 	k8s.io/utils v0.0.0-20260507154919-ff6756f316d2
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -69,7 +69,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
-	github.com/konflux-ci/coverport/instrumentation/go v0.0.0-20260526151850-df0340fccd6e // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
@@ -120,5 +119,6 @@ require (
 	k8s.io/streaming v0.36.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 )

--- a/internal/controller/ctlog/actions/handle_keys.go
+++ b/internal/controller/ctlog/actions/handle_keys.go
@@ -117,7 +117,7 @@ func (g handleKeys) setupKeys(ns string, instanceStatus *rhtasv1.CTlogStatus) (*
 	}
 
 	if instanceStatus.PrivateKeyRef == nil {
-		return utils.CreatePrivateKey(config.PrivateKeyPass)
+		return utils.CreatePrivateKey()
 	} else {
 		config.PrivateKey, err = kubernetes.GetSecretData(g.Client, ns, instanceStatus.PrivateKeyRef)
 		if err != nil {

--- a/internal/controller/ctlog/actions/handle_keys_test.go
+++ b/internal/controller/ctlog/actions/handle_keys_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
-	utils2 "github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -195,10 +194,10 @@ func TestKeysCan_Handle(t *testing.T) {
 }
 func TestKeys_Handle(t *testing.T) {
 	g := NewWithT(t)
-	noPassKeyConf, err := utils.CreatePrivateKey(nil)
+	noPassKeyConf, err := utils.CreatePrivateKey()
 	g.Expect(err).To(Not(HaveOccurred()))
 
-	encryptedKeyConf, err := utils.CreatePrivateKey(utils2.GeneratePassword(8))
+	encryptedKeyConf, err := utils.CreatePrivateKey()
 	g.Expect(err).To(Not(HaveOccurred()))
 	type env struct {
 		spec    rhtasv1.CTlogSpec
@@ -287,7 +286,7 @@ func TestKeys_Handle(t *testing.T) {
 								privateKeyRefAnnotation:  "encrypted",
 							},
 						},
-						Data: map[string][]byte{"private": encryptedKeyConf.PrivateKey, "password": encryptedKeyConf.PrivateKeyPass, "public": encryptedKeyConf.PublicKey},
+						Data: map[string][]byte{"private": encryptedKeyConf.PrivateKey, "password": []byte("test-pass"), "public": encryptedKeyConf.PublicKey},
 					},
 				},
 			},

--- a/internal/controller/ctlog/ctlog_hot_update_test.go
+++ b/internal/controller/ctlog/ctlog_hot_update_test.go
@@ -189,7 +189,7 @@ var _ = Describe("CTlog update test", func() {
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Private key has changed")
-			key, err := utils.CreatePrivateKey(nil)
+			key, err := utils.CreatePrivateKey()
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(suite.Client().Create(ctx, &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/ctlog/utils/ctlog_config.go
+++ b/internal/controller/ctlog/utils/ctlog_config.go
@@ -3,14 +3,11 @@ package utils
 import (
 	"bytes"
 	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 
 	"github.com/google/certificate-transparency-go/trillian/ctfe/configpb"
 	"github.com/google/trillian/crypto/keyspb"
-	"github.com/securesign/operator/internal/utils"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -140,30 +137,9 @@ func mustMarshalAny(pb proto.Message) *anypb.Any {
 
 func createConfigWithKeys(certConfig *KeyConfig) (*Config, error) {
 	config := &Config{
-		PubKey: certConfig.PublicKey,
-	}
-	if certConfig.PrivateKeyPass != nil {
-		config.PrivKeyPassword = certConfig.PrivateKeyPass
-		config.PrivKey = certConfig.PrivateKey
-	} else {
-		// private key MUST be encrypted by password
-		config.PrivKeyPassword = utils.GeneratePassword(8)
-		block, _ := pem.Decode(certConfig.PrivateKey)
-		if block == nil {
-			return nil, fmt.Errorf("failed to decode private key")
-		}
-		// Encrypt the pem
-		encryptedBlock, err := x509.EncryptPEMBlock(rand.Reader, block.Type, block.Bytes, config.PrivKeyPassword, x509.PEMCipherAES256) // nolint
-		if err != nil {
-			return nil, fmt.Errorf("failed to encrypt private key: %w", err)
-		}
-
-		privPEM := pem.EncodeToMemory(encryptedBlock)
-		if privPEM == nil {
-			return nil, fmt.Errorf("failed to encode encrypted private key")
-		}
-		config.PrivKey = privPEM
-
+		PubKey:          certConfig.PublicKey,
+		PrivKey:         certConfig.PrivateKey,
+		PrivKeyPassword: certConfig.PrivateKeyPass,
 	}
 	return config, nil
 }
@@ -192,7 +168,9 @@ func CreateCtlogConfig(trillianUrl string, treeID int64, rootCerts []RootCertifi
 		ConfigKey:  config,
 		PrivateKey: ctlogConfig.PrivKey,
 		PublicKey:  ctlogConfig.PubKey,
-		Password:   ctlogConfig.PrivKeyPassword,
+	}
+	if len(ctlogConfig.PrivKeyPassword) > 0 {
+		data[Password] = ctlogConfig.PrivKeyPassword
 	}
 	for i, cert := range ctlogConfig.RootCerts {
 		fulcioKey := fmt.Sprintf("fulcio-%d", i)

--- a/internal/controller/ctlog/utils/keys.go
+++ b/internal/controller/ctlog/utils/keys.go
@@ -20,15 +20,7 @@ type KeyConfig struct {
 	PublicKey      []byte
 }
 
-func (k KeyConfig) ToMap() map[string][]byte {
-	return map[string][]byte{
-		"private":  k.PrivateKey,
-		"public":   k.PublicKey,
-		"password": k.PrivateKeyPass,
-	}
-}
-
-func CreatePrivateKey(password []byte) (*KeyConfig, error) {
+func CreatePrivateKey() (*KeyConfig, error) {
 
 	key, err := ecdsa.GenerateKey(supportedCurves[curveType], rand.Reader)
 	if err != nil {
@@ -40,20 +32,11 @@ func CreatePrivateKey(password []byte) (*KeyConfig, error) {
 		return nil, err
 	}
 
-	var block *pem.Block
-	if len(password) > 0 {
-		block, err = x509.EncryptPEMBlock(rand.Reader, "EC PRIVATE KEY", mKey, password, x509.PEMCipherAES256) //nolint:staticcheck
-	} else {
-		block = &pem.Block{
-			Type:  "EC PRIVATE KEY",
-			Bytes: mKey,
-		}
-	}
-	if err != nil {
-		return nil, err
-	}
 	var pemKey bytes.Buffer
-	err = pem.Encode(&pemKey, block)
+	err = pem.Encode(&pemKey, &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: mKey,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -73,9 +56,8 @@ func CreatePrivateKey(password []byte) (*KeyConfig, error) {
 	}
 
 	return &KeyConfig{
-		PrivateKey:     pemKey.Bytes(),
-		PublicKey:      pemPubKey.Bytes(),
-		PrivateKeyPass: password,
+		PrivateKey: pemKey.Bytes(),
+		PublicKey:  pemPubKey.Bytes(),
 	}, nil
 }
 
@@ -90,6 +72,7 @@ func GeneratePublicKey(certConfig *KeyConfig) (*KeyConfig, error) {
 		return nil, fmt.Errorf("failed to decode private key")
 	}
 
+	// Deprecated: kept for backward compatibility with existing encrypted keys.
 	if x509.IsEncryptedPEMBlock(privatePEMBlock) { //nolint:staticcheck
 		if certConfig.PrivateKeyPass == nil {
 			return nil, fmt.Errorf("can't find private key password")

--- a/internal/controller/fulcio/actions/generate_cert.go
+++ b/internal/controller/fulcio/actions/generate_cert.go
@@ -16,7 +16,6 @@ import (
 	"github.com/securesign/operator/internal/controller/fulcio/utils"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
-	utils2 "github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -207,8 +206,6 @@ func (g handleCert) setupCert(instance *rhtasv1.Fulcio) (*utils.FulcioCertConfig
 			return nil, err
 		}
 		config.PrivateKeyPassword = password
-	} else if instance.Status.Certificate.PrivateKeyRef == nil {
-		config.PrivateKeyPassword = utils2.GeneratePassword(8)
 	}
 	if ref := instance.Status.Certificate.PrivateKeyRef; ref != nil {
 		key, err := kubernetes.GetSecretData(g.Client, instance.Namespace, ref)
@@ -222,7 +219,7 @@ func (g handleCert) setupCert(instance *rhtasv1.Fulcio) (*utils.FulcioCertConfig
 			return nil, err
 		}
 
-		pemKey, err := utils.CreateCAKey(key, config.PrivateKeyPassword)
+		pemKey, err := utils.CreateCAKey(key)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controller/fulcio/actions/generate_cert_test.go
+++ b/internal/controller/fulcio/actions/generate_cert_test.go
@@ -31,7 +31,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 	g := NewWithT(t)
 	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	g.Expect(err).ToNot(HaveOccurred())
-	pemKey, err := utils.CreateCAKey(key, nil)
+	pemKey, err := utils.CreateCAKey(key)
 	g.Expect(err).ToNot(HaveOccurred())
 	type env struct {
 		certSpec rhtasv1.FulcioCert
@@ -66,7 +66,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.OrganizationEmail).To(Equal("jdoe@redhat.com"))
 					g.Expect(fulcio.Certificate.OrganizationName).To(Equal("RH"))
-					g.Expect(fulcio.Certificate.PrivateKeyPasswordRef.Name).ToNot(BeEmpty())
+					g.Expect(fulcio.Certificate.PrivateKeyPasswordRef).To(BeNil())
 					g.Expect(fulcio.Certificate.PrivateKeyRef.Name).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.CARef.Name).ToNot(BeEmpty())
 

--- a/internal/controller/fulcio/actions/generate_cert_test.go
+++ b/internal/controller/fulcio/actions/generate_cert_test.go
@@ -66,7 +66,7 @@ func TestGenerateCert_Handle(t *testing.T) {
 					g.Expect(fulcio.Certificate.CommonName).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.OrganizationEmail).To(Equal("jdoe@redhat.com"))
 					g.Expect(fulcio.Certificate.OrganizationName).To(Equal("RH"))
-					g.Expect(fulcio.Certificate.PrivateKeyPasswordRef).To(BeNil())
+					g.Expect(fulcio.Certificate.PrivateKeyPasswordRef).To(BeNil()) //nolint:staticcheck
 					g.Expect(fulcio.Certificate.PrivateKeyRef.Name).ToNot(BeEmpty())
 					g.Expect(fulcio.Certificate.CARef.Name).ToNot(BeEmpty())
 

--- a/internal/controller/fulcio/utils/fulcio_secrets.go
+++ b/internal/controller/fulcio/utils/fulcio_secrets.go
@@ -43,19 +43,17 @@ func (c FulcioCertConfig) ToData() map[string][]byte {
 	return result
 }
 
-func CreateCAKey(key *ecdsa.PrivateKey, password []byte) ([]byte, error) {
+func CreateCAKey(key *ecdsa.PrivateKey) ([]byte, error) {
 	mKey, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
 		return nil, err
 	}
 
-	block, err := x509.EncryptPEMBlock(rand.Reader, "EC PRIVATE KEY", mKey, password, x509.PEMCipherAES256) //nolint:staticcheck
-	if err != nil {
-		return nil, err
-	}
-
 	var pemData bytes.Buffer
-	if err := pem.Encode(&pemData, block); err != nil {
+	if err := pem.Encode(&pemData, &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: mKey,
+	}); err != nil {
 		return nil, err
 	}
 
@@ -89,6 +87,7 @@ func CreateFulcioCA(config *FulcioCertConfig) ([]byte, error) {
 
 	block, _ := pem.Decode(config.PrivateKey)
 	keyBytes := block.Bytes
+	// Deprecated: kept for backward compatibility with existing encrypted keys from pre-FIPS operator versions.
 	if x509.IsEncryptedPEMBlock(block) { //nolint:staticcheck
 		keyBytes, err = x509.DecryptPEMBlock(block, config.PrivateKeyPassword) //nolint:staticcheck
 		if err != nil {

--- a/internal/controller/fulcio/utils/fulcio_secrets.go
+++ b/internal/controller/fulcio/utils/fulcio_secrets.go
@@ -86,6 +86,9 @@ func CreateFulcioCA(config *FulcioCertConfig) ([]byte, error) {
 	}
 
 	block, _ := pem.Decode(config.PrivateKey)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block from private key")
+	}
 	keyBytes := block.Bytes
 	// Deprecated: kept for backward compatibility with existing encrypted keys from pre-FIPS operator versions.
 	if x509.IsEncryptedPEMBlock(block) { //nolint:staticcheck

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -17,7 +17,6 @@ import (
 	tsaUtils "github.com/securesign/operator/internal/controller/tsa/utils"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
-	"github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	v1 "k8s.io/api/core/v1"
@@ -241,12 +240,11 @@ func (g generateSigner) handleSignerKeys(instance *rhtasv1.TimestampAuthority, c
 		}
 
 		if ref := instance.Spec.Signer.CertificateChain.CertificateChainRef; ref == nil {
-			config.RootPrivateKeyPassword = utils.GeneratePassword(8)
 			key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 			if err != nil {
 				return nil, err
 			}
-			rootCAPrivKey, err := tsaUtils.CreatePrivateKey(key, config.RootPrivateKeyPassword)
+			rootCAPrivKey, err := tsaUtils.CreatePrivateKey(key)
 			if err != nil {
 				return nil, err
 			}
@@ -270,12 +268,11 @@ func (g generateSigner) handleSignerKeys(instance *rhtasv1.TimestampAuthority, c
 					config.RootPrivateKeyPassword = password
 				}
 			} else {
-				config.RootPrivateKeyPassword = utils.GeneratePassword(8)
 				key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 				if err != nil {
 					return nil, err
 				}
-				rootCAPrivKey, err := tsaUtils.CreatePrivateKey(key, config.RootPrivateKeyPassword)
+				rootCAPrivKey, err := tsaUtils.CreatePrivateKey(key)
 				if err != nil {
 					return nil, err
 				}
@@ -283,7 +280,7 @@ func (g generateSigner) handleSignerKeys(instance *rhtasv1.TimestampAuthority, c
 			}
 		}
 
-		for index, intermediateCA := range instance.Spec.Signer.CertificateChain.IntermediateCA {
+		for _, intermediateCA := range instance.Spec.Signer.CertificateChain.IntermediateCA {
 			if ref := intermediateCA.PrivateKeyRef; ref != nil {
 				key, err := kubernetes.GetSecretData(g.Client, instance.Namespace, ref)
 				if err != nil {
@@ -301,12 +298,12 @@ func (g generateSigner) handleSignerKeys(instance *rhtasv1.TimestampAuthority, c
 					config.IntermediatePrivateKeyPasswords = append(config.IntermediatePrivateKeyPasswords, []byte(""))
 				}
 			} else {
-				config.IntermediatePrivateKeyPasswords = append(config.IntermediatePrivateKeyPasswords, utils.GeneratePassword(8))
+				config.IntermediatePrivateKeyPasswords = append(config.IntermediatePrivateKeyPasswords, nil)
 				key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 				if err != nil {
 					return nil, err
 				}
-				interCAPrivKey, err := tsaUtils.CreatePrivateKey(key, config.IntermediatePrivateKeyPasswords[index])
+				interCAPrivKey, err := tsaUtils.CreatePrivateKey(key)
 				if err != nil {
 					return nil, err
 				}
@@ -330,12 +327,11 @@ func (g generateSigner) handleSignerKeys(instance *rhtasv1.TimestampAuthority, c
 					config.LeafPrivateKeyPassword = password
 				}
 			} else {
-				config.LeafPrivateKeyPassword = utils.GeneratePassword(8)
 				key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 				if err != nil {
 					return nil, err
 				}
-				leafCAPrivKey, err := tsaUtils.CreatePrivateKey(key, config.LeafPrivateKeyPassword)
+				leafCAPrivKey, err := tsaUtils.CreatePrivateKey(key)
 				if err != nil {
 					return nil, err
 				}
@@ -388,15 +384,6 @@ func (g generateSigner) alignStatusFields(secretName string, instance *rhtasv1.T
 		if instance.Spec.Signer.File == nil || instance.Spec.Signer.File.PrivateKeyRef == nil {
 			instance.Status.Signer.File.PrivateKeyRef = &rhtasv1.SecretKeySelector{
 				Key: tsaUtils.KeyLeafPrivateKey,
-				LocalObjectReference: rhtasv1.LocalObjectReference{
-					Name: secretName,
-				},
-			}
-		}
-
-		if instance.Spec.Signer.File == nil || instance.Spec.Signer.File.PasswordRef == nil {
-			instance.Status.Signer.File.PasswordRef = &rhtasv1.SecretKeySelector{
-				Key: tsaUtils.KeyLeafPrivateKeyPassword,
 				LocalObjectReference: rhtasv1.LocalObjectReference{
 					Name: secretName,
 				},

--- a/internal/controller/tsa/actions/generate_signer_test.go
+++ b/internal/controller/tsa/actions/generate_signer_test.go
@@ -468,9 +468,10 @@ func Test_AlignStatusFields(t *testing.T) {
 	const userSecret = "user-signer-secret"
 
 	tests := []struct {
-		name     string
-		signer   rhtasv1.TimestampAuthoritySigner
-		testCase func(Gomega, *rhtasv1.TimestampAuthority)
+		name           string
+		signer         rhtasv1.TimestampAuthoritySigner
+		existingStatus *rhtasv1.TimestampAuthoritySigner
+		testCase       func(Gomega, *rhtasv1.TimestampAuthority)
 	}{
 		{
 			name: "default signer (no File, no ChainRef) — defaults to File-based",
@@ -488,7 +489,7 @@ func Test_AlignStatusFields(t *testing.T) {
 				g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef.Name).To(Equal("test-secret"))
 				g.Expect(instance.Status.Signer.File.PrivateKeyRef).NotTo(BeNil(), "PrivateKeyRef should be defaulted")
 				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Key).To(Equal("leafPrivateKey"))
-				g.Expect(instance.Status.Signer.File.PasswordRef).To(BeNil())
+				g.Expect(instance.Status.Signer.File.PasswordRef).To(BeNil()) //nolint:staticcheck
 			},
 		},
 		{
@@ -537,7 +538,42 @@ func Test_AlignStatusFields(t *testing.T) {
 			},
 			testCase: func(g Gomega, instance *rhtasv1.TimestampAuthority) {
 				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Name).To(Equal(userSecret), "should keep user-provided PrivateKeyRef")
-				g.Expect(instance.Status.Signer.File.PasswordRef).To(BeNil())
+				g.Expect(instance.Status.Signer.File.PasswordRef).To(BeNil()) //nolint:staticcheck
+			},
+		},
+		{
+			name: "upgrade from old operator — drops auto-generated PasswordRef",
+			signer: rhtasv1.TimestampAuthoritySigner{
+				CertificateChain: rhtasv1.CertificateChain{
+					RootCA:         &rhtasv1.TsaCertificateAuthority{OrganizationName: "Red Hat"},
+					IntermediateCA: []*rhtasv1.TsaCertificateAuthority{{OrganizationName: "Red Hat"}},
+					LeafCA:         &rhtasv1.TsaCertificateAuthority{OrganizationName: "Red Hat"},
+				},
+			},
+			existingStatus: &rhtasv1.TimestampAuthoritySigner{
+				CertificateChain: rhtasv1.CertificateChain{
+					CertificateChainRef: &rhtasv1.SecretKeySelector{
+						Key:                  "certificateChain",
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "old-secret"},
+					},
+				},
+				File: &rhtasv1.File{
+					PrivateKeyRef: &rhtasv1.SecretKeySelector{
+						Key:                  "leafPrivateKey",
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "old-secret"},
+					},
+					PasswordRef: &rhtasv1.SecretKeySelector{
+						Key:                  "leafPrivateKeyPassword",
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "old-secret"},
+					},
+				},
+			},
+			testCase: func(g Gomega, instance *rhtasv1.TimestampAuthority) {
+				g.Expect(instance.Status.Signer).NotTo(BeNil())
+				g.Expect(instance.Status.Signer.File).NotTo(BeNil(), "File should be defaulted on Status")
+				g.Expect(instance.Status.Signer.File.PrivateKeyRef).NotTo(BeNil(), "PrivateKeyRef should be defaulted")
+				g.Expect(instance.Status.Signer.File.PasswordRef).To(BeNil(), "PasswordRef from old operator should be dropped") //nolint:staticcheck
+				g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef.Name).To(Equal("test-secret"))
 			},
 		},
 		{
@@ -570,6 +606,9 @@ func Test_AlignStatusFields(t *testing.T) {
 				Spec: rhtasv1.TimestampAuthoritySpec{
 					Signer: tt.signer,
 				},
+			}
+			if tt.existingStatus != nil {
+				instance.Status.Signer = tt.existingStatus.DeepCopy()
 			}
 			a := generateSigner{}
 			a.alignStatusFields("test-secret", instance)

--- a/internal/controller/tsa/actions/generate_signer_test.go
+++ b/internal/controller/tsa/actions/generate_signer_test.go
@@ -186,7 +186,7 @@ func Test_SignerHandle(t *testing.T) {
 					},
 				}
 
-				secret := tsa.CreateSecrets(instance.Namespace, "tsa-test-secret")
+				secret := tsa.CreateSecrets(instance.Namespace, "tsa-test-secret", true)
 				return common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), secret)
 			},
 			testCase: func(g Gomega, a action.Action[*rhtasv1.TimestampAuthority], client client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
@@ -238,7 +238,7 @@ func Test_SignerHandle(t *testing.T) {
 						},
 					},
 				}
-				secret := tsa.CreateSecrets(instance.Namespace, "tsa-test-secret")
+				secret := tsa.CreateSecrets(instance.Namespace, "tsa-test-secret", true)
 				return common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), secret)
 			},
 			testCase: func(g Gomega, a action.Action[*rhtasv1.TimestampAuthority], client client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
@@ -309,8 +309,8 @@ func Test_SignerHandle(t *testing.T) {
 					},
 				}
 
-				secret := tsa.CreateSecrets(instance.Namespace, "tsa-test-secret")
-				old := tsa.CreateSecrets(instance.Namespace, "old")
+				secret := tsa.CreateSecrets(instance.Namespace, "tsa-test-secret", true)
+				old := tsa.CreateSecrets(instance.Namespace, "old", true)
 				old.Annotations = generateSecretAnnotations(*instance.Status.Signer)
 				return common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), secret, old)
 			},
@@ -378,7 +378,7 @@ func Test_SignerHandle(t *testing.T) {
 					},
 				}
 
-				old := tsa.CreateSecrets(instance.Namespace, "old")
+				old := tsa.CreateSecrets(instance.Namespace, "old", true)
 				old.Annotations = generateSecretAnnotations(*instance.Status.Signer)
 				return common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), old)
 			},
@@ -422,7 +422,7 @@ func Test_SignerHandle(t *testing.T) {
 					},
 				}
 
-				secret := tsa.CreateSecrets(instance.Namespace, "secret")
+				secret := tsa.CreateSecrets(instance.Namespace, "secret", true)
 				secret.Annotations = generateSecretAnnotations(instance.Spec.Signer)
 				secret.Labels = map[string]string{TSACertCALabel: "fake"}
 				return common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), secret)
@@ -488,8 +488,7 @@ func Test_AlignStatusFields(t *testing.T) {
 				g.Expect(instance.Status.Signer.CertificateChain.CertificateChainRef.Name).To(Equal("test-secret"))
 				g.Expect(instance.Status.Signer.File.PrivateKeyRef).NotTo(BeNil(), "PrivateKeyRef should be defaulted")
 				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Key).To(Equal("leafPrivateKey"))
-				g.Expect(instance.Status.Signer.File.PasswordRef).NotTo(BeNil(), "PasswordRef should be defaulted")
-				g.Expect(instance.Status.Signer.File.PasswordRef.Key).To(Equal("leafPrivateKeyPassword"))
+				g.Expect(instance.Status.Signer.File.PasswordRef).To(BeNil())
 			},
 		},
 		{
@@ -538,9 +537,7 @@ func Test_AlignStatusFields(t *testing.T) {
 			},
 			testCase: func(g Gomega, instance *rhtasv1.TimestampAuthority) {
 				g.Expect(instance.Status.Signer.File.PrivateKeyRef.Name).To(Equal(userSecret), "should keep user-provided PrivateKeyRef")
-				g.Expect(instance.Status.Signer.File.PasswordRef).NotTo(BeNil(), "should default missing PasswordRef")
-				g.Expect(instance.Status.Signer.File.PasswordRef.Key).To(Equal("leafPrivateKeyPassword"))
-				g.Expect(instance.Status.Signer.File.PasswordRef.Name).To(Equal("test-secret"))
+				g.Expect(instance.Status.Signer.File.PasswordRef).To(BeNil())
 			},
 		},
 		{
@@ -597,7 +594,7 @@ func Test_SignerHandle_KMS(t *testing.T) {
 		},
 	}
 
-	secret := tsa.CreateSecrets(instance.Namespace, "kms-secret")
+	secret := tsa.CreateSecrets(instance.Namespace, "kms-secret", true)
 	cli, act := common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), secret)
 	g.Expect(cli).NotTo(BeNil())
 	g.Expect(act).NotTo(BeNil())
@@ -629,7 +626,7 @@ func Test_SignerHandle_Tink(t *testing.T) {
 		},
 	}
 
-	secret := tsa.CreateSecrets(instance.Namespace, "tink-secret")
+	secret := tsa.CreateSecrets(instance.Namespace, "tink-secret", true)
 	cli, act := common.TsaTestSetup(instance, t, nil, NewGenerateSignerAction(), secret)
 	g.Expect(cli).NotTo(BeNil())
 	g.Expect(act).NotTo(BeNil())

--- a/internal/controller/tsa/tsa_hot_update_test.go
+++ b/internal/controller/tsa/tsa_hot_update_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			}).Should(Equal(state.Pending.String()))
 
 			By("Creating new certificate chain and signer keys")
-			secret := tsa.CreateSecrets(Namespace, "tsa-test-secret")
+			secret := tsa.CreateSecrets(Namespace, "tsa-test-secret", true)
 			Expect(suite.Client().Create(context.TODO(), secret)).NotTo(HaveOccurred())
 
 			By("Status field changed for cert chain")

--- a/internal/controller/tsa/utils/tsa_cert_chain.go
+++ b/internal/controller/tsa/utils/tsa_cert_chain.go
@@ -74,19 +74,17 @@ func (c TsaCertChainConfig) ToMap() map[string][]byte {
 	return result
 }
 
-func CreatePrivateKey(key *ecdsa.PrivateKey, password []byte) ([]byte, error) {
+func CreatePrivateKey(key *ecdsa.PrivateKey) ([]byte, error) {
 	mKey, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
 		return nil, err
 	}
 
-	block, err := x509.EncryptPEMBlock(rand.Reader, "EC PRIVATE KEY", mKey, password, x509.PEMCipherAES256) //nolint:staticcheck
-	if err != nil {
-		return nil, err
-	}
-
 	var pemData bytes.Buffer
-	if err := pem.Encode(&pemData, block); err != nil {
+	if err := pem.Encode(&pemData, &pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: mKey,
+	}); err != nil {
 		return nil, err
 	}
 
@@ -212,6 +210,7 @@ func parsePrivateKey(privateKeyPEM []byte, password []byte) (crypto.PrivateKey, 
 	}
 
 	keyBytes := block.Bytes
+	// Deprecated: kept for backward compatibility with existing encrypted keys.
 	if x509.IsEncryptedPEMBlock(block) { //nolint:staticcheck
 		keyBytes, err = x509.DecryptPEMBlock(block, password) //nolint:staticcheck
 		if err != nil {

--- a/test/e2e/common_install_test.go
+++ b/test/e2e/common_install_test.go
@@ -89,7 +89,6 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 						&matchers.HaveKeyMatcher{Key: "cert"},
 						&matchers.HaveKeyMatcher{Key: "private"},
 						&matchers.HaveKeyMatcher{Key: "public"},
-						&matchers.HaveKeyMatcher{Key: "password"},
 					)))
 		})
 
@@ -120,11 +119,8 @@ var _ = Describe("Securesign install with certificate generation", Ordered, func
 				WithTransform(func(secret *v1.Secret) map[string][]byte { return secret.Data },
 					And(
 						&matchers.HaveKeyMatcher{Key: "rootPrivateKey"},
-						&matchers.HaveKeyMatcher{Key: "rootPrivateKeyPassword"},
 						&matchers.HaveKeyMatcher{Key: "interPrivateKey-0"},
-						&matchers.HaveKeyMatcher{Key: "interPrivateKeyPassword-0"},
 						&matchers.HaveKeyMatcher{Key: "leafPrivateKey"},
-						&matchers.HaveKeyMatcher{Key: "leafPrivateKeyPassword"},
 						&matchers.HaveKeyMatcher{Key: "certificateChain"},
 					)))
 		})

--- a/test/e2e/key_autodiscovery_test.go
+++ b/test/e2e/key_autodiscovery_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Securesign key autodiscovery test", Ordered, func() {
 	BeforeAll(func(ctx SpecContext) {
 		s = securesign.Create(namespace.Name, "test",
 			securesign.WithDefaults(),
-			securesign.WithProvidedCerts(),
+			securesign.WithProvidedEncryptedCerts(),
 		)
 	})
 
@@ -45,10 +45,10 @@ var _ = Describe("Securesign key autodiscovery test", Ordered, func() {
 
 	Describe("Install with provided certificates", func() {
 		BeforeAll(func(ctx SpecContext) {
-			Expect(cli.Create(ctx, ctlog.CreateSecret(namespace.Name, "my-ctlog-secret", false))).To(Succeed())
-			Expect(cli.Create(ctx, fulcio.CreateSecret(namespace.Name, "my-fulcio-secret"))).To(Succeed())
-			Expect(cli.Create(ctx, rekor.CreateSecret(namespace.Name, "my-rekor-secret"))).To(Succeed())
-			Expect(cli.Create(ctx, tsa.CreateSecrets(namespace.Name, "test-tsa-secret"))).To(Succeed())
+			Expect(cli.Create(ctx, ctlog.CreateSecret(namespace.Name, "my-ctlog-secret", true))).To(Succeed())
+			Expect(cli.Create(ctx, fulcio.CreateSecret(namespace.Name, "my-fulcio-secret", true))).To(Succeed())
+			Expect(cli.Create(ctx, rekor.CreateSecret(namespace.Name, "my-rekor-secret", true))).To(Succeed())
+			Expect(cli.Create(ctx, tsa.CreateSecrets(namespace.Name, "test-tsa-secret", true))).To(Succeed())
 			Expect(cli.Create(ctx, s)).To(Succeed())
 		})
 

--- a/test/e2e/key_rotation_test.go
+++ b/test/e2e/key_rotation_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Key rotation test", Ordered, func() {
 
 		It("Update fulcio cert", func(ctx SpecContext) {
 			secretName := "new-fulcio-cert"
-			newFulcioCert = fulcio.CreateSecret(namespace.Name, secretName)
+			newFulcioCert = fulcio.CreateSecret(namespace.Name, secretName, true)
 			Expect(cli.Create(ctx, newFulcioCert)).To(Succeed())
 
 			Eventually(func() error {
@@ -213,7 +213,7 @@ var _ = Describe("Key rotation test", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			secretName := "new-rekor-signer"
-			newRekorSigner = rekor.CreateSecret(namespace.Name, secretName)
+			newRekorSigner = rekor.CreateSecret(namespace.Name, secretName, false)
 			Expect(cli.Create(ctx, newRekorSigner)).To(Succeed())
 
 			Eventually(func() error {
@@ -386,7 +386,7 @@ var _ = Describe("Key rotation test", Ordered, func() {
 
 		It("Update tsa cert", func(ctx SpecContext) {
 			secretName := "new-tsa-cert"
-			newTsaSecret = tsa.CreateSecrets(namespace.Name, secretName)
+			newTsaSecret = tsa.CreateSecrets(namespace.Name, secretName, true)
 			Expect(cli.Create(ctx, newTsaSecret)).To(Succeed())
 
 			Eventually(func() error {

--- a/test/e2e/namespaced.go
+++ b/test/e2e/namespaced.go
@@ -276,7 +276,7 @@ var _ = Describe("Install components to separate namespaces", Ordered, func() {
 		BeforeAll(func(ctx SpecContext) {
 			By("stores secrets into namespaces")
 			// Rekor
-			rekorSecret := rekor.CreateSecret(namespaces["rekor"].Name, "my-rekor-secret")
+			rekorSecret := rekor.CreateSecret(namespaces["rekor"].Name, "my-rekor-secret", false)
 
 			tufRekorSecret := rekorSecret.DeepCopy()
 			tufRekorSecret.Namespace = namespaces["tuf"].Name
@@ -285,7 +285,7 @@ var _ = Describe("Install components to separate namespaces", Ordered, func() {
 			Expect(cli.Create(ctx, tufRekorSecret)).To(Succeed())
 
 			// Fulcio
-			fulcioSecret := fulcio.CreateSecret(namespaces["fulcio"].Name, "my-fulcio-secret")
+			fulcioSecret := fulcio.CreateSecret(namespaces["fulcio"].Name, "my-fulcio-secret", true)
 
 			tufFulcioSecret := fulcioSecret.DeepCopy()
 			tufFulcioSecret.Namespace = namespaces["tuf"].Name
@@ -307,7 +307,7 @@ var _ = Describe("Install components to separate namespaces", Ordered, func() {
 			Expect(cli.Create(ctx, tufCtlogSecret)).To(Succeed())
 
 			// TSA
-			tsaSecret := tsa.CreateSecrets(namespaces["tsa"].Name, "test-tsa-secret")
+			tsaSecret := tsa.CreateSecrets(namespaces["tsa"].Name, "test-tsa-secret", true)
 
 			tufTSASecret := tsaSecret.DeepCopy()
 			tufTSASecret.Namespace = namespaces["tuf"].Name

--- a/test/e2e/provided_unencrypted_certs_test.go
+++ b/test/e2e/provided_unencrypted_certs_test.go
@@ -19,7 +19,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Securesign install with provided certs", Ordered, func() {
+var _ = Describe("Securesign install with provided unencrypted certs", Ordered, func() {
 	cli, _ := support.CreateClient()
 
 	var targetImageName string
@@ -33,7 +33,7 @@ var _ = Describe("Securesign install with provided certs", Ordered, func() {
 	BeforeAll(func(ctx SpecContext) {
 		s = securesign.Create(namespace.Name, "test",
 			securesign.WithDefaults(),
-			securesign.WithProvidedEncryptedCerts(),
+			securesign.WithProvidedUnencryptedCerts(),
 			func(v *rhtasv1.Securesign) {
 				v.Spec.Tuf.Keys = []rhtasv1.TufKey{
 					{
@@ -81,12 +81,12 @@ var _ = Describe("Securesign install with provided certs", Ordered, func() {
 		targetImageName = support.PrepareImage(ctx)
 	})
 
-	Describe("Install with provided certificates", func() {
+	Describe("Install with unencrypted certificates", func() {
 		BeforeAll(func(ctx SpecContext) {
-			Expect(cli.Create(ctx, ctlog.CreateSecret(namespace.Name, "my-ctlog-secret", true))).To(Succeed())
-			Expect(cli.Create(ctx, fulcio.CreateSecret(namespace.Name, "my-fulcio-secret", true))).To(Succeed())
-			Expect(cli.Create(ctx, rekor.CreateSecret(namespace.Name, "my-rekor-secret", true))).To(Succeed())
-			Expect(cli.Create(ctx, tsa.CreateSecrets(namespace.Name, "test-tsa-secret", true))).To(Succeed())
+			Expect(cli.Create(ctx, ctlog.CreateSecret(namespace.Name, "my-ctlog-secret", false))).To(Succeed())
+			Expect(cli.Create(ctx, fulcio.CreateSecret(namespace.Name, "my-fulcio-secret", false))).To(Succeed())
+			Expect(cli.Create(ctx, rekor.CreateSecret(namespace.Name, "my-rekor-secret", false))).To(Succeed())
+			Expect(cli.Create(ctx, tsa.CreateSecrets(namespace.Name, "test-tsa-secret", false))).To(Succeed())
 			Expect(cli.Create(ctx, s)).To(Succeed())
 		})
 

--- a/test/e2e/support/cert.go
+++ b/test/e2e/support/cert.go
@@ -26,7 +26,9 @@ func CreateCertificates(passwordProtected bool) ([]byte, []byte, []byte, error) 
 	}
 	var block *pem.Block
 	if passwordProtected {
-		block, err = x509.EncryptPEMBlock(rand.Reader, "EC PRIVATE KEY", privateKeyBytes, []byte(CertPassword), x509.PEMCipher3DES) //nolint:staticcheck
+		// Simulate a user-provided encrypted key — exercises the backward-compat
+		// DecryptPEMBlock/IsEncryptedPEMBlock path in production code.
+		block, err = x509.EncryptPEMBlock(rand.Reader, "EC PRIVATE KEY", privateKeyBytes, []byte(CertPassword), x509.PEMCipherAES256) //nolint:staticcheck
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/test/e2e/support/tas/fulcio/fulcio.go
+++ b/test/e2e/support/tas/fulcio/fulcio.go
@@ -52,21 +52,24 @@ func Get(ctx context.Context, cli client.Client, ns string, name string) *rhtasv
 	return instance
 }
 
-func CreateSecret(ns string, name string) *v1.Secret {
-	public, private, root, err := support.CreateCertificates(true)
+func CreateSecret(ns string, name string, passwordProtected bool) *v1.Secret {
+	public, private, root, err := support.CreateCertificates(passwordProtected)
 	if err != nil {
 		return nil
 	}
-	return &v1.Secret{
+	s := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
 		Data: map[string][]byte{
-			"password": []byte(support.CertPassword),
-			"private":  private,
-			"public":   public,
-			"cert":     root,
+			"private": private,
+			"public":  public,
+			"cert":    root,
 		},
 	}
+	if passwordProtected {
+		s.Data["password"] = []byte(support.CertPassword)
+	}
+	return s
 }

--- a/test/e2e/support/tas/rekor/rekor.go
+++ b/test/e2e/support/tas/rekor/rekor.go
@@ -60,12 +60,12 @@ func Get(ctx context.Context, cli client.Client, ns string, name string) *rhtasv
 	return instance
 }
 
-func CreateSecret(ns string, name string) *v1.Secret {
-	public, private, _, err := support.CreateCertificates(false)
+func CreateSecret(ns string, name string, passwordProtected bool) *v1.Secret {
+	public, private, _, err := support.CreateCertificates(passwordProtected)
 	if err != nil {
 		return nil
 	}
-	return &v1.Secret{
+	s := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
@@ -75,6 +75,10 @@ func CreateSecret(ns string, name string) *v1.Secret {
 			"public":  public,
 		},
 	}
+	if passwordProtected {
+		s.Data["password"] = []byte(support.CertPassword)
+	}
+	return s
 }
 
 func SetRekorReplicaCount(ctx context.Context, cli client.Client, namespace, securesignDeploymentName string, replicaCount int32) {

--- a/test/e2e/support/tas/securesign/securesign.go
+++ b/test/e2e/support/tas/securesign/securesign.go
@@ -165,7 +165,96 @@ func WithGeneratedCerts() Opts {
 	}
 }
 
-func WithProvidedCerts() Opts {
+func WithProvidedEncryptedCerts() Opts {
+	return func(s *rhtasv1.Securesign) {
+		s.Spec.Rekor.Signer = rhtasv1.RekorSigner{
+			KMS: "secret",
+			KeyRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{
+					Name: "my-rekor-secret",
+				},
+				Key: "private",
+			},
+			PasswordRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{
+					Name: "my-rekor-secret",
+				},
+				Key: "password",
+			},
+		}
+
+		s.Spec.Fulcio.Certificate = rhtasv1.FulcioCert{
+			PrivateKeyRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{
+					Name: "my-fulcio-secret",
+				},
+				Key: "private",
+			},
+			PrivateKeyPasswordRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{
+					Name: "my-fulcio-secret",
+				},
+				Key: "password",
+			},
+			CARef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{
+					Name: "my-fulcio-secret",
+				},
+				Key: "cert",
+			},
+		}
+
+		s.Spec.Ctlog.PrivateKeyRef = &rhtasv1.SecretKeySelector{
+			LocalObjectReference: rhtasv1.LocalObjectReference{
+				Name: "my-ctlog-secret",
+			},
+			Key: "private",
+		}
+		s.Spec.Ctlog.PrivateKeyPasswordRef = &rhtasv1.SecretKeySelector{
+			LocalObjectReference: rhtasv1.LocalObjectReference{
+				Name: "my-ctlog-secret",
+			},
+			Key: "password",
+		}
+		s.Spec.Ctlog.RootCertificates = []rhtasv1.SecretKeySelector{
+			{
+				LocalObjectReference: rhtasv1.LocalObjectReference{
+					Name: "my-fulcio-secret",
+				},
+				Key: "cert",
+			},
+		}
+
+		if s.Spec.TimestampAuthority != nil {
+			s.Spec.TimestampAuthority.Signer = rhtasv1.TimestampAuthoritySigner{
+				CertificateChain: rhtasv1.CertificateChain{
+					CertificateChainRef: &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{
+							Name: "test-tsa-secret",
+						},
+						Key: "certificateChain",
+					},
+				},
+				File: &rhtasv1.File{
+					PrivateKeyRef: &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{
+							Name: "test-tsa-secret",
+						},
+						Key: "leafPrivateKey",
+					},
+					PasswordRef: &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{
+							Name: "test-tsa-secret",
+						},
+						Key: "leafPrivateKeyPassword",
+					},
+				},
+			}
+		}
+	}
+}
+
+func WithProvidedUnencryptedCerts() Opts {
 	return func(s *rhtasv1.Securesign) {
 		s.Spec.Rekor.Signer = rhtasv1.RekorSigner{
 			KMS: "secret",
@@ -183,12 +272,6 @@ func WithProvidedCerts() Opts {
 					Name: "my-fulcio-secret",
 				},
 				Key: "private",
-			},
-			PrivateKeyPasswordRef: &rhtasv1.SecretKeySelector{
-				LocalObjectReference: rhtasv1.LocalObjectReference{
-					Name: "my-fulcio-secret",
-				},
-				Key: "password",
 			},
 			CARef: &rhtasv1.SecretKeySelector{
 				LocalObjectReference: rhtasv1.LocalObjectReference{
@@ -229,12 +312,6 @@ func WithProvidedCerts() Opts {
 							Name: "test-tsa-secret",
 						},
 						Key: "leafPrivateKey",
-					},
-					PasswordRef: &rhtasv1.SecretKeySelector{
-						LocalObjectReference: rhtasv1.LocalObjectReference{
-							Name: "test-tsa-secret",
-						},
-						Key: "leafPrivateKeyPassword",
 					},
 				},
 			}

--- a/test/e2e/support/tas/securesign/securesign.go
+++ b/test/e2e/support/tas/securesign/securesign.go
@@ -210,7 +210,7 @@ func WithProvidedEncryptedCerts() Opts {
 			},
 			Key: "private",
 		}
-		s.Spec.Ctlog.PrivateKeyPasswordRef = &rhtasv1.SecretKeySelector{
+		s.Spec.Ctlog.PrivateKeyPasswordRef = &rhtasv1.SecretKeySelector{ //nolint:staticcheck
 			LocalObjectReference: rhtasv1.LocalObjectReference{
 				Name: "my-ctlog-secret",
 			},

--- a/test/e2e/support/tas/tsa/tsa.go
+++ b/test/e2e/support/tas/tsa/tsa.go
@@ -98,26 +98,22 @@ func GetCertificateChain(ctx context.Context, url string) error {
 	return nil
 }
 
-func CreateSecrets(ns string, name string) *v1.Secret {
+func CreateSecrets(ns string, name string, passwordProtected bool) *v1.Secret {
 
-	config := &tsaUtils.TsaCertChainConfig{
-		RootPrivateKeyPassword:          []byte(support.CertPassword),
-		IntermediatePrivateKeyPasswords: [][]byte{[]byte(support.CertPassword)},
-		LeafPrivateKeyPassword:          []byte(support.CertPassword),
-	}
-	_, rootPrivateKey, rootCA, err := support.CreateCertificates(true)
+	config := &tsaUtils.TsaCertChainConfig{}
+	_, rootPrivateKey, rootCA, err := support.CreateCertificates(passwordProtected)
 	if err != nil {
 		return nil
 	}
 	config.RootPrivateKey = rootPrivateKey
 
-	intermediatePublicKey, intermediatePrivateKey, _, err := support.CreateCertificates(true)
+	intermediatePublicKey, intermediatePrivateKey, _, err := support.CreateCertificates(passwordProtected)
 	if err != nil {
 		return nil
 	}
 	config.IntermediatePrivateKeys = append(config.IntermediatePrivateKeys, intermediatePrivateKey)
 
-	leafPublicKey, leafPrivateKey, _, err := support.CreateCertificates(true)
+	leafPublicKey, leafPrivateKey, _, err := support.CreateCertificates(passwordProtected)
 	if err != nil {
 		return nil
 	}
@@ -125,21 +121,20 @@ func CreateSecrets(ns string, name string) *v1.Secret {
 
 	block, _ := pem.Decode(rootPrivateKey)
 	keyBytes := block.Bytes
+	// Decrypt the encrypted test key to use it for signing intermediate/leaf certs.
 	if x509.IsEncryptedPEMBlock(block) { //nolint:staticcheck
 		keyBytes, err = x509.DecryptPEMBlock(block, []byte(support.CertPassword)) //nolint:staticcheck
 		if err != nil {
 			return nil
 		}
 	}
-
 	rootPrivKey, err := x509.ParseECPrivateKey(keyBytes)
 	if err != nil {
 		return nil
 	}
 
 	block, _ = pem.Decode(intermediatePublicKey)
-	keyBytes = block.Bytes
-	interPubKey, err := x509.ParsePKIXPublicKey(keyBytes)
+	interPubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
 		return nil
 	}
@@ -156,8 +151,7 @@ func CreateSecrets(ns string, name string) *v1.Secret {
 	}
 
 	block, _ = pem.Decode(leafPublicKey)
-	keyBytes = block.Bytes
-	leafPuKey, err := x509.ParsePKIXPublicKey(keyBytes)
+	leafPuKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
 		return nil
 	}
@@ -180,21 +174,24 @@ func CreateSecrets(ns string, name string) *v1.Secret {
 	certificateChain = append(certificateChain, rootCA...)
 	config.CertificateChain = certificateChain
 
-	return &v1.Secret{
+	s := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
 		Data: map[string][]byte{
-			"rootPrivateKey":            config.RootPrivateKey,
-			"rootPrivateKeyPassword":    config.RootPrivateKeyPassword,
-			"interPrivateKey-0":         config.IntermediatePrivateKeys[0],
-			"interPrivateKeyPassword-0": config.IntermediatePrivateKeyPasswords[0],
-			"leafPrivateKey":            config.LeafPrivateKey,
-			"leafPrivateKeyPassword":    config.LeafPrivateKeyPassword,
-			"certificateChain":          config.CertificateChain,
+			"rootPrivateKey":    config.RootPrivateKey,
+			"interPrivateKey-0": config.IntermediatePrivateKeys[0],
+			"leafPrivateKey":    config.LeafPrivateKey,
+			"certificateChain":  config.CertificateChain,
 		},
 	}
+	if passwordProtected {
+		s.Data["rootPrivateKeyPassword"] = []byte(support.CertPassword)
+		s.Data["interPrivateKeyPassword-0"] = []byte(support.CertPassword)
+		s.Data["leafPrivateKeyPassword"] = []byte(support.CertPassword)
+	}
+	return s
 }
 
 func getCertTemplate(isCA bool) *x509.Certificate {

--- a/test/e2e/update/fulcio_test.go
+++ b/test/e2e/update/fulcio_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Fulcio update", Ordered, func() {
 		})
 
 		It("created my-fulcio-secret", func(ctx SpecContext) {
-			Expect(cli.Create(ctx, fulcio.CreateSecret(namespace.Name, "my-fulcio-secret"))).Should(Succeed())
+			Expect(cli.Create(ctx, fulcio.CreateSecret(namespace.Name, "my-fulcio-secret", true))).Should(Succeed())
 		})
 
 		It("has status ReadyCondition", func(ctx SpecContext) {

--- a/test/e2e/update/rekor_test.go
+++ b/test/e2e/update/rekor_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Rekor update", Ordered, func() {
 		})
 
 		It("created my-rekor-secret", func(ctx SpecContext) {
-			Expect(cli.Create(ctx, rekor.CreateSecret(namespace.Name, "my-rekor-secret"))).Should(Succeed())
+			Expect(cli.Create(ctx, rekor.CreateSecret(namespace.Name, "my-rekor-secret", false))).Should(Succeed())
 		})
 
 		It("has status Ready", func(ctx SpecContext) {

--- a/test/e2e/update/tsa_test.go
+++ b/test/e2e/update/tsa_test.go
@@ -116,7 +116,7 @@ var _ = Describe("TSA update", Ordered, func() {
 		})
 
 		It("created my-tsa-secret", func(ctx SpecContext) {
-			Expect(cli.Create(ctx, tsa.CreateSecrets(namespace.Name, "my-tsa-secret"))).Should(Succeed())
+			Expect(cli.Create(ctx, tsa.CreateSecrets(namespace.Name, "my-tsa-secret", true))).Should(Succeed())
 		})
 
 		It("has status ReadyCondition", func(ctx SpecContext) {


### PR DESCRIPTION
# Summary
- Remove x509.EncryptPEMBlock from all production code — auto-generated private keys (Fulcio, CTLog, TSA) are now stored as unencrypted PEM
- Retain x509.DecryptPEMBlock/x509.IsEncryptedPEMBlock in three backward-compatibility code paths so existing encrypted keys continue to work without migration
- Users can still provide both encrypted and unencrypted keys — fully backward compatible
- Add E2E test coverage for user-provided unencrypted keys alongside existing encrypted key tests

https://redhat.atlassian.net/browse/SECURESIGN-3617