### PR TITLE
chore: Update crdify to match OLM v1 check

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,29 +35,38 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: Install crdifi
+      - name: Install tools
         run: |
           go install sigs.k8s.io/crdify@v0.5.0
-      - name: Compare CTlog CRD
+          go install sigs.k8s.io/kustomize/kustomize/v5@v5.6.0
+      - name: Build kustomized CRDs
         run: |
-          crdify --config=crdify.yaml "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_ctlogs.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_ctlogs.yaml"
-      - name: Compare Fulcio CRD
+          BASE_REPO="${{ github.event.pull_request.base.repo.full_name }}"
+          HEAD_REPO="${{ github.event.pull_request.head.repo.full_name }}"
+          mkdir -p /tmp/crd-base /tmp/crd-head
+          kustomize build "https://github.com/${BASE_REPO}//config/crd?ref=${{ github.event.pull_request.base.sha }}" -o /tmp/crd-base/
+          kustomize build "https://github.com/${HEAD_REPO}//config/crd?ref=${{ github.event.pull_request.head.sha }}" -o /tmp/crd-head/
+      - name: Compare CRDs
         run: |
-          crdify --config=crdify.yaml "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_fulcios.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_fulcios.yaml"
-      - name: Compare Rekor CRD
-        run: |
-          crdify --config=crdify.yaml "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_rekors.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_rekors.yaml"
-      - name: Compare TSA CRD
-        run: |
-          crdify --config=crdify.yaml "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_timestampauthorities.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_timestampauthorities.yaml"
-      - name: Compare Trillian CRD
-        run: |
-          crdify --config=crdify.yaml "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_trillians.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_trillians.yaml"
-      - name: Compare TUF CRD
-        run: |
-          crdify --config=crdify.yaml "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_tufs.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_tufs.yaml"
-      - name: Compare Securesign CRD
-        run: |
-          crdify --config=crdify.yaml "git://${{ github.event.pull_request.base.sha }}?path=config/crd/bases/rhtas.redhat.com_securesigns.yaml" "git://${{ github.event.pull_request.head.sha }}?path=config/crd/bases/rhtas.redhat.com_securesigns.yaml"
+          FAILED=0
+          for crd in /tmp/crd-head/*_customresourcedefinition_*.yaml; do
+            NAME=$(basename "$crd")
+            echo "--- Comparing ${NAME} ---"
+            if [ ! -f "/tmp/crd-base/${NAME}" ]; then
+              echo "Skipping: not present in base (new CRD)"
+              continue
+            fi
+            if ! crdify --config=crdify.yaml "file:///tmp/crd-base/${NAME}" "file://${crd}"; then
+              FAILED=1
+            fi
+          done
+          for crd in /tmp/crd-base/*_customresourcedefinition_*.yaml; do
+            NAME=$(basename "$crd")
+            if [ ! -f "/tmp/crd-head/${NAME}" ]; then
+              echo "ERROR: CRD ${NAME} removed in head"
+              FAILED=1
+            fi
+          done
+          exit $FAILED
 
 

--- a/crdify.yaml
+++ b/crdify.yaml
@@ -1,3 +1,11 @@
+# Matches OLM v1 default configuration for CRD upgrade safety preflight checks.
+# Reference: https://github.com/operator-framework/operator-controller/blob/main/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety.go
+conversion: Ignore
+unhandledEnforcement: Error
 validations:
   - name: description
     enforcement: Warn
+  - name: enum
+    enforcement: Error
+    configuration:
+      additionPolicy: Allow


### PR DESCRIPTION
## Summary

Aligns the crdify CI configuration with [OLM v1 CRD upgrade safety defaults](https://github.com/operator-framework/operator-controller/blob/main/internal/operator-controller/rukpak/preflights/crdupgradesafety/crdupgradesafety.go) and switches the workflow to compare kustomized CRDs instead of raw bases.

### Changes

**`crdify.yaml`** — new config file matching OLM v1 defaults:
- `conversion: Ignore` — skip cross-version schema checks when a conversion webhook is present
- `unhandledEnforcement: Error` — fail-closed for unrecognized schema changes
- `description: Warn` — description changes don't block (OLM uses `None`, we use `Warn` for visibility)
- `enum: Error` with `additionPolicy: Allow` — new enum values are safe

**`.github/workflows/linter.yml`** — reworked crdify job:
- Builds kustomized CRDs via `kustomize build` from git refs instead of comparing raw base CRDs
- Kustomized output includes `spec.conversion.strategy: Webhook` from patches, so `conversion: Ignore` triggers correctly
- Uses `base.repo.full_name` for base SHA and `head.repo.full_name` for head SHA — works correctly for fork PRs
- Kustomize pinned to `v5.6.0` (matches Makefile) instead of `@latest`
- Single loop replaces 7 individual compare steps

### Why

The raw base CRDs (`config/crd/bases/`) don't contain the conversion webhook config — it's added by kustomize patches. Without it, crdify's `conversion: Ignore` policy can't trigger, causing false positives on cross-version schema differences that are handled by the webhook.

OLM at upgrade time always sees the webhook (injected by OLM itself), so its preflight checks pass. The CI should validate the same artifact shape.

## Test plan

- [x] Verified locally: `kustomize build config/crd -o /tmp/test/` produces CRDs with `spec.conversion.strategy: Webhook`
- [x] crdify passes with the new config against kustomized CRDs
- [ ] CI validates on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)