### PR TITLE
fix: resolve infinite reconcile loop on Securesign upgrade due to mis…

### DIFF
--- a/api/v1alpha1/trillian_types.go
+++ b/api/v1alpha1/trillian_types.go
@@ -29,8 +29,10 @@ type TrillianSpec struct {
 	// Enable Monitoring for Logsigner and Logserver
 	Monitoring MonitoringConfig `json:"monitoring,omitempty"`
 	// Configuration for Trillian log server service
+	//+kubebuilder:default:={}
 	LogServer TrillianLogServer `json:"server,omitempty"`
 	// Configuration for Trillian log signer service
+	//+kubebuilder:default:={}
 	LogSigner TrillianLogSigner `json:"signer,omitempty"`
 
 	// ConfigMap with additional bundle of trusted CA

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -5741,6 +5741,7 @@ spec:
                     - enabled
                     type: object
                   server:
+                    default: {}
                     description: Configuration for Trillian log server service
                     properties:
                       affinity:
@@ -6820,6 +6821,7 @@ spec:
                         type: array
                     type: object
                   signer:
+                    default: {}
                     description: Configuration for Trillian log signer service
                     properties:
                       affinity:

--- a/config/crd/bases/rhtas.redhat.com_trillians.yaml
+++ b/config/crd/bases/rhtas.redhat.com_trillians.yaml
@@ -403,6 +403,7 @@ spec:
                 - enabled
                 type: object
               server:
+                default: {}
                 description: Configuration for Trillian log server service
                 properties:
                   affinity:
@@ -1477,6 +1478,7 @@ spec:
                     type: array
                 type: object
               signer:
+                default: {}
                 description: Configuration for Trillian log signer service
                 properties:
                   affinity:


### PR DESCRIPTION
…sing CRD defaults

After upgrading from TAS 1.1.0, the Securesign CR lacks CRD-defaulted fields (trillian server/signer) causing ensure_trillian to detect a spec diff on every reconcile, permanently stuck on "Creating".