### PR TITLE
fix: remove TerminalError from transient API server errors

### DIFF
--- a/internal/action/rbac/action.go
+++ b/internal/action/rbac/action.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func WithRule[T apis.ConditionsAwareObject](rule rbacv1.PolicyRule) func(action2 *rbacAction[T]) {
@@ -104,7 +103,7 @@ func (i rbacAction[T]) handleServiceAccount(ctx context.Context, instance T) *ac
 		ensure.ControllerReference[*v1.ServiceAccount](instance, i.Client),
 		ensure.Labels[*v1.ServiceAccount](slices.Collect(maps.Keys(l)), l),
 	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create SA: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create SA: %w", err), instance)
 	}
 
 	return i.Continue()
@@ -136,7 +135,7 @@ func (i rbacAction[T]) handleRole(ctx context.Context, instance T) *action.Resul
 		ensure.Labels[*rbacv1.Role](slices.Collect(maps.Keys(l)), l),
 		kubernetes.EnsureRoleRules(i.rules...),
 	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create Role: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create Role: %w", err), instance)
 	}
 
 	return i.Continue()
@@ -175,7 +174,7 @@ func (i rbacAction[T]) handleRoleBinding(ctx context.Context, instance T) *actio
 			rbacv1.Subject{Kind: "ServiceAccount", Name: i.rbacName, Namespace: instance.GetNamespace()},
 		),
 	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create RoleBinding: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create RoleBinding: %w", err), instance)
 	}
 
 	return i.Continue()

--- a/internal/action/rbac/action_test.go
+++ b/internal/action/rbac/action_test.go
@@ -2,6 +2,8 @@ package rbac
 
 import (
 	"context"
+	stderrors "errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
 	testAction "github.com/securesign/operator/internal/testing/action"
+
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -18,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 type namedTest struct {
@@ -611,6 +616,99 @@ func TestRbac_Handle(t *testing.T) {
 	for _, nt := range tests {
 		t.Run(nt.name, func(t *testing.T) {
 			nt.run(t)
+		})
+	}
+}
+
+func TestRbac_CreationFailure_ReturnsRetryableError(t *testing.T) {
+	injectedErr := fmt.Errorf("connection refused")
+
+	for _, tc := range []struct {
+		name      string
+		intercept interceptor.Funcs
+		handleFn  func(*rbacAction[*v1alpha1.Rekor], context.Context, *v1alpha1.Rekor) *action.Result
+		errSubstr string
+	}{
+		{
+			name: "ServiceAccount creation failure is retryable",
+			intercept: interceptor.Funcs{
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if _, ok := obj.(*corev1.ServiceAccount); ok {
+						return injectedErr
+					}
+					return c.Create(ctx, obj, opts...)
+				},
+			},
+			handleFn: func(r *rbacAction[*v1alpha1.Rekor], ctx context.Context, rekor *v1alpha1.Rekor) *action.Result {
+				return r.handleServiceAccount(ctx, rekor)
+			},
+			errSubstr: "could not create SA",
+		},
+		{
+			name: "Role creation failure is retryable",
+			intercept: interceptor.Funcs{
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if _, ok := obj.(*rbacv1.Role); ok {
+						return injectedErr
+					}
+					return c.Create(ctx, obj, opts...)
+				},
+			},
+			handleFn: func(r *rbacAction[*v1alpha1.Rekor], ctx context.Context, rekor *v1alpha1.Rekor) *action.Result {
+				return r.handleRole(ctx, rekor)
+			},
+			errSubstr: "could not create Role",
+		},
+		{
+			name: "RoleBinding creation failure is retryable",
+			intercept: interceptor.Funcs{
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if _, ok := obj.(*rbacv1.RoleBinding); ok {
+						return injectedErr
+					}
+					return c.Create(ctx, obj, opts...)
+				},
+			},
+			handleFn: func(r *rbacAction[*v1alpha1.Rekor], ctx context.Context, rekor *v1alpha1.Rekor) *action.Result {
+				return r.handleRoleBinding(ctx, rekor)
+			},
+			errSubstr: "could not create RoleBinding",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := context.Background()
+
+			instance := &v1alpha1.Rekor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nnObject.Name,
+					Namespace: nnObject.Namespace,
+				},
+			}
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				WithInterceptorFuncs(tc.intercept).
+				Build()
+
+			a := testAction.PrepareAction(c, NewAction[*v1alpha1.Rekor]("component", nnObject.Name,
+				WithRule[*v1alpha1.Rekor](rbacv1.PolicyRule{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs:     []string{"list"},
+				}),
+			))
+			ra := a.(*rbacAction[*v1alpha1.Rekor])
+
+			g.Expect(c.Get(ctx, nnObject, instance)).To(Succeed())
+
+			result := tc.handleFn(ra, ctx, instance)
+			g.Expect(result).ToNot(BeNil())
+			g.Expect(result.Err).To(HaveOccurred())
+			g.Expect(result.Err.Error()).To(ContainSubstring(tc.errSubstr))
+			g.Expect(stderrors.Is(result.Err, reconcile.TerminalError(nil))).To(BeFalse(),
+				"API server errors must be retryable, not terminal")
 		})
 	}
 }

