### PR TITLE
fix(test): add nil guards for FindStatusCondition in envtest assertions

### DIFF
--- a/internal/controller/ctlog/ctlog_controller_test.go
+++ b/internal/controller/ctlog/ctlog_controller_test.go
@@ -123,7 +123,9 @@ var _ = Describe("CTlog controller", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Creating.String()))
 
 			By("Creating fulcio root cert")
@@ -139,7 +141,9 @@ var _ = Describe("CTlog controller", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Creating.String()))
 
 			By("Key Secret is created")

--- a/internal/controller/fulcio/fulcio_controller_test.go
+++ b/internal/controller/fulcio/fulcio_controller_test.go
@@ -147,7 +147,9 @@ var _ = Describe("Fulcio controller", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Pending.String()))
 
 			By("Creating password secret with cert password")

--- a/internal/controller/fulcio/fulcio_hot_update_test.go
+++ b/internal/controller/fulcio/fulcio_hot_update_test.go
@@ -158,7 +158,9 @@ var _ = Describe("Fulcio hot update", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Pending.String()))
 
 			By("Creating password secret with cert password")
@@ -177,7 +179,9 @@ var _ = Describe("Fulcio hot update", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return found.Status.Certificate.PrivateKeyPasswordRef.Name
+				g.Expect(found.Status.Certificate).ToNot(BeNil())
+				g.Expect(found.Status.Certificate.PrivateKeyPasswordRef).ToNot(BeNil()) //nolint:staticcheck
+				return found.Status.Certificate.PrivateKeyPasswordRef.Name              //nolint:staticcheck
 			}).Should(Equal("password-secret"))
 
 			Eventually(func(g Gomega) bool {

--- a/internal/controller/rekor/rekor_attestation_test.go
+++ b/internal/controller/rekor/rekor_attestation_test.go
@@ -263,7 +263,9 @@ func deployAndVerify(ctx context.Context, instance *rhtasv1.Rekor) {
 	Eventually(func(g Gomega) string {
 		found := &rhtasv1.Rekor{}
 		g.Expect(suite.Client().Get(ctx, client.ObjectKeyFromObject(instance), found)).Should(Succeed())
-		return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+		cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+		g.Expect(cond).ToNot(BeNil())
+		return cond.Reason
 	}).Should(Equal(state.Initialize.String()))
 
 	By("Move to Ready phase")

--- a/internal/controller/rekor/rekor_controller_test.go
+++ b/internal/controller/rekor/rekor_controller_test.go
@@ -212,7 +212,9 @@ var _ = Describe("Rekor controller", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Initialize.String()))
 
 			By("Move to Ready phase")

--- a/internal/controller/rekor/rekor_hot_update_test.go
+++ b/internal/controller/rekor/rekor_hot_update_test.go
@@ -161,8 +161,10 @@ var _ = Describe("Rekor hot update test", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				g.Expect(meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, constants.ReadyCondition, metav1.ConditionFalse)).Should(BeTrue())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				return cond.Reason
 			}).Should(Equal(state.Initialize.String()))
 
 			By("Move to Ready phase")

--- a/internal/controller/trillian/trillian_controller_test.go
+++ b/internal/controller/trillian/trillian_controller_test.go
@@ -161,7 +161,9 @@ var _ = Describe("Trillian controller", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.Trillian{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Initialize.String()))
 
 			By("Move to Ready phase")

--- a/internal/controller/tsa/actions/ntpMonitoring_test.go
+++ b/internal/controller/tsa/actions/ntpMonitoring_test.go
@@ -147,7 +147,9 @@ func Test_NTPHandle(t *testing.T) {
 
 				g.Expect(instance.Status.NTPMonitoring.Config.NtpConfigRef.Name).To(Equal(cm.Name), "Config Map name mismatch")
 
-				g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Message).To(Equal("NTP monitoring configured"))
+				cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Message).To(Equal("NTP monitoring configured"))
 
 				return true
 			},
@@ -185,7 +187,9 @@ func Test_NTPHandle(t *testing.T) {
 				err := client.Get(context.TODO(), types.NamespacedName{Name: instance.Status.NTPMonitoring.Config.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
 				g.Expect(err).NotTo(HaveOccurred(), "Unable to find config map")
 
-				g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Message).To(Equal("NTP monitoring configured"))
+				cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Message).To(Equal("NTP monitoring configured"))
 
 				return true
 			},
@@ -219,7 +223,9 @@ func Test_NTPHandle(t *testing.T) {
 
 				g.Expect(instance.Spec.NTPMonitoring.Config.NumServers).To(Equal(2), "NumServers mismatch")
 
-				g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Message).To(Equal("NTP monitoring configured"))
+				cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Message).To(Equal("NTP monitoring configured"))
 
 				return true
 			},
@@ -253,7 +259,9 @@ func Test_NTPHandle(t *testing.T) {
 				err = cli.Get(context.TODO(), types.NamespacedName{Name: oldConfigMapName, Namespace: instance.GetNamespace()}, &corev1.ConfigMap{})
 				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "Old ConfigMap should be deleted")
 
