### PR TITLE
fix: migrate playwright-go to mxschmitt/playwright-go (CDN shutdown)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -608,7 +608,7 @@ jobs:
           cd e2e
           source ./tas-env-variables.sh
           # Install Playwright with dependencies for UI tests
-          go run github.com/playwright-community/playwright-go/cmd/playwright install --with-deps
+          go run github.com/mxschmitt/playwright-go/cmd/playwright install --with-deps
           go test -v ./test/...
 
       - name: dump the logs of the operator


### PR DESCRIPTION
## Summary

- Migrate `playwright-community/playwright-go` → `mxschmitt/playwright-go` (one-line change)
- The Playwright `/builds/driver` CDN (azureedge) has been shut down — `playwright install` fails with 404
- The module moved to `mxschmitt/playwright-go` which downloads the driver from npm + nodejs.org instead ([PR #615](https://github.com/playwright-community/playwright-go/pull/615))

### Related PRs
- sigstore-e2e: https://github.com/securesign/sigstore-e2e/pull/80
- releases: https://github.com/securesign/releases/pull/291
- pipelines: https://github.com/securesign/pipelines/pull/548
- Jira: [SECURESIGN-4984](https://redhat.atlassian.net/browse/SECURESIGN-4984)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SECURESIGN-4984]: https://redhat.atlassian.net/browse/SECURESIGN-4984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