--- a/internal/action/tree/action.go
+++ b/internal/action/tree/action.go
@@ -109,7 +109,7 @@ func (i resolveTree[T]) handleRbac(ctx context.Context, instance T) *action.Resu
 		ensure.ControllerReference[*corev1.ServiceAccount](instance, i.Client),
 		ensure.Labels[*corev1.ServiceAccount](slices.Collect(maps.Keys(labels)), labels),
 	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create SA: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create SA: %w", err), instance)
 	}
 
 	// Role
@@ -128,7 +128,7 @@ func (i resolveTree[T]) handleRbac(ctx context.Context, instance T) *action.Resu
 				Verbs:     []string{"patch"},
 			}),
 	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create Role: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create Role: %w", err), instance)
 	}
 
 	// RoleBinding
@@ -149,7 +149,7 @@ func (i resolveTree[T]) handleRbac(ctx context.Context, instance T) *action.Resu
 			rbacv1.Subject{Kind: "ServiceAccount", Name: rbacName, Namespace: instance.GetNamespace()},
 		),
 	); err != nil {
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create RoleBinding: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create RoleBinding: %w", err), instance)
 	}
 
 	return i.Continue()
@@ -205,7 +205,7 @@ func (i resolveTree[T]) handleJob(ctx context.Context, instance T) *action.Resul
 		if apierrors.IsNotFound(err) {
 			return i.Requeue()
 		}
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not get configmap: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not get configmap: %w", err), instance)
 	}
 
 	for _, ref := range configMap.GetOwnerReferences() {
@@ -303,7 +303,7 @@ func (i resolveTree[T]) handleJobFinished(ctx context.Context, instance T) *acti
 		if apierrors.IsNotFound(err) {
 			return i.Requeue()
 		}
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not get configmap: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not get configmap: %w", err), instance)
 	}
 
 	for _, ref := range configMap.GetOwnerReferences() {
@@ -352,7 +352,7 @@ func (i resolveTree[T]) handleExtractJobResult(ctx context.Context, instance T) 
 		if apierrors.IsNotFound(err) {
 			return i.Requeue()
 		}
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not get configmap: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not get configmap: %w", err), instance)
 	}
 
 	if result, ok := configMap.Data[configMapResultField]; ok && result != "" {

--- a/internal/action/tree/action_test.go
+++ b/internal/action/tree/action_test.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -18,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/securesign/operator/api/v1alpha1"
@@ -685,4 +687,106 @@ func TestResolveTree_Handle(t *testing.T) {
 			nt.run(t)
 		})
 	}