-				g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Message).To(Equal("NTP monitoring configured"))
+				cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Message).To(Equal("NTP monitoring configured"))
 
 				return true
 			},
@@ -277,7 +285,9 @@ func Test_NTPHandle(t *testing.T) {
 				g.Expect(cli.List(context.TODO(), list, &client.ListOptions{LabelSelector: apilabels.SelectorFromSet(l)})).To(Succeed())
 				g.Expect(list.Items).To(BeEmpty(), "List should be empty")
 
-				g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Message).To(Equal("NTP monitoring configured"))
+				cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Message).To(Equal("NTP monitoring configured"))
 				return true
 			},
 		},

--- a/internal/controller/tsa/timestampauthority_controller_test.go
+++ b/internal/controller/tsa/timestampauthority_controller_test.go
@@ -169,13 +169,17 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			By("Should be in a creating phase")
 			Eventually(func(g Gomega) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Creating.String()))
 
 			By("NTP monitoring should be resolved")
 			Eventually(func(g Gomega) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Message
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Message
 			}).Should(Equal("Waiting for deployment to be ready"))
 
 			By("NTP monitoring config should be created")

--- a/internal/controller/tsa/tsa_hot_update_test.go
+++ b/internal/controller/tsa/tsa_hot_update_test.go
@@ -184,7 +184,9 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			By("Pending phase until new keys and certs are resolved")
 			Eventually(func(g Gomega) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Pending.String()))
 
 			By("Creating new certificate chain and signer keys")
@@ -243,7 +245,9 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			By("NTP monitoring should be resolved")
 			Eventually(func(g Gomega) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Message
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Message
 			}).Should(Equal("Waiting for deployment to be ready"))
 
 			By("Timestamp Authority deployment is updated")

--- a/internal/controller/tuf/actions/migration_job_test.go
+++ b/internal/controller/tuf/actions/migration_job_test.go
@@ -96,8 +96,10 @@ func TestMigrateJob_NoRootKeySecret(t *testing.T) {
 	g.Expect(result.Err).To(HaveOccurred())
 	g.Expect(result.Err).To(MatchError(ContainSubstring("cannot migrate TUF: root key secret test-secret not found")))
 
-	g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Reason).To(Equal(state.Failure.String()))
-	g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Message).To(ContainSubstring("cannot migrate TUF: root key secret test-secret not found"))
+	cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+	g.Expect(cond).ToNot(BeNil())
+	g.Expect(cond.Reason).To(Equal(state.Failure.String()))
+	g.Expect(cond.Message).To(ContainSubstring("cannot migrate TUF: root key secret test-secret not found"))
 }
 
 func TestMigrateJob_Succeeded(t *testing.T) {
@@ -265,8 +267,10 @@ func TestMigrateJob_Failed(t *testing.T) {
 	g.Expect(result.Err).To(HaveOccurred())
 	g.Expect(result.Err).To(MatchError(ContainSubstring("tuf-repository-migration job failed")))
 
-	g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Reason).To(Equal(state.Failure.String()))
-	g.Expect(meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition).Message).To(ContainSubstring("tuf-repository-migration job failed"))
+	cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+	g.Expect(cond).ToNot(BeNil())
+	g.Expect(cond.Reason).To(Equal(state.Failure.String()))
+	g.Expect(cond.Message).To(ContainSubstring("tuf-repository-migration job failed"))
 
 	found := &rhtasv1.Tuf{}
 	g.Expect(migrateJobTestAction.Client.Get(t.Context(), client.ObjectKeyFromObject(instance), found)).To(Succeed())

--- a/internal/controller/tuf/tuf_controller_test.go
+++ b/internal/controller/tuf/tuf_controller_test.go
@@ -153,7 +153,9 @@ var _ = Describe("TUF controller", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.Tuf{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Pending.String()))
 
 			By("Creating ctlog secret with public key")
@@ -287,7 +289,9 @@ var _ = Describe("TUF controller", func() {
 			Eventually(func(g Gomega) string {
 				found := &rhtasv1.Tuf{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-				return meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition).Reason
+				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				return cond.Reason
 			}).Should(Equal(state.Initialize.String()))
 
 			deployment := &appsv1.Deployment{}


### PR DESCRIPTION
## Summary
- Add nil guards before dereferencing `meta.FindStatusCondition()` return values in `Eventually` pollers and direct assertions across all controller tests
- Fixes flaky test panics caused by nil pointer dereference when the reconciler hasn't yet set status conditions during envtest polling
- Observed panic in `fulcio_hot_update_test.go:180` on PR #1930 CI (Build-operator job)

## Changes
- **12 test files** across ctlog, fulcio, rekor, trillian, tsa, and tuf controllers
- Pattern: `FindStatusCondition(...).Reason` → extract to local `cond` variable, assert non-nil, then access `.Reason`/`.Message`
- No production code changes

## Test plan
- [x] All 8 affected controller test packages pass locally
- [x] Linter passes clean (0 issues)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)