### PR TITLE
  fix(backport-1.4): add retry logic to platform discovery to handle …

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"crypto/tls"
 	"flag"
 	"os"
+	"time"
 
 	appconfig "github.com/securesign/operator/internal/config"
 	"github.com/securesign/operator/internal/constants"
@@ -109,6 +110,7 @@ func main() {
 	flag.Int64Var(&appconfig.CreateTreeDeadline, "create-tree-deadline", appconfig.CreateTreeDeadline, "The time allowance (in seconds) for the create tree job to run before failing.")
 	utils.BoolFlagOrEnv(&appconfig.Openshift, "openshift", "OPENSHIFT", false, "Enable to ensures the operator applies OpenShift specific configurations.")
 	utils.StringFlagOrEnv(&appconfig.OpenshiftAPIServerName, "openshift-apiserver-name", "OPENSHIFT_APISERVER_NAME", "openshift-apiserver", "The OpenShift API Server name.")
+	utils.DurationFlagOrEnv(&appconfig.APIServerTimeout, "apiserver-timeout", "APISERVER_TIMEOUT", 30*time.Second, "The initial timeout for contacting the API Server, defaults to 30 seconds.")
 	utils.RelatedImageFlag("trillian-log-signer-image", images.TrillianLogSigner, "The image used for trillian log signer.")
 	utils.RelatedImageFlag("trillian-log-server-image", images.TrillianServer, "The image used for trillian log server.")
 	utils.RelatedImageFlag("trillian-db-image", images.TrillianDb, "The image used for trillian's database.")
@@ -134,10 +136,10 @@ func main() {
 	ctrl.SetLogger(klog.NewKlogr())
 
 	if !utils.IsFlagProvided("openshift", "OPENSHIFT") {
-		openshift, err := kubernetes.DetectOpenShiftPlatform(setupLog, appconfig.OpenshiftAPIServerName)
+		openshift, err := kubernetes.DetectOpenShiftPlatform(setupLog, appconfig.OpenshiftAPIServerName, appconfig.APIServerTimeout)
 		if err != nil {
-			setupLog.Error(err, "Platform auto-detection failed, falling back to kubernetes", "error")
-			openshift = false
+			setupLog.Error(err, "Platform auto-detection failed, exiting")
+			os.Exit(1)
 		}
 		appconfig.Openshift = openshift
 		setupLog.Info("Platform auto-detected", "openshift", appconfig.Openshift)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,10 @@
 package config
 
+import "time"
+
 var (
 	CreateTreeDeadline     int64 = 1200
 	Openshift              bool
 	OpenshiftAPIServerName string
+	APIServerTimeout       time.Duration
 )

--- a/internal/utils/flag_or_env.go
+++ b/internal/utils/flag_or_env.go
@@ -4,9 +4,22 @@ import (
 	"flag"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/securesign/operator/internal/images"
 )
+
+// DurationFlagOrEnv defines a string flag which can be set by an environment variable.
+// Precedence: flag > env var > default value.
+func DurationFlagOrEnv(p *time.Duration, name string, envName string, defaultValue time.Duration, usage string) {
+	envValue := os.Getenv(envName)
+	if envValue != "" {
+		if value, err := time.ParseDuration(envValue); err == nil {
+			defaultValue = value
+		}
+	}
+	flag.DurationVar(p, name, defaultValue, usage)
+}
 
 // StringFlagOrEnv defines a string flag which can be set by an environment variable.
 // Precedence: flag > env var > default value.

--- a/internal/utils/kubernetes/platform.go
+++ b/internal/utils/kubernetes/platform.go
@@ -2,22 +2,40 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"syscall"
+	"time"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
+const minAPIServiceTimeout = 15 * time.Second
+
 //+kubebuilder:rbac:groups=apiregistration.k8s.io,resources=apiservices,verbs=get;list;watch
 
 // DetectOpenShiftPlatform detects whether the operator is running on OpenShift.
 // It checks for API services with the specified OpenShift API service name.
-func DetectOpenShiftPlatform(log logr.Logger, apiServiceName string) (bool, error) {
+// Transient connectivity errors (connection refused, EOF, 503) are retried with
+// exponential backoff, with a minimum timeout of 15 seconds.
+func DetectOpenShiftPlatform(log logr.Logger, apiServiceName string, apiServiceTimeout time.Duration) (bool, error) {
 	if apiServiceName == "" {
 		return false, nil
 	}
+	if apiServiceTimeout <= minAPIServiceTimeout {
+		log.Info("APIServiceTimeout too low, defaulting to minimum timeout", "apiServiceTimeout", apiServiceTimeout, "minAPIServiceTimeout", minAPIServiceTimeout)
+		apiServiceTimeout = minAPIServiceTimeout
+	}
+	log.Info("APIServiceTimeout", "apiServiceTimeout", apiServiceTimeout)
 	cfg, err := config.GetConfig()
 	if err != nil {
 		return false, err
@@ -32,20 +50,67 @@ func DetectOpenShiftPlatform(log logr.Logger, apiServiceName string) (bool, erro
 		return false, err
 	}
 
-	apiServiceList := &apiregistrationv1.APIServiceList{}
-	if err := cl.List(context.Background(), apiServiceList); err != nil {
-		return false, err
+	ctx, cancel := context.WithTimeout(context.Background(), apiServiceTimeout)
+	defer cancel()
+
+	backoff := wait.Backoff{
+		Duration: 2 * time.Second,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    5,
 	}
 
-	for _, apiService := range apiServiceList.Items {
-		if service := apiService.Spec.Service; service != nil {
-			// The service will be default/openshift-apiserver or openshift-apiserver/api
-			if apiServiceName == service.Namespace || apiServiceName == service.Name {
-				log.Info("Discovered APIService matching API service name", "namespace", service.Namespace, "name", service.Name)
-				return true, nil
+	return detectOpenShiftWithRetry(ctx, log, cl, apiServiceName, backoff)
+}
+
+func detectOpenShiftWithRetry(ctx context.Context, log logr.Logger, cl client.Client, apiServiceName string, backoff wait.Backoff) (bool, error) {
+	var found bool
+	var lastErr error
+	retryErr := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		apiServiceList := &apiregistrationv1.APIServiceList{}
+		if listErr := cl.List(ctx, apiServiceList); listErr != nil {
+			if isTransientError(listErr) {
+				log.Info("Transient error during OpenShift platform detection, retrying", "error", listErr)
+				lastErr = listErr
+				return false, nil
+			}
+			return false, listErr
+		}
+		for _, apiService := range apiServiceList.Items {
+			if service := apiService.Spec.Service; service != nil {
+				// The service will be default/openshift-apiserver or openshift-apiserver/api
+				if apiServiceName == service.Namespace || apiServiceName == service.Name {
+					log.Info("Discovered APIService matching API service name", "namespace", service.Namespace, "name", service.Name)
+					found = true
+					return true, nil
+				}
 			}
 		}
+		return true, nil
+	})
+	if retryErr != nil {
+		if wait.Interrupted(retryErr) {
+			if lastErr != nil {
+				return false, fmt.Errorf("timed out waiting for API server during OpenShift platform detection: %w", lastErr)
+			}
+			return false, errors.New("timed out waiting for API server during OpenShift platform detection")
+		}
+		return false, retryErr
 	}
+	return found, nil
+}
 
-	return false, nil
+func isTransientError(err error) bool {
+	if apierrors.IsServiceUnavailable(err) || apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return isTransientError(urlErr.Err)
+	}
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, io.EOF)
 }

--- a/internal/utils/kubernetes/platform_test.go
+++ b/internal/utils/kubernetes/platform_test.go
@@ -20,6 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const testServiceName = "openshift-apiserver"
+
 // retriableClient embeds a fake client but injects failures for the first
 // failTimes List calls, simulating transient API server errors.
 type retriableClient struct {
@@ -58,25 +60,25 @@ func TestDetectOpenShiftWithRetry_ServiceDiscovery(t *testing.T) {
 	}{
 		{
 			name:        "no services",
-			searchName:  "openshift-apiserver",
+			searchName:  testServiceName,
 			expectFound: false,
 		},
 		{
 			name:        "match by namespace",
-			services:    []apiregistrationv1.APIService{apiService("openshift-apiserver", "api")},
-			searchName:  "openshift-apiserver",
+			services:    []apiregistrationv1.APIService{apiService(testServiceName, "api")},
+			searchName:  testServiceName,
 			expectFound: true,
 		},
 		{
 			name:        "match by name",
-			services:    []apiregistrationv1.APIService{apiService("default", "openshift-apiserver")},
-			searchName:  "openshift-apiserver",
+			services:    []apiregistrationv1.APIService{apiService("default", testServiceName)},
+			searchName:  testServiceName,
 			expectFound: true,
 		},
 		{
 			name:        "no match",
 			services:    []apiregistrationv1.APIService{apiService("some-namespace", "some-service")},
-			searchName:  "openshift-apiserver",
+			searchName:  testServiceName,
 			expectFound: false,
 		},
 	}
@@ -113,12 +115,12 @@ func TestDetectOpenShiftWithRetry_RetriesOnTransientErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			g := gomega.NewWithT(t)
 
-			inner := buildFakeClient(apiService("openshift-apiserver", "api"))
+			inner := buildFakeClient(apiService(testServiceName, "api"))
 			rc := &retriableClient{Client: inner, failTimes: 2, failErr: tc.err}
 
 			found, err := detectOpenShiftWithRetry(
 				context.Background(), logr.Discard(),
-				rc, "openshift-apiserver",
+				rc, testServiceName,
 				wait.Backoff{Duration: 1 * time.Millisecond, Factor: 1.0, Steps: 10},
 			)
 
@@ -141,7 +143,7 @@ func TestDetectOpenShiftWithRetry_NonTransientErrorPropagated(t *testing.T) {
 
 	_, err := detectOpenShiftWithRetry(
 		context.Background(), logr.Discard(),
-		rc, "openshift-apiserver", fastBackoff(),
+		rc, testServiceName, fastBackoff(),
 	)
 
 	g.Expect(err).To(gomega.MatchError(unexpectedErr))
@@ -161,7 +163,7 @@ func TestDetectOpenShiftWithRetry_ContextTimeout(t *testing.T) {
 
 	_, err := detectOpenShiftWithRetry(
 		ctx, logr.Discard(),
-		rc, "openshift-apiserver",
+		rc, testServiceName,
 		wait.Backoff{Duration: 5 * time.Millisecond, Factor: 1.0, Steps: 100},
 	)
 

--- a/internal/utils/kubernetes/platform_test.go
+++ b/internal/utils/kubernetes/platform_test.go
@@ -1,0 +1,190 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// retriableClient embeds a fake client but injects failures for the first
+// failTimes List calls, simulating transient API server errors.
+type retriableClient struct {
+	client.Client
+	callCount int
+	failTimes int
+	failErr   error
+}
+
+func (r *retriableClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	r.callCount++
+	if r.callCount <= r.failTimes {
+		return r.failErr
+	}
+	return r.Client.List(ctx, list, opts...)
+}
+
+func apiService(namespace, name string) apiregistrationv1.APIService {
+	return apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace + "." + name},
+		Spec: apiregistrationv1.APIServiceSpec{
+			Service: &apiregistrationv1.ServiceReference{
+				Namespace: namespace,
+				Name:      name,
+			},
+		},
+	}
+}
+
+func TestDetectOpenShiftWithRetry_ServiceDiscovery(t *testing.T) {
+	tests := []struct {
+		name        string
+		services    []apiregistrationv1.APIService
+		searchName  string
+		expectFound bool
+	}{
+		{
+			name:        "no services",
+			searchName:  "openshift-apiserver",
+			expectFound: false,
+		},
+		{
+			name:        "match by namespace",
+			services:    []apiregistrationv1.APIService{apiService("openshift-apiserver", "api")},
+			searchName:  "openshift-apiserver",
+			expectFound: true,
+		},
+		{
+			name:        "match by name",
+			services:    []apiregistrationv1.APIService{apiService("default", "openshift-apiserver")},
+			searchName:  "openshift-apiserver",
+			expectFound: true,
+		},
+		{
+			name:        "no match",
+			services:    []apiregistrationv1.APIService{apiService("some-namespace", "some-service")},
+			searchName:  "openshift-apiserver",
+			expectFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			found, err := detectOpenShiftWithRetry(
+				context.Background(), logr.Discard(),
+				buildFakeClient(tt.services...),
+				tt.searchName, fastBackoff(),
+			)
+
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(found).To(gomega.Equal(tt.expectFound))
+		})
+	}
+}
+
+func TestDetectOpenShiftWithRetry_RetriesOnTransientErrors(t *testing.T) {
+	transientCases := []struct {
+		name string
+		err  error
+	}{
+		{"ServiceUnavailable", apierrors.NewServiceUnavailable("server busy")},
+		{"EOF", io.EOF},
+		{"NetError", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection reset")}},
+		{"ServerTimeout", apierrors.NewServerTimeout(schema.GroupResource{}, "list", 0)},
+		{"TooManyRequests", apierrors.NewTooManyRequests("rate limited", 1)},
+	}
+
+	for _, tc := range transientCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			inner := buildFakeClient(apiService("openshift-apiserver", "api"))
+			rc := &retriableClient{Client: inner, failTimes: 2, failErr: tc.err}
+
+			found, err := detectOpenShiftWithRetry(
+				context.Background(), logr.Discard(),
+				rc, "openshift-apiserver",
+				wait.Backoff{Duration: 1 * time.Millisecond, Factor: 1.0, Steps: 10},
+			)
+
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(found).To(gomega.BeTrue())
+			g.Expect(rc.callCount).To(gomega.Equal(3)) // 2 failures + 1 success
+		})
+	}
+}
+
+func TestDetectOpenShiftWithRetry_NonTransientErrorPropagated(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	unexpectedErr := errors.New("unexpected error")
+	rc := &retriableClient{
+		Client:    buildFakeClient(),
+		failTimes: 999,
+		failErr:   unexpectedErr,
+	}
+
+	_, err := detectOpenShiftWithRetry(
+		context.Background(), logr.Discard(),
+		rc, "openshift-apiserver", fastBackoff(),
+	)
+
+	g.Expect(err).To(gomega.MatchError(unexpectedErr))
+}
+
+func TestDetectOpenShiftWithRetry_ContextTimeout(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	rc := &retriableClient{
+		Client:    buildFakeClient(),
+		failTimes: 999,
+		failErr:   io.EOF,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := detectOpenShiftWithRetry(
+		ctx, logr.Discard(),
+		rc, "openshift-apiserver",
+		wait.Backoff{Duration: 5 * time.Millisecond, Factor: 1.0, Steps: 100},
+	)
+
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("timed out"))
+}
+
+func buildFakeClient(services ...apiregistrationv1.APIService) client.Client {
+	scheme := runtime.NewScheme()
+	if err := apiregistrationv1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	objs := make([]client.Object, len(services))
+	for i := range services {
+		objs[i] = &services[i]
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func fastBackoff() wait.Backoff {
+	return wait.Backoff{
+		Duration: 1 * time.Millisecond,
+		Factor:   1.0,
+		Steps:    10,
+	}
+}


### PR DESCRIPTION
…API server blackouts

  Backport of #[1784](https://github.com/securesign/secure-sign-operator/pull/1784) (SECURESIGN-4401) from main to release-1.4.