### PR TITLE
fix: return clear error when ServiceMonitor CRD is missing

### DIFF
--- a/internal/controller/ctlog/actions/monitor/monitoring.go
+++ b/internal/controller/ctlog/actions/monitor/monitoring.go
@@ -14,6 +14,7 @@ import (
 	"github.com/securesign/operator/internal/state"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -49,6 +50,9 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1.CTlog) *
 			kubernetes.ServiceMonitorEndpoint(actions.MonitorMetricsPortName),
 		),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return i.Error(ctx, fmt.Errorf("monitoring.enabled is true but ServiceMonitor CRD is not installed; install the Prometheus Operator or set monitoring.enabled=false"), instance)
+		}
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance, metav1.Condition{
 			Type:    actions.MonitorCondition,
 			Status:  metav1.ConditionFalse,

--- a/internal/controller/ctlog/actions/monitor/monitoring_test.go
+++ b/internal/controller/ctlog/actions/monitor/monitoring_test.go
@@ -1,0 +1,66 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testaction "github.com/securesign/operator/internal/testing/action"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestCtlogMonitorHandle_NoServiceMonitorCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	cl := testaction.FakeClientBuilder().
+		WithStatusSubresource(&rhtasv1.CTlog{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "ServiceMonitor" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testaction.PrepareAction(cl, NewCreateMonitorAction())
+
+	instance := &rhtasv1.CTlog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: rhtasv1.CTlogSpec{
+			Monitoring: rhtasv1.MonitoringWithTLogConfig{
+				TLog: rhtasv1.TlogMonitoring{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+		Status: rhtasv1.CTlogStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   constants.ReadyCondition,
+					Reason: state.Creating.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	result := a.Handle(context.Background(), instance)
+
+	g.Expect(result.Err).To(MatchError(ContainSubstring("ServiceMonitor CRD is not installed")))
+}

--- a/internal/controller/ctlog/actions/monitoring.go
+++ b/internal/controller/ctlog/actions/monitoring.go
@@ -14,6 +14,7 @@ import (
 	"github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -48,6 +49,9 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1.CTlog) *
 			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
 		),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return i.Error(ctx, fmt.Errorf("monitoring.enabled is true but ServiceMonitor CRD is not installed; install the Prometheus Operator or set monitoring.enabled=false"), instance)
+		}
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
 	}
 

--- a/internal/controller/ctlog/actions/monitoring_test.go
+++ b/internal/controller/ctlog/actions/monitoring_test.go
@@ -1,0 +1,66 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testaction "github.com/securesign/operator/internal/testing/action"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestCtlogMonitoringHandle_NoServiceMonitorCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	cl := testaction.FakeClientBuilder().
+		WithStatusSubresource(&rhtasv1.CTlog{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "ServiceMonitor" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testaction.PrepareAction(cl, NewCreateMonitorAction())
+
+	instance := &rhtasv1.CTlog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: rhtasv1.CTlogSpec{
+			Monitoring: rhtasv1.MonitoringWithTLogConfig{
+				MonitoringConfig: rhtasv1.MonitoringConfig{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+		Status: rhtasv1.CTlogStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   constants.ReadyCondition,
+					Reason: state.Creating.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	result := a.Handle(context.Background(), instance)
+
+	g.Expect(result.Err).To(MatchError(ContainSubstring("ServiceMonitor CRD is not installed")))
+}

--- a/internal/controller/fulcio/actions/monitoring.go
+++ b/internal/controller/fulcio/actions/monitoring.go
@@ -14,6 +14,7 @@ import (
 	"github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -48,6 +49,9 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1.Fulcio) 
 			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
 		),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return i.Error(ctx, fmt.Errorf("monitoring.enabled is true but ServiceMonitor CRD is not installed; install the Prometheus Operator or set monitoring.enabled=false"), instance)
+		}
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
 	}
 

--- a/internal/controller/fulcio/actions/monitoring_test.go
+++ b/internal/controller/fulcio/actions/monitoring_test.go
@@ -1,0 +1,69 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testaction "github.com/securesign/operator/internal/testing/action"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// TestMonitoringHandle_NoServiceMonitorCRD verifies that Handle returns a clear,
+// actionable error when monitoring.enabled is true but the ServiceMonitor CRD
+// is not installed (e.g. on vanilla Kubernetes without the Prometheus Operator).
+func TestMonitoringHandle_NoServiceMonitorCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	// Build a fake client that returns NoKindMatchError for ServiceMonitor lookups,
+	// simulating a cluster where the Prometheus Operator CRD is absent.
+	cl := testaction.FakeClientBuilder().
+		WithStatusSubresource(&rhtasv1.Fulcio{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "ServiceMonitor" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testaction.PrepareAction(cl, NewCreateMonitorAction())
+
+	instance := &rhtasv1.Fulcio{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: rhtasv1.FulcioSpec{
+			Monitoring: rhtasv1.MonitoringConfig{
+				Enabled: ptr.To(true),
+			},
+		},
+		Status: rhtasv1.FulcioStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   constants.ReadyCondition,
+					Reason: state.Creating.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	result := a.Handle(context.Background(), instance)
+
+	g.Expect(result.Err).To(MatchError(ContainSubstring("ServiceMonitor CRD is not installed")))
+}

--- a/internal/controller/rekor/actions/monitor/monitoring.go
+++ b/internal/controller/rekor/actions/monitor/monitoring.go
@@ -14,6 +14,7 @@ import (
 	"github.com/securesign/operator/internal/state"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -49,6 +50,9 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1.Rekor) *
 			kubernetes.ServiceMonitorEndpoint(actions.MonitorMetricsPortName),
 		),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return i.Error(ctx, fmt.Errorf("monitoring.enabled is true but ServiceMonitor CRD is not installed; install the Prometheus Operator or set monitoring.enabled=false"), instance)
+		}
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance, metav1.Condition{
 			Type:    actions.MonitorCondition,
 			Status:  metav1.ConditionFalse,

--- a/internal/controller/rekor/actions/monitor/monitoring_test.go
+++ b/internal/controller/rekor/actions/monitor/monitoring_test.go
@@ -1,0 +1,66 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testaction "github.com/securesign/operator/internal/testing/action"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestRekorMonitorHandle_NoServiceMonitorCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	cl := testaction.FakeClientBuilder().
+		WithStatusSubresource(&rhtasv1.Rekor{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "ServiceMonitor" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testaction.PrepareAction(cl, NewCreateMonitorAction())
+
+	instance := &rhtasv1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: rhtasv1.RekorSpec{
+			Monitoring: rhtasv1.MonitoringWithTLogConfig{
+				TLog: rhtasv1.TlogMonitoring{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+		Status: rhtasv1.RekorStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   constants.ReadyCondition,
+					Reason: state.Creating.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	result := a.Handle(context.Background(), instance)
+
+	g.Expect(result.Err).To(MatchError(ContainSubstring("ServiceMonitor CRD is not installed")))
+}

--- a/internal/controller/rekor/actions/server/monitoring.go
+++ b/internal/controller/rekor/actions/server/monitoring.go
@@ -15,6 +15,7 @@ import (
 	"github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -50,6 +51,9 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1.Rekor) *
 			kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
 		),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return i.Error(ctx, fmt.Errorf("monitoring.enabled is true but ServiceMonitor CRD is not installed; install the Prometheus Operator or set monitoring.enabled=false"), instance)
+		}
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance, metav1.Condition{
 			Type:    actions.ServerCondition,
 			Status:  metav1.ConditionFalse,

--- a/internal/controller/rekor/actions/server/monitoring_test.go
+++ b/internal/controller/rekor/actions/server/monitoring_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testaction "github.com/securesign/operator/internal/testing/action"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestRekorServerMonitoringHandle_NoServiceMonitorCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	cl := testaction.FakeClientBuilder().
+		WithStatusSubresource(&rhtasv1.Rekor{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "ServiceMonitor" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testaction.PrepareAction(cl, NewCreateMonitorAction())
+
+	instance := &rhtasv1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: rhtasv1.RekorSpec{
+			Monitoring: rhtasv1.MonitoringWithTLogConfig{
+				MonitoringConfig: rhtasv1.MonitoringConfig{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+		Status: rhtasv1.RekorStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   constants.ReadyCondition,
+					Reason: state.Creating.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	result := a.Handle(context.Background(), instance)
+
+	g.Expect(result.Err).To(MatchError(ContainSubstring("ServiceMonitor CRD is not installed")))
+}

--- a/internal/controller/trillian/actions/logserver/monitoring.go
+++ b/internal/controller/trillian/actions/logserver/monitoring.go
@@ -15,6 +15,7 @@ import (
 	"github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -61,6 +62,9 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1.Trillian
 				kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
 			)),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return i.Error(ctx, fmt.Errorf("monitoring.enabled is true but ServiceMonitor CRD is not installed; install the Prometheus Operator or set monitoring.enabled=false"), instance)
+		}
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance,
 			metav1.Condition{
 				Type:    actions.ServerCondition,

--- a/internal/controller/trillian/actions/logserver/monitoring_test.go
+++ b/internal/controller/trillian/actions/logserver/monitoring_test.go
@@ -1,0 +1,64 @@
+package logserver
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testaction "github.com/securesign/operator/internal/testing/action"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestLogserverMonitoringHandle_NoServiceMonitorCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	cl := testaction.FakeClientBuilder().
+		WithStatusSubresource(&rhtasv1.Trillian{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "ServiceMonitor" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testaction.PrepareAction(cl, NewCreateMonitorAction())
+
+	instance := &rhtasv1.Trillian{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: rhtasv1.TrillianSpec{
+			Monitoring: rhtasv1.MonitoringConfig{
+				Enabled: ptr.To(true),
+			},
+		},
+		Status: rhtasv1.TrillianStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   constants.ReadyCondition,
+					Reason: state.Creating.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	result := a.Handle(context.Background(), instance)
+
+	g.Expect(result.Err).To(MatchError(ContainSubstring("ServiceMonitor CRD is not installed")))
+}

--- a/internal/controller/trillian/actions/logsigner/monitoring.go
+++ b/internal/controller/trillian/actions/logsigner/monitoring.go
@@ -15,6 +15,7 @@ import (
 	"github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -61,6 +62,9 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1.Trillian
 				kubernetes.ServiceMonitorEndpoint(actions.MetricsPortName),
 			)),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return i.Error(ctx, fmt.Errorf("monitoring.enabled is true but ServiceMonitor CRD is not installed; install the Prometheus Operator or set monitoring.enabled=false"), instance)
+		}
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance,
 			metav1.Condition{
 				Type:    actions.ServerCondition,

--- a/internal/controller/trillian/actions/logsigner/monitoring_test.go
+++ b/internal/controller/trillian/actions/logsigner/monitoring_test.go
@@ -1,0 +1,64 @@
+package logsigner
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testaction "github.com/securesign/operator/internal/testing/action"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestLogsignerMonitoringHandle_NoServiceMonitorCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	cl := testaction.FakeClientBuilder().
+		WithStatusSubresource(&rhtasv1.Trillian{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "ServiceMonitor" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testaction.PrepareAction(cl, NewCreateMonitorAction())
+
+	instance := &rhtasv1.Trillian{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: rhtasv1.TrillianSpec{
+			Monitoring: rhtasv1.MonitoringConfig{
+				Enabled: ptr.To(true),
+			},
+		},
+		Status: rhtasv1.TrillianStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   constants.ReadyCondition,
+					Reason: state.Creating.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	result := a.Handle(context.Background(), instance)
+
+	g.Expect(result.Err).To(MatchError(ContainSubstring("ServiceMonitor CRD is not installed")))
+}

--- a/internal/controller/tsa/actions/monitoring.go
+++ b/internal/controller/tsa/actions/monitoring.go
@@ -14,6 +14,7 @@ import (
 	"github.com/securesign/operator/internal/utils"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -47,6 +48,9 @@ func (i monitoringAction) Handle(ctx context.Context, instance *rhtasv1.Timestam
 			kubernetes.ServiceMonitorEndpoint(MetricsPortName),
 		),
 	); err != nil {
+		if meta.IsNoMatchError(err) {
+			return i.Error(ctx, fmt.Errorf("monitoring.enabled is true but ServiceMonitor CRD is not installed; install the Prometheus Operator or set monitoring.enabled=false"), instance)
+		}
 		return i.Error(ctx, fmt.Errorf("could not create serviceMonitor: %w", err), instance)
 	}
 

--- a/internal/controller/tsa/actions/monitoring_test.go
+++ b/internal/controller/tsa/actions/monitoring_test.go
@@ -1,0 +1,64 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testaction "github.com/securesign/operator/internal/testing/action"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestTSAMonitoringHandle_NoServiceMonitorCRD(t *testing.T) {
+	g := NewWithT(t)
+
+	cl := testaction.FakeClientBuilder().
+		WithStatusSubresource(&rhtasv1.TimestampAuthority{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "ServiceMonitor" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "monitoring.coreos.com", Kind: "ServiceMonitor"},
+						SearchedVersions: []string{"v1"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testaction.PrepareAction(cl, NewMonitoringAction())
+
+	instance := &rhtasv1.TimestampAuthority{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: rhtasv1.TimestampAuthoritySpec{
+			Monitoring: rhtasv1.MonitoringConfig{
+				Enabled: ptr.To(true),
+			},
+		},
+		Status: rhtasv1.TimestampAuthorityStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   constants.ReadyCondition,
+					Reason: state.Creating.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	result := a.Handle(context.Background(), instance)
+
+	g.Expect(result.Err).To(MatchError(ContainSubstring("ServiceMonitor CRD is not installed")))
+}


### PR DESCRIPTION
When monitoring.enabled is true but the ServiceMonitor CRD is not installed (e.g. vanilla Kubernetes without Prometheus Operator), all monitoring Handle() actions fail with an opaque "no matches for kind ServiceMonitor" error. This leaves components in a non-Ready state with no actionable guidance for the operator.

Catch meta.IsNoMatchError from the CreateOrUpdate call in all 8 monitoring actions and return a clear, actionable error:

  monitoring.enabled is true but ServiceMonitor CRD is not installed;
  install the Prometheus Operator or set monitoring.enabled=false

The DynamicRESTMapper used by controller-runtime caches discovery results and auto-invalidates when CRDs are added, so the error self-heals on the next reconciliation once the Prometheus Operator is installed — no operator restart required.

Add TestMonitoringHandle_NoServiceMonitorCRD to validate the fail-fast path using a fake client interceptor that returns NoKindMatchError for ServiceMonitor lookups.

Note: This PR is one of the spilt implementations based on [review comments](https://github.com/securesign/secure-sign-operator/pull/1990#pullrequestreview-4625972335) received for https://github.com/securesign/secure-sign-operator/pull/1990

