### PR TITLE
fix: initialize missing status conditions on upgrade

### DIFF
--- a/internal/action/transitions/ensure_conditions.go
+++ b/internal/action/transitions/ensure_conditions.go
@@ -1,0 +1,46 @@
+package transitions
+
+import (
+	"context"
+
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/apis"
+	"github.com/securesign/operator/internal/state"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewEnsureConditionsAction[T apis.ConditionsAwareObject](componentSupplier ComponentSupplier[T]) action.Action[T] {
+	return &ensureConditions[T]{componentSupplier: componentSupplier}
+}
+
+type ensureConditions[T apis.ConditionsAwareObject] struct {
+	action.BaseAction
+	componentSupplier func(T) []string
+}
+
+func (i ensureConditions[T]) Name() string {
+	return "ensure conditions"
+}
+
+func (i ensureConditions[T]) CanHandle(_ context.Context, instance T) bool {
+	for _, c := range i.componentSupplier(instance) {
+		if meta.FindStatusCondition(instance.GetConditions(), c) == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (i ensureConditions[T]) Handle(ctx context.Context, instance T) *action.Result {
+	for _, c := range i.componentSupplier(instance) {
+		if meta.FindStatusCondition(instance.GetConditions(), c) == nil {
+			instance.SetCondition(metav1.Condition{
+				Type:   c,
+				Status: metav1.ConditionUnknown,
+				Reason: state.Pending.String(),
+			})
+		}
+	}
+	return i.StatusUpdate(ctx, instance)
+}

--- a/internal/action/transitions/ensure_conditions_test.go
+++ b/internal/action/transitions/ensure_conditions_test.go
@@ -1,0 +1,171 @@
+package transitions
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1alpha1"
+	"github.com/securesign/operator/internal/state"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const reasonReady = "Ready"
+
+func TestEnsureConditions_CanHandle(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		supplier   func(*rhtasv1.CTlog) []string
+		want       bool
+	}{
+		{
+			name: "all conditions present",
+			conditions: []metav1.Condition{
+				{Type: "A", Status: metav1.ConditionTrue, Reason: reasonReady},
+				{Type: "B", Status: metav1.ConditionTrue, Reason: reasonReady},
+			},
+			supplier: func(_ *rhtasv1.CTlog) []string { return []string{"A", "B"} },
+			want:     false,
+		},
+		{
+			name: "one condition missing",
+			conditions: []metav1.Condition{
+				{Type: "A", Status: metav1.ConditionTrue, Reason: reasonReady},
+			},
+			supplier: func(_ *rhtasv1.CTlog) []string { return []string{"A", "B"} },
+			want:     true,
+		},
+		{
+			name:       "all conditions missing",
+			conditions: nil,
+			supplier:   func(_ *rhtasv1.CTlog) []string { return []string{"A", "B"} },
+			want:       true,
+		},
+		{
+			name: "empty supplier",
+			conditions: []metav1.Condition{
+				{Type: "A", Status: metav1.ConditionTrue, Reason: reasonReady},
+			},
+			supplier: func(_ *rhtasv1.CTlog) []string { return nil },
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance := &rhtasv1.CTlog{
+				Status: rhtasv1.CTlogStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			a := ensureConditions[*rhtasv1.CTlog]{componentSupplier: tt.supplier}
+			if got := a.CanHandle(context.Background(), instance); got != tt.want {
+				t.Errorf("CanHandle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEnsureConditions_Handle(t *testing.T) {
+	const namespace = "default"
+	nn := types.NamespacedName{Name: "test-ctlog", Namespace: namespace}
+
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		supplier   func(*rhtasv1.CTlog) []string
+		verify     func(gomega.Gomega, *rhtasv1.CTlog)
+	}{
+		{
+			name:       "adds all missing conditions",
+			conditions: nil,
+			supplier:   func(_ *rhtasv1.CTlog) []string { return []string{"A", "B", "C"} },
+			verify: func(g gomega.Gomega, obj *rhtasv1.CTlog) {
+				for _, name := range []string{"A", "B", "C"} {
+					c := meta.FindStatusCondition(obj.GetConditions(), name)
+					g.Expect(c).ToNot(gomega.BeNil(), "condition %s should exist", name)
+					g.Expect(c.Status).To(gomega.Equal(metav1.ConditionUnknown))
+					g.Expect(c.Reason).To(gomega.Equal(state.Pending.String()))
+				}
+			},
+		},
+		{
+			name: "adds only missing conditions, preserves existing",
+			conditions: []metav1.Condition{
+				{Type: "A", Status: metav1.ConditionTrue, Reason: reasonReady},
+			},
+			supplier: func(_ *rhtasv1.CTlog) []string { return []string{"A", "B"} },
+			verify: func(g gomega.Gomega, obj *rhtasv1.CTlog) {
+				a := meta.FindStatusCondition(obj.GetConditions(), "A")
+				g.Expect(a).ToNot(gomega.BeNil())
+				g.Expect(a.Status).To(gomega.Equal(metav1.ConditionTrue), "existing condition should not be modified")
+				g.Expect(a.Reason).To(gomega.Equal(reasonReady))
+
+				b := meta.FindStatusCondition(obj.GetConditions(), "B")
+				g.Expect(b).ToNot(gomega.BeNil(), "missing condition B should be added")
+				g.Expect(b.Status).To(gomega.Equal(metav1.ConditionUnknown))
+				g.Expect(b.Reason).To(gomega.Equal(state.Pending.String()))
+			},
+		},
+		{
+			name: "dynamic supplier based on instance spec",
+			conditions: []metav1.Condition{
+				{Type: "base", Status: metav1.ConditionTrue, Reason: reasonReady},
+			},
+			supplier: func(c *rhtasv1.CTlog) []string {
+				conditions := []string{"base"}
+				if c.Spec.TreeID != nil {
+					conditions = append(conditions, "extra")
+				}
+				return conditions
+			},
+			verify: func(g gomega.Gomega, obj *rhtasv1.CTlog) {
+				base := meta.FindStatusCondition(obj.GetConditions(), "base")
+				g.Expect(base).ToNot(gomega.BeNil())
+				g.Expect(base.Status).To(gomega.Equal(metav1.ConditionTrue))
+
+				extra := meta.FindStatusCondition(obj.GetConditions(), "extra")
+				g.Expect(extra).ToNot(gomega.BeNil(), "dynamic condition should be added")
+				g.Expect(extra.Status).To(gomega.Equal(metav1.ConditionUnknown))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			ctx := context.Background()
+
+			instance := &rhtasv1.CTlog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      nn.Name,
+					Namespace: nn.Namespace,
+				},
+				Spec: rhtasv1.CTlogSpec{
+					TreeID: func() *int64 { v := int64(123); return &v }(),
+				},
+				Status: rhtasv1.CTlogStatus{
+					Conditions: tt.conditions,
+				},
+			}
+
+			c := testAction.FakeClientBuilder().
+				WithObjects(instance).
+				WithStatusSubresource(instance).
+				Build()
+
+			a := testAction.PrepareAction(c, NewEnsureConditionsAction[*rhtasv1.CTlog](tt.supplier))
+
+			result := a.Handle(ctx, instance)
+			g.Expect(result).ToNot(gomega.BeNil())
+
+			updated := &rhtasv1.CTlog{}
+			g.Expect(c.Get(ctx, nn, updated)).To(gomega.Succeed())
+			tt.verify(g, updated)
+		})
+	}
+}

--- a/internal/action/transitions/to_pending_phase.go
+++ b/internal/action/transitions/to_pending_phase.go
@@ -13,13 +13,12 @@ import (
 
 type ComponentSupplier[T apis.ConditionsAwareObject] func(T) []string
 
-func NewToPendingPhaseAction[T apis.ConditionsAwareObject](componentSupplier ComponentSupplier[T]) action.Action[T] {
-	return &toPending[T]{componentSupplier: componentSupplier}
+func NewToPendingPhaseAction[T apis.ConditionsAwareObject]() action.Action[T] {
+	return &toPending[T]{}
 }
 
 type toPending[T apis.ConditionsAwareObject] struct {
 	action.BaseAction
-	componentSupplier func(T) []string
 }
 
 func (i toPending[T]) Name() string {
@@ -36,9 +35,5 @@ func (i toPending[T]) Handle(ctx context.Context, instance T) *action.Result {
 		Status: metav1.ConditionFalse, Reason: state.Pending.String(),
 		ObservedGeneration: instance.GetGeneration()})
 
-	for _, c := range i.componentSupplier(instance) {
-		instance.SetCondition(metav1.Condition{Type: c,
-			Status: metav1.ConditionUnknown, Reason: state.Pending.String()})
-	}
 	return i.StatusUpdate(ctx, instance)
 }

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -99,10 +99,12 @@ func (r *ctlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	target := instance.DeepCopy()
+	conditionSupplier := func(_ *rhtasv1alpha1.CTlog) []string {
+		return []string{actions.CertCondition, actions.ConfigCondition, actions.TLSCondition}
+	}
 	acs := []action.Action[*rhtasv1alpha1.CTlog]{
-		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.CTlog](func(_ *rhtasv1alpha1.CTlog) []string {
-			return []string{actions.CertCondition, actions.ConfigCondition, actions.TLSCondition}
-		}),
+		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.CTlog](),
+		transitions.NewEnsureConditionsAction[*rhtasv1alpha1.CTlog](conditionSupplier),
 
 		actions.NewTlsAction(),
 

--- a/internal/controller/fulcio/fulcio_controller.go
+++ b/internal/controller/fulcio/fulcio_controller.go
@@ -93,10 +93,12 @@ func (r *fulcioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	target := instance.DeepCopy()
+	conditionSupplier := func(_ *rhtasv1alpha1.Fulcio) []string {
+		return []string{actions.CertCondition}
+	}
 	acs := []action.Action[*rhtasv1alpha1.Fulcio]{
-		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Fulcio](func(_ *rhtasv1alpha1.Fulcio) []string {
-			return []string{actions.CertCondition}
-		}),
+		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Fulcio](),
+		transitions.NewEnsureConditionsAction[*rhtasv1alpha1.Fulcio](conditionSupplier),
 		actions.NewHandleCertAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1alpha1.Fulcio](),
 		actions.NewRBACAction(),

--- a/internal/controller/rekor/rekor_controller.go
+++ b/internal/controller/rekor/rekor_controller.go
@@ -99,17 +99,19 @@ func (r *rekorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	target := instance.DeepCopy()
+	conditionSupplier := func(rekor *rhtasv1alpha1.Rekor) []string {
+		components := []string{actions2.ServerCondition, actions2.SignerCondition}
+		if utils.OptionalBool(rekor.Spec.RekorSearchUI.Enabled) {
+			components = append(components, actions2.UICondition)
+		}
+		if utils.OptionalBool(rekor.Spec.SearchIndex.Create) {
+			components = append(components, actions2.RedisCondition)
+		}
+		return components
+	}
 	actions := []action.Action[*rhtasv1alpha1.Rekor]{
-		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Rekor](func(rekor *rhtasv1alpha1.Rekor) []string {
-			components := []string{actions2.ServerCondition, actions2.SignerCondition}
-			if utils.OptionalBool(rekor.Spec.RekorSearchUI.Enabled) {
-				components = append(components, actions2.UICondition)
-			}
-			if utils.OptionalBool(rekor.Spec.SearchIndex.Create) {
-				components = append(components, actions2.RedisCondition)
-			}
-			return components
-		}),
+		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Rekor](),
+		transitions.NewEnsureConditionsAction[*rhtasv1alpha1.Rekor](conditionSupplier),
 
 		redis.NewTlsAction(),
 		redis.NewGeneratePasswordAction(),

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -96,10 +96,12 @@ func (r *trillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	target := instance.DeepCopy()
+	conditionSupplier := func(_ *rhtasv1alpha1.Trillian) []string {
+		return []string{actions.ServerCondition, actions.SignerCondition, actions.DbCondition}
+	}
 	actions := []action.Action[*rhtasv1alpha1.Trillian]{
-		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Trillian](func(t *rhtasv1alpha1.Trillian) []string {
-			return []string{actions.ServerCondition, actions.SignerCondition, actions.DbCondition}
-		}),
+		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Trillian](),
+		transitions.NewEnsureConditionsAction[*rhtasv1alpha1.Trillian](conditionSupplier),
 
 		logserver.NewTlsAction(),
 		logsigner.NewTlsAction(),

--- a/internal/controller/tsa/timestampauthority_controller.go
+++ b/internal/controller/tsa/timestampauthority_controller.go
@@ -92,11 +92,12 @@ func (r *timestampAuthorityReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	target := instance.DeepCopy()
+	conditionSupplier := func(_ *rhtasv1alpha1.TimestampAuthority) []string {
+		return []string{actions.TSASignerCondition}
+	}
 	actions := []action.Action[*rhtasv1alpha1.TimestampAuthority]{
-		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.TimestampAuthority](func(ta *rhtasv1alpha1.TimestampAuthority) []string {
-			components := []string{actions.TSASignerCondition}
-			return components
-		}),
+		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.TimestampAuthority](),
+		transitions.NewEnsureConditionsAction[*rhtasv1alpha1.TimestampAuthority](conditionSupplier),
 		actions.NewGenerateSignerAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1alpha1.TimestampAuthority](),
 		actions.NewRBACAction(),

--- a/internal/controller/tuf/tuf_controller.go
+++ b/internal/controller/tuf/tuf_controller.go
@@ -94,15 +94,17 @@ func (r *tufReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	target := instance.DeepCopy()
+	conditionSupplier := func(tuf *rhtasv1alpha1.Tuf) []string {
+		conditions := make([]string, 0, len(tuf.Spec.Keys)+1)
+		for _, k := range tuf.Spec.Keys {
+			conditions = append(conditions, k.Name)
+		}
+		conditions = append(conditions, constants.RepositoryCondition)
+		return conditions
+	}
 	acs := []action.Action[*rhtasv1alpha1.Tuf]{
-		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Tuf](func(tuf *rhtasv1alpha1.Tuf) []string {
-			conditions := make([]string, 0, len(tuf.Spec.Keys)+1)
-			for _, k := range tuf.Spec.Keys {
-				conditions = append(conditions, k.Name)
-			}
-			conditions = append(conditions, constants.RepositoryCondition)
-			return conditions
-		}),
+		transitions.NewToPendingPhaseAction[*rhtasv1alpha1.Tuf](),
+		transitions.NewEnsureConditionsAction[*rhtasv1alpha1.Tuf](conditionSupplier),
 
 		actions.NewResolveKeysAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1alpha1.Tuf](),


### PR DESCRIPTION
On upgrade from an older version, new conditions (e.g. ServerTLS) added in later releases are never created because ToPendingPhaseAction only runs on fresh instances (ReadyCondition nil/Unknown). Downstream actions check for nil conditions and bail out, leaving components misconfigured — for example, CTLog stays on HTTP while Fulcio assumes HTTPS on OpenShift, breaking signing after upgrade.

Split condition initialization out of ToPendingPhaseAction into a new EnsureConditionsAction that idempotently adds any missing conditions on every reconcile. Wire it into all 6 component controllers.