### PR TITLE
fix: add playwright install and enable UI tests (CDN shutdown)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -618,8 +618,9 @@ jobs:
           
           cd e2e
           source ./tas-env-variables.sh
-          # exclude UI tests
-          go test -v $(go list ./test/... | grep -v rekorsearchui)
+          # Install Playwright with dependencies for UI tests
+          go run github.com/mxschmitt/playwright-go/cmd/playwright install --with-deps
+          go test -v ./test/...
 
       - name: dump the logs of the operator
         run: |


### PR DESCRIPTION
## Summary

- Add `playwright install` step and enable rekorsearchui tests (matching release-1.4 and main)
- Uses `mxschmitt/playwright-go` — the old `playwright-community` CDN has been shut down ([playwright-go#593](https://github.com/playwright-community/playwright-go/issues/593))

### Related
- Jira: [SECURESIGN-4984](https://redhat.atlassian.net/browse/SECURESIGN-4984)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SECURESIGN-4984]: https://redhat.atlassian.net/browse/SECURESIGN-4984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