### PR TITLE
refactor!: remove CommonName from FulcioCertStatus

### DIFF
--- a/api/v1/fulcio_types.go
+++ b/api/v1/fulcio_types.go
@@ -181,8 +181,6 @@ type FulcioCertStatus struct {
 	PrivateKeyRef         *SecretKeySelector `json:"privateKeyRef,omitempty"`
 	PrivateKeyPasswordRef *SecretKeySelector `json:"privateKeyPasswordRef,omitempty"`
 	CARef                 *SecretKeySelector `json:"caRef,omitempty"`
-	// CommonName is cached to survive cluster restore — re-resolving from route could yield a different hostname.
-	CommonName string `json:"commonName,omitempty"`
 }
 
 // FulcioStatus defines the observed state of Fulcio

--- a/api/v1alpha1/conversion_roundtrip_test.go
+++ b/api/v1alpha1/conversion_roundtrip_test.go
@@ -141,7 +141,6 @@ func TestFulcioConversion(t *testing.T) {
 							c.FillNoCustom(&s.Certificate.PrivateKeyRef)
 							c.FillNoCustom(&s.Certificate.PrivateKeyPasswordRef)
 							c.FillNoCustom(&s.Certificate.CARef)
-							c.FillNoCustom(&s.Certificate.CommonName)
 						}
 					},
 				}

--- a/api/v1alpha1/conversion_unit_test.go
+++ b/api/v1alpha1/conversion_unit_test.go
@@ -489,7 +489,6 @@ func TestFulcioConversionUnit(t *testing.T) {
 						PrivateKeyRef:         &rhtasv1.SecretKeySelector{LocalObjectReference: rhtasv1.LocalObjectReference{Name: "fulcio-keys"}, Key: "private"},
 						PrivateKeyPasswordRef: &rhtasv1.SecretKeySelector{LocalObjectReference: rhtasv1.LocalObjectReference{Name: "fulcio-keys"}, Key: "password"},
 						CARef:                 &rhtasv1.SecretKeySelector{LocalObjectReference: rhtasv1.LocalObjectReference{Name: "fulcio-keys"}, Key: "cert"},
-						CommonName:            "fulcio.apps.cluster.example.com",
 					},
 					Conditions: []metav1.Condition{
 						{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Deployed", Message: "all good"},
@@ -505,7 +504,6 @@ func TestFulcioConversionUnit(t *testing.T) {
 						PrivateKeyRef:         &SecretKeySelector{LocalObjectReference: LocalObjectReference{Name: "fulcio-keys"}, Key: "private"},
 						PrivateKeyPasswordRef: &SecretKeySelector{LocalObjectReference: LocalObjectReference{Name: "fulcio-keys"}, Key: "password"},
 						CARef:                 &SecretKeySelector{LocalObjectReference: LocalObjectReference{Name: "fulcio-keys"}, Key: "cert"},
-						CommonName:            "fulcio.apps.cluster.example.com",
 					},
 					Conditions: []metav1.Condition{
 						{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Deployed", Message: "all good"},

--- a/api/v1alpha1/fulcio_conversion.go
+++ b/api/v1alpha1/fulcio_conversion.go
@@ -26,7 +26,6 @@ func Convert_v1alpha1_FulcioCert_To_v1_FulcioCertStatus(in *FulcioCert, out *rht
 			return err
 		}
 	}
-	out.CommonName = in.CommonName
 	return nil
 }
 
@@ -49,7 +48,6 @@ func Convert_v1_FulcioCertStatus_To_v1alpha1_FulcioCert(in *rhtasv1.FulcioCertSt
 			return err
 		}
 	}
-	out.CommonName = in.CommonName
 	return nil
 }
 

--- a/config/crd/bases/rhtas.redhat.com_fulcios.yaml
+++ b/config/crd/bases/rhtas.redhat.com_fulcios.yaml
@@ -1462,10 +1462,6 @@ spec:
                     - name
                     type: object
                     x-kubernetes-map-type: atomic
-                  commonName:
-                    description: CommonName is cached to survive cluster restore —
-                      re-resolving from route could yield a different hostname.
-                    type: string
                   privateKeyPasswordRef:
                     description: SecretKeySelector selects a key of a Secret.
                     properties:


### PR DESCRIPTION
## Summary

Removes `CommonName` from `FulcioCertStatus` in the v1 API. This field was cached in status to survive cluster restore, but the cert is generated once and stored in an immutable secret — re-resolving CommonName has no effect since the cert is never regenerated.

All usage was already removed from the signer action in #1963.

Depends on #1963 (generic signer secret action).

SECURESIGN-4794

🤖 Generated with [Claude Code](https://claude.com/claude-code)