+}
+
+func TestResolveTree_ConfigMapGetFailure_ReturnsRetryableError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	instance := &v1alpha1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nnObject.Name,
+			Namespace: nnObject.Namespace,
+		},
+		Spec: v1alpha1.RekorSpec{
+			Trillian: v1alpha1.TrillianService{
+				Address: "trillian-logserver",
+				Port:    ptr.To(int32(8091)),
+			},
+		},
+	}
+
+	injectedErr := fmt.Errorf("connection refused")
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.ConfigMap); ok {
+					return injectedErr
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testAction.PrepareAction(c, NewResolveTreeAction("test", defaultWrapper))
+	ra := a.(*resolveTree[*v1alpha1.Rekor])
+
+	g.Expect(c.Get(ctx, nnObject, instance)).To(Succeed())
+
+	for _, tc := range []struct {
+		name     string
+		handleFn func(context.Context, *v1alpha1.Rekor) *action.Result
+	}{
+		{name: "handleJob", handleFn: ra.handleJob},
+		{name: "handleJobFinished", handleFn: ra.handleJobFinished},
+		{name: "handleExtractJobResult", handleFn: ra.handleExtractJobResult},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := tc.handleFn(ctx, instance)
+			g.Expect(result).ToNot(BeNil())
+			g.Expect(result.Err).To(HaveOccurred())
+			g.Expect(result.Err.Error()).To(ContainSubstring("could not get configmap"))
+			g.Expect(stderrors.Is(result.Err, reconcile.TerminalError(nil))).To(BeFalse(),
+				"ConfigMap Get errors must be retryable, not terminal")
+		})
+	}
+}
+
+func TestResolveTree_RbacCreationFailure_ReturnsRetryableError(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	instance := &v1alpha1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nnObject.Name,
+			Namespace: nnObject.Namespace,
+		},
+		Spec: v1alpha1.RekorSpec{
+			Trillian: v1alpha1.TrillianService{
+				Address: "trillian-logserver",
+				Port:    ptr.To(int32(8091)),
+			},
+		},
+	}
+
+	injectedErr := fmt.Errorf("connection refused")
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*corev1.ServiceAccount); ok {
+					return injectedErr
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testAction.PrepareAction(c, NewResolveTreeAction("test", defaultWrapper))
+	ra := a.(*resolveTree[*v1alpha1.Rekor])
+
+	g.Expect(c.Get(ctx, nnObject, instance)).To(Succeed())
+
+	result := ra.handleRbac(ctx, instance)
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).To(HaveOccurred())
+	g.Expect(result.Err.Error()).To(ContainSubstring("could not create SA"))
+	g.Expect(stderrors.Is(result.Err, reconcile.TerminalError(nil))).To(BeFalse(),
+		"API server errors must be retryable, not terminal")
 }

--- a/internal/controller/securesign/actions/segment_rbac.go
+++ b/internal/controller/securesign/actions/segment_rbac.go
@@ -13,7 +13,6 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
@@ -77,7 +76,7 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesi
 			Reason:  constants.Failure,
 			Message: err.Error(),
 		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create SA: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create SA: %w", err), instance)
 	}
 
 	// Role
@@ -109,7 +108,7 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesi
 			Reason:  constants.Failure,
 			Message: err.Error(),
 		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create openshift-monitoring role for SBJ: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create openshift-monitoring role for SBJ: %w", err), instance)
 	}
 
 	// RoleBinding
@@ -135,7 +134,7 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesi
 			Reason:  constants.Failure,
 			Message: err.Error(),
 		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create openshift-monitoring role binding for SBJ: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create openshift-monitoring role binding for SBJ: %w", err), instance)
 	}
 
 	// ClusterRoleBinding
@@ -160,7 +159,7 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesi
 			Reason:  constants.Failure,
 			Message: err.Error(),
 		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create monitoring ClusterRoleBinding for SBJ: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create monitoring ClusterRoleBinding for SBJ: %w", err), instance)
 	}
 
 	// ClusterRole
@@ -191,7 +190,7 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesi
 			Reason:  constants.Failure,
 			Message: err.Error(),
 		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create openshift-console ClusterRole for SBJ: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create openshift-console ClusterRole for SBJ: %w", err), instance)
 	}
 
 	// ClusterRoleBinding
@@ -216,7 +215,7 @@ func (i rbacAction) Handle(ctx context.Context, instance *rhtasv1alpha1.Securesi
 			Reason:  constants.Failure,
 			Message: err.Error(),
 		})
-		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not create openshift-console ClusterRoleBinding for SBJ: %w", err)), instance)
+		return i.Error(ctx, fmt.Errorf("could not create openshift-console ClusterRoleBinding for SBJ: %w", err), instance)
 	}
 
 	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{


### PR DESCRIPTION
Backport of #1930 to release-1.3.

## Summary
- Remove `TerminalError` wrapping from transient API server errors so the reconciler can retry them
- Affects 9 call sites in `rbac/action.go` and `tree/action.go` (SA/Role/RoleBinding creation, ConfigMap Get)
- Keeps `TerminalError` at sites where errors are truly unrecoverable (invalid config, exhausted job retries, data corruption)

Ref: SECURESIGN-4664

🤖 Generated with [Claude Code](https://claude.com/claude-code)