### PR TITLE
feat: add FIPS mode enforcement for signing keys and algorithms

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/securesign/operator/internal/images"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/utils"
+	"github.com/securesign/operator/internal/utils/fips"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -143,6 +144,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(klog.NewKlogr())
+
+	setupLog.Info("FIPS mode", "enabled", fips.Enabled())
 
 	if !utils.IsFlagProvided("openshift", "OPENSHIFT") {
 		openshift, err := kubernetes.DetectOpenShiftPlatform(setupLog, appconfig.OpenshiftAPIServerName, appconfig.APIServerTimeout)

--- a/internal/action/generateSigner/action.go
+++ b/internal/action/generateSigner/action.go
@@ -14,6 +14,7 @@ import (
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
+	"github.com/securesign/operator/internal/utils/fips"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	corev1 "k8s.io/api/core/v1"
@@ -75,6 +76,26 @@ func (i signerAction[T]) CanHandle(_ context.Context, instance T) bool {
 
 func (i signerAction[T]) Handle(ctx context.Context, instance T) *action.Result {
 	w := i.wrapper(instance)
+
+	if fips.Enabled() && w.PasswordRef() != nil {
+		err := reconcile.TerminalError(fips.ErrPasswordRefInFIPS)
+		return i.Error(ctx, err, instance,
+			metav1.Condition{
+				Type:               i.conditionType,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Failure.String(),
+				Message:            err.Error(),
+				ObservedGeneration: instance.GetGeneration(),
+			},
+			metav1.Condition{
+				Type:               constants.ReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Pending.String(),
+				Message:            err.Error(),
+				ObservedGeneration: instance.GetGeneration(),
+			},
+		)
+	}
 
 	resolvedRef, err := w.ResolveRef(ctx, i.Client)
 	if err != nil {

--- a/internal/action/generateSigner/action_test.go
+++ b/internal/action/generateSigner/action_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
+	"github.com/securesign/operator/internal/utils/fips"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -444,4 +445,89 @@ func TestHandle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandle_FIPSPasswordRefGuard(t *testing.T) {
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	t.Run("rejects PasswordRef as terminal error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := context.TODO()
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testNameFormat, testComponent, testDeployment,
+			Wrapper(Config[*rhtasv1.Rekor]{
+				ResolveRef: func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) (*rhtasv1.SecretKeySelector, error) {
+					return nil, nil
+				},
+				GenerateData: func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) (map[string][]byte, error) {
+					return testData, nil
+				},
+				AlignStatus: func(r *rhtasv1.Rekor, ref rhtasv1.SecretKeySelector) {
+					r.Status.Signer.KeyRef = &rhtasv1.SecretKeySelector{
+						Key:                  "private",
+						LocalObjectReference: ref.LocalObjectReference,
+					}
+				},
+				IsEnabled: func(_ *rhtasv1.Rekor) bool { return true },
+				PasswordRef: func(_ *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
+					return &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "password-secret"},
+						Key:                  "password",
+					}
+				},
+			}),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result.Err).To(HaveOccurred())
+		g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+		g.Expect(errors.Is(result.Err, fips.ErrPasswordRefInFIPS)).To(BeTrue())
+	})
+
+	t.Run("allows nil PasswordRef in FIPS mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := context.TODO()
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testNameFormat, testComponent, testDeployment,
+			Wrapper(Config[*rhtasv1.Rekor]{
+				ResolveRef: func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) (*rhtasv1.SecretKeySelector, error) {
+					return nil, nil
+				},
+				GenerateData: func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) (map[string][]byte, error) {
+					return testData, nil
+				},
+				AlignStatus: func(r *rhtasv1.Rekor, ref rhtasv1.SecretKeySelector) {
+					r.Status.Signer.KeyRef = &rhtasv1.SecretKeySelector{
+						Key:                  "private",
+						LocalObjectReference: ref.LocalObjectReference,
+					}
+				},
+				IsEnabled: func(_ *rhtasv1.Rekor) bool { return true },
+				PasswordRef: func(_ *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
+					return nil
+				},
+			}),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result).To(Equal(testAction.Return()))
+	})
 }

--- a/internal/action/generateSigner/action_test.go
+++ b/internal/action/generateSigner/action_test.go
@@ -454,7 +454,7 @@ func TestHandle_FIPSPasswordRefGuard(t *testing.T) {
 
 	t.Run("rejects PasswordRef as terminal error", func(t *testing.T) {
 		g := NewWithT(t)
-		ctx := context.TODO()
+		ctx := t.Context()
 		instance := testInstance(pendingConditions()...)
 
 		cli := testAction.FakeClientBuilder().
@@ -496,7 +496,7 @@ func TestHandle_FIPSPasswordRefGuard(t *testing.T) {
 
 	t.Run("allows nil PasswordRef in FIPS mode", func(t *testing.T) {
 		g := NewWithT(t)
-		ctx := context.TODO()
+		ctx := t.Context()
 		instance := testInstance(pendingConditions()...)
 
 		cli := testAction.FakeClientBuilder().

--- a/internal/action/generateSigner/doc.go
+++ b/internal/action/generateSigner/doc.go
@@ -6,8 +6,10 @@
 // The action follows a create-once, verify-always pattern. Signer keys are
 // generated ONLY on fresh installation. After creation the secret is immutable
 // (Kubernetes enforces data immutability). Most errors are retriable —
-// the only terminal errors come from [Config.GenerateData] callbacks
-// (e.g., invalid spec combinations).
+// terminal errors come from the FIPS password-ref guard in [signerAction.Handle],
+// from component-level [Config.ResolveRef] callbacks (e.g., invalid spec combinations
+// such as a missing private key or CA certificate), and from [Config.GenerateData]
+// callbacks.
 //
 // Handle executes the following decision tree on every reconcile:
 //
@@ -42,6 +44,9 @@
 //     adds TUF autodiscovery labels (e.g., fulcio_v1.crt.pem, tsa.certchain.pem).
 //     Also applied to user-provided secrets in the resolved path as a temporary
 //     workaround until dedicated resolve_pub_key actions are implemented.
+//   - PasswordRef: (optional) extract the password-ref selector from the instance.
+//     When set and FIPS mode is active, [signerAction.Handle] returns a terminal
+//     error if the selector is non-nil — password-protected keys are forbidden in FIPS.
 //
 // # Upgrade Path
 //
@@ -63,6 +68,12 @@
 //	            GenerateData: generateData,
 //	            AlignStatus:  alignStatus,
 //	            IsEnabled:    isEnabled,
+//	            PasswordRef: func(i *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
+//	                if i.Spec.Signer.KeyRef != nil {
+//	                    return i.Spec.Signer.PasswordRef
+//	                }
+//	                return nil
+//	            },
 //	        }),
 //	    )
 //	}

--- a/internal/action/generateSigner/types.go
+++ b/internal/action/generateSigner/types.go
@@ -38,6 +38,12 @@ type Config[T apis.ConditionsAwareObject] struct {
 	// to add labels, annotations, or modify the secret in any way.
 	// Nil is a no-op.
 	MutateSecret func(T, *corev1.Secret)
+
+	// PasswordRef extracts the password-ref selector from the instance's spec.
+	// When non-nil and FIPS mode is active, Handle returns a TerminalError
+	// if the selector is non-nil (password-protected keys are forbidden in FIPS).
+	// Nil disables the FIPS password-ref guard.
+	PasswordRef func(T) *rhtasv1.SecretKeySelector
 }
 
 func Wrapper[T apis.ConditionsAwareObject](cfg Config[T]) func(T) *wrapper[T] {
@@ -56,6 +62,13 @@ type wrapper[T apis.ConditionsAwareObject] struct {
 
 func (w *wrapper[T]) ResolveRef(ctx context.Context, c client.Client) (*rhtasv1.SecretKeySelector, error) {
 	return w.cfg.ResolveRef(ctx, w.object, c)
+}
+
+func (w *wrapper[T]) PasswordRef() *rhtasv1.SecretKeySelector {
+	if w.cfg.PasswordRef == nil {
+		return nil
+	}
+	return w.cfg.PasswordRef(w.object)
 }
 
 func (w *wrapper[T]) GenerateData(ctx context.Context, c client.Client) (map[string][]byte, error) {

--- a/internal/controller/ctlog/actions/generate_signer.go
+++ b/internal/controller/ctlog/actions/generate_signer.go
@@ -36,6 +36,12 @@ func NewGenerateSignerAction() action.Action[*rhtasv1.CTlog] {
 				}
 				secret.Labels[labels.LabelNamespace+"/ctfe.pub"] = constants.KeyPublic
 			},
+			PasswordRef: func(i *rhtasv1.CTlog) *rhtasv1.SecretKeySelector {
+				if i.Spec.PrivateKeyRef != nil {
+					return i.Spec.PrivateKeyPasswordRef //nolint:staticcheck
+				}
+				return nil
+			},
 		}),
 	)
 }

--- a/internal/controller/ctlog/actions/generate_signer_test.go
+++ b/internal/controller/ctlog/actions/generate_signer_test.go
@@ -1,6 +1,12 @@
 package actions
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -10,10 +16,12 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
+	"github.com/securesign/operator/internal/utils/fips"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func ctlogInstance() *rhtasv1.CTlog {
@@ -195,4 +203,73 @@ func TestCTlogKeys_MigrationFromPreExistingSecret(t *testing.T) {
 func TestCTlogKeys_DeterministicName(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(fmt.Sprintf(signerSecretNameFormat, "my-ctlog")).To(Equal("ctlog-keys-config-my-ctlog"))
+}
+
+func TestCTlogKeys_PasswordRefRejectedInFIPS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	instance := ctlogInstance()
+	instance.Spec.PrivateKeyRef = &rhtasv1.SecretKeySelector{
+		LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-secret"},
+		Key:                  "private",
+	}
+	instance.Spec.PrivateKeyPasswordRef = &rhtasv1.SecretKeySelector{ //nolint:staticcheck
+		LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-password"},
+		Key:                  "password",
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result.Err).To(HaveOccurred())
+	g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+	g.Expect(result.Err.Error()).To(ContainSubstring("FIPS"))
+	cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+}
+
+func TestCTlogKeys_UnencryptedKeyAllowedInFIPS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	g.Expect(err).ToNot(HaveOccurred())
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	g.Expect(err).ToNot(HaveOccurred())
+	unencryptedKey := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+
+	instance := ctlogInstance()
+	instance.Spec.PrivateKeyRef = &rhtasv1.SecretKeySelector{
+		LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-secret"},
+		Key:                  "private",
+	}
+
+	userSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-secret", Namespace: "default"},
+		Data:       map[string][]byte{"private": unencryptedKey},
+	}
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance, userSecret).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result.Err).ToNot(HaveOccurred())
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, SignerCondition)).To(BeTrue())
 }

--- a/internal/controller/fulcio/actions/deployment.go
+++ b/internal/controller/fulcio/actions/deployment.go
@@ -13,6 +13,7 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
 	"github.com/securesign/operator/internal/utils"
+	"github.com/securesign/operator/internal/utils/fips"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure/deployment"
@@ -170,6 +171,10 @@ func (i deployAction) ensureDeployment(instance *rhtasv1.Fulcio, sa string, labe
 				},
 			}
 			args = append(args, "--fileca-key-passwd", "$(PASSWORD)")
+		}
+
+		if fips.Enabled() {
+			args = append(args, "--client-signing-algorithms", fips.ClientSigningAlgorithms)
 		}
 
 		container.Args = args

--- a/internal/controller/fulcio/actions/fulcio_deployment_test.go
+++ b/internal/controller/fulcio/actions/fulcio_deployment_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller/fulcio/utils"
 	"github.com/securesign/operator/internal/labels"
+	"github.com/securesign/operator/internal/utils/fips"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure/deployment"
 	v13 "k8s.io/api/apps/v1"
@@ -122,6 +123,40 @@ func TestMissingPrivateKey(t *testing.T) {
 	deployment, err := createDeployment(instance, labels)
 	g.Expect(err).Should(HaveOccurred())
 	g.Expect(deployment).Should(BeNil())
+}
+
+func TestFIPSClientSigningAlgorithms(t *testing.T) {
+	g := NewWithT(t)
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	instance := createInstance()
+	labels := labels.For(componentName, deploymentName, instance.Name)
+	dp, err := createDeployment(instance, labels)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(dp.Spec.Template.Spec.Containers[0].Args).Should(
+		ContainElement(Equal("--client-signing-algorithms")))
+	g.Expect(dp.Spec.Template.Spec.Containers[0].Args).Should(
+		ContainElement(Equal(fips.ClientSigningAlgorithms)))
+}
+
+func TestNonFIPSNoClientSigningAlgorithms(t *testing.T) {
+	g := NewWithT(t)
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return false }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	instance := createInstance()
+	labels := labels.For(componentName, deploymentName, instance.Name)
+	dp, err := createDeployment(instance, labels)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(dp.Spec.Template.Spec.Containers[0].Args).ShouldNot(
+		ContainElement(Equal("--client-signing-algorithms")))
 }
 
 func TestCtlogConfig(t *testing.T) {

--- a/internal/controller/fulcio/actions/generate_signer.go
+++ b/internal/controller/fulcio/actions/generate_signer.go
@@ -45,6 +45,12 @@ func NewGenerateSignerAction() action.Action[*rhtasv1.Fulcio] {
 				}
 				secret.Labels[FulcioCALabel] = constants.KeyCert
 			},
+			PasswordRef: func(i *rhtasv1.Fulcio) *rhtasv1.SecretKeySelector {
+				if i.Spec.Certificate.PrivateKeyRef != nil {
+					return i.Spec.Certificate.PrivateKeyPasswordRef //nolint:staticcheck
+				}
+				return nil
+			},
 		}),
 	)
 }

--- a/internal/controller/fulcio/actions/generate_signer_test.go
+++ b/internal/controller/fulcio/actions/generate_signer_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/securesign/operator/internal/controller/fulcio/utils"
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
+	"github.com/securesign/operator/internal/utils/fips"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func fulcioInstance() *rhtasv1.Fulcio {
@@ -371,4 +373,89 @@ func TestFulcioCert_CanHandle_GenerationBump(t *testing.T) {
 	c := testAction.FakeClientBuilder().Build()
 	a := testAction.PrepareAction(c, NewGenerateSignerAction())
 	g.Expect(a.CanHandle(t.Context(), instance)).To(BeTrue())
+}
+
+func TestFulcioCert_PasswordRefRejectedInFIPS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	instance := fulcioInstance()
+	instance.Spec.Certificate = rhtasv1.FulcioCert{
+		PrivateKeyRef: &rhtasv1.SecretKeySelector{
+			LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-private"},
+			Key:                  "private",
+		},
+		CARef: &rhtasv1.SecretKeySelector{
+			LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-cert"},
+			Key:                  "cert",
+		},
+		PrivateKeyPasswordRef: &rhtasv1.SecretKeySelector{ //nolint:staticcheck
+			LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-password"},
+			Key:                  "password",
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result.Err).To(HaveOccurred())
+	g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+	g.Expect(result.Err.Error()).To(ContainSubstring("FIPS"))
+	cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+}
+
+func TestFulcioCert_UnencryptedKeyAllowedInFIPS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	g.Expect(err).ToNot(HaveOccurred())
+	unencryptedKey, err := utils.CreateCAKey(ecKey)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	instance := fulcioInstance()
+	instance.Spec.Certificate = rhtasv1.FulcioCert{
+		PrivateKeyRef: &rhtasv1.SecretKeySelector{
+			LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-private"},
+			Key:                  "private",
+		},
+		CARef: &rhtasv1.SecretKeySelector{
+			LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-cert"},
+			Key:                  "cert",
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance,
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-private", Namespace: "default"},
+				Data:       map[string][]byte{"private": unencryptedKey},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-cert", Namespace: "default"},
+				Data:       map[string][]byte{"cert": []byte("fake-cert")},
+			},
+		).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result.Err).ToNot(HaveOccurred())
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, CertCondition)).To(BeTrue())
 }

--- a/internal/controller/rekor/actions/server/deployment.go
+++ b/internal/controller/rekor/actions/server/deployment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
 	"github.com/securesign/operator/internal/utils"
+	"github.com/securesign/operator/internal/utils/fips"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure/deployment"
@@ -193,6 +194,10 @@ func (i deployAction) ensureServerDeployment(instance *rhtasv1.Rekor, sa string,
 					},
 				}
 			}
+		}
+
+		if fips.Enabled() {
+			args = append(args, "--client-signing-algorithms", fips.ClientSigningAlgorithms)
 		}
 
 		//TODO mount additional ENV variables and secrets to enable cloud KMS service

--- a/internal/controller/rekor/actions/server/deployment_test.go
+++ b/internal/controller/rekor/actions/server/deployment_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -11,6 +10,7 @@ import (
 	actions2 "github.com/securesign/operator/internal/controller/trillian/actions"
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
+	"github.com/securesign/operator/internal/utils/fips"
 	v2 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,8 +23,110 @@ const (
 	testPrivateKey = "private"
 )
 
+func createRekorInstance() *rhtasv1.Rekor {
+	instance := &rhtasv1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rekor",
+			Namespace: testNamespace,
+		},
+		Spec: rhtasv1.RekorSpec{
+			Trillian: rhtasv1.TrillianService{
+				Port: ptr.To[int32](8091),
+			},
+			Signer: rhtasv1.RekorSigner{
+				KMS: signerKMSSecret,
+			},
+			SearchIndex: rhtasv1.SearchIndex{
+				Create: ptr.To(true),
+			},
+		},
+		Status: rhtasv1.RekorStatus{
+			TreeID:          ptr.To[int64](123456),
+			ServerConfigRef: &rhtasv1.LocalObjectReference{Name: "test-config"},
+			Signer: rhtasv1.RekorSignerStatus{
+				KeyRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{Name: "signer-secret"},
+					Key:                  testPrivateKey,
+				},
+			},
+		},
+	}
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:   constants.ReadyCondition,
+		Status: metav1.ConditionFalse,
+		Reason: state.Creating.String(),
+	})
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:   actions.ServerCondition,
+		Status: metav1.ConditionFalse,
+		Reason: state.Creating.String(),
+	})
+	return instance
+}
+
+func TestFIPSClientSigningAlgorithms(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	instance := createRekorInstance()
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewDeployAction())
+	result := a.Handle(ctx, instance)
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).ToNot(HaveOccurred())
+
+	dep := &v2.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{
+		Name:      actions.ServerDeploymentName,
+		Namespace: testNamespace,
+	}, dep)).To(Succeed())
+
+	container := dep.Spec.Template.Spec.Containers[0]
+	g.Expect(container.Args).To(ContainElement("--client-signing-algorithms"))
+	g.Expect(container.Args).To(ContainElement(fips.ClientSigningAlgorithms))
+}
+
+func TestNonFIPSNoClientSigningAlgorithms(t *testing.T) {
+	ctx := t.Context()
+	g := NewWithT(t)
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return false }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	instance := createRekorInstance()
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewDeployAction())
+	result := a.Handle(ctx, instance)
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).ToNot(HaveOccurred())
+
+	dep := &v2.Deployment{}
+	g.Expect(c.Get(ctx, client.ObjectKey{
+		Name:      actions.ServerDeploymentName,
+		Namespace: testNamespace,
+	}, dep)).To(Succeed())
+
+	container := dep.Spec.Template.Spec.Containers[0]
+	g.Expect(container.Args).ToNot(ContainElement("--client-signing-algorithms"))
+}
+
 func TestDeployAction_Handle_DefaultTrillianAddress(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	g := NewWithT(t)
 
 	instance := &rhtasv1.Rekor{

--- a/internal/controller/rekor/actions/server/generate_signer.go
+++ b/internal/controller/rekor/actions/server/generate_signer.go
@@ -34,6 +34,12 @@ func NewGenerateSignerAction() action.Action[*rhtasv1.Rekor] {
 			GenerateData: generateData,
 			AlignStatus:  alignStatus,
 			IsEnabled:    isEnabled,
+			PasswordRef: func(i *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
+				if i.Spec.Signer.KeyRef != nil {
+					return i.Spec.Signer.PasswordRef //nolint:staticcheck
+				}
+				return nil
+			},
 		}),
 	)
 }

--- a/internal/controller/rekor/actions/server/generate_signer_test.go
+++ b/internal/controller/rekor/actions/server/generate_signer_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -10,9 +11,11 @@ import (
 	"github.com/securesign/operator/internal/controller/rekor/actions"
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
+	"github.com/securesign/operator/internal/utils/fips"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -159,4 +162,70 @@ func TestRekorSigner_MigrationFromPreExistingSecret(t *testing.T) {
 func TestRekorSigner_DeterministicName(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(fmt.Sprintf(signerSecretNameFormat, "my-rekor")).To(Equal("rekor-signer-config-my-rekor"))
+}
+
+func TestRekorSigner_PasswordRefRejectedInFIPS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	instance := rekorInstance()
+	instance.Spec.Signer.KeyRef = &rhtasv1.SecretKeySelector{
+		LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-secret"},
+		Key:                  "private",
+	}
+	instance.Spec.Signer.PasswordRef = &rhtasv1.SecretKeySelector{ //nolint:staticcheck
+		LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-password"},
+		Key:                  "password",
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result.Err).To(HaveOccurred())
+	g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+	g.Expect(result.Err.Error()).To(ContainSubstring("FIPS"))
+	cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+}
+
+func TestRekorSigner_UnencryptedKeyAllowedInFIPS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	unencryptedKey, _, err := createSignerKey()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	instance := rekorInstance()
+	instance.Spec.Signer.KeyRef = &rhtasv1.SecretKeySelector{
+		LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-secret"},
+		Key:                  "private",
+	}
+
+	userSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-secret", Namespace: "default"},
+		Data:       map[string][]byte{"private": unencryptedKey},
+	}
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance, userSecret).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result.Err).ToNot(HaveOccurred())
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).To(BeTrue())
 }

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -42,6 +42,12 @@ func NewGenerateSignerAction() action.Action[*rhtasv1.TimestampAuthority] {
 				}
 				secret.Labels[labels.LabelNamespace+"/tsa.certchain.pem"] = tsaUtils.KeyCertificateChain
 			},
+			PasswordRef: func(i *rhtasv1.TimestampAuthority) *rhtasv1.SecretKeySelector {
+				if i.Spec.Signer.File != nil && i.Spec.Signer.File.PrivateKeyRef != nil {
+					return i.Spec.Signer.File.PasswordRef //nolint:staticcheck
+				}
+				return nil
+			},
 		}),
 	)
 }

--- a/internal/controller/tsa/actions/generate_signer_test.go
+++ b/internal/controller/tsa/actions/generate_signer_test.go
@@ -13,10 +13,12 @@ import (
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
+	"github.com/securesign/operator/internal/utils/fips"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func tsaInstance() *rhtasv1.TimestampAuthority {
@@ -264,6 +266,96 @@ func TestTSASigner_MigrationFromPreExistingSecret(t *testing.T) {
 func TestTSASigner_DeterministicName(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(fmt.Sprintf(signerSecretNameFormat, "my-tsa")).To(Equal("tsa-signer-config-my-tsa"))
+}
+
+func TestTSASigner_PasswordRefRejectedInFIPS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	instance := tsaInstance()
+	instance.Spec.Signer = rhtasv1.TimestampAuthoritySigner{
+		CertificateChain: rhtasv1.CertificateChain{
+			CertificateChainRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-cert-secret"},
+				Key:                  "certificateChain",
+			},
+		},
+		File: &rhtasv1.File{
+			PrivateKeyRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-key-secret"},
+				Key:                  "leafPrivateKey",
+			},
+			PasswordRef: &rhtasv1.SecretKeySelector{ //nolint:staticcheck
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-password"},
+				Key:                  "password",
+			},
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result.Err).To(HaveOccurred())
+	g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+	g.Expect(result.Err.Error()).To(ContainSubstring("FIPS"))
+	cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+}
+
+func TestTSASigner_UnencryptedKeyAllowedInFIPS(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	original := fips.Enabled
+	fips.Enabled = func() bool { return true }
+	t.Cleanup(func() { fips.Enabled = original })
+
+	unencryptedKey, err := generatePrivateKey()
+	g.Expect(err).ToNot(HaveOccurred())
+
+	instance := tsaInstance()
+	instance.Spec.Signer = rhtasv1.TimestampAuthoritySigner{
+		CertificateChain: rhtasv1.CertificateChain{
+			CertificateChainRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-cert-secret"},
+				Key:                  "certificateChain",
+			},
+		},
+		File: &rhtasv1.File{
+			PrivateKeyRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "user-key-secret"},
+				Key:                  "leafPrivateKey",
+			},
+		},
+	}
+
+	keySecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-key-secret", Namespace: "default"},
+		Data:       map[string][]byte{"leafPrivateKey": unencryptedKey},
+	}
+	certSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "user-cert-secret", Namespace: "default"},
+		Data:       map[string][]byte{"certificateChain": []byte("cert-data")},
+	}
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance, keySecret, certSecret).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result.Err).ToNot(HaveOccurred())
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, TSASignerCondition)).To(BeTrue())
 }
 
 func TestTSASigner_AlignStatusFields(t *testing.T) {

--- a/internal/utils/fips/fips.go
+++ b/internal/utils/fips/fips.go
@@ -8,3 +8,5 @@ import (
 var Enabled = fips140.Enabled
 
 var ErrPasswordRefInFIPS = errors.New("password-protected private keys are not allowed in FIPS mode: remove the password reference and provide an unencrypted key")
+
+const ClientSigningAlgorithms = "ecdsa-sha2-256-nistp256,ecdsa-sha2-384-nistp384,ecdsa-sha2-512-nistp521,rsa-sign-pkcs1-2048-sha256,rsa-sign-pkcs1-3072-sha256,rsa-sign-pkcs1-4096-sha256"

--- a/internal/utils/fips/fips.go
+++ b/internal/utils/fips/fips.go
@@ -1,0 +1,10 @@
+package fips
+
+import (
+	"crypto/fips140"
+	"errors"
+)
+
+var Enabled = fips140.Enabled
+
+var ErrPasswordRefInFIPS = errors.New("password-protected private keys are not allowed in FIPS mode: remove the password reference and provide an unencrypted key")

--- a/test/e2e/fips/fips_password_ref_test.go
+++ b/test/e2e/fips/fips_password_ref_test.go
@@ -1,0 +1,123 @@
+//go:build fips
+
+package fips
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	ctlogactions "github.com/securesign/operator/internal/controller/ctlog/actions"
+	fulcioactions "github.com/securesign/operator/internal/controller/fulcio/actions"
+	rekoractions "github.com/securesign/operator/internal/controller/rekor/actions"
+	tsaactions "github.com/securesign/operator/internal/controller/tsa/actions"
+	"github.com/securesign/operator/test/e2e/support"
+	"github.com/securesign/operator/test/e2e/support/postgresql"
+	"github.com/securesign/operator/test/e2e/support/steps"
+	"github.com/securesign/operator/test/e2e/support/tas/ctlog"
+	fulciohelpers "github.com/securesign/operator/test/e2e/support/tas/fulcio"
+	rekorhelpers "github.com/securesign/operator/test/e2e/support/tas/rekor"
+	"github.com/securesign/operator/test/e2e/support/tas/securesign"
+	tsahelpers "github.com/securesign/operator/test/e2e/support/tas/tsa"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("FIPS password-ref rejection", Ordered, func() {
+	cli, _ := support.CreateClient()
+
+	var namespace *v1.Namespace
+	var s *rhtasv1.Securesign
+
+	BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+		namespace = new
+	}))
+
+	BeforeAll(func(ctx SpecContext) {
+		Expect(postgresql.CreateDB(ctx, cli, namespace.Name, postgresql.DefaultSecretName, "fips-compliant-password")).To(Succeed())
+		postgresql.WaitAndLoadSchema(ctx, cli, namespace.Name)
+
+		s = securesign.Create(namespace.Name, "test-fips-reject",
+			securesign.WithFipsDefaults(namespace.Name),
+			securesign.WithProvidedEncryptedCerts(),
+		)
+		Expect(cli.Create(ctx, s)).To(Succeed())
+	})
+
+	findCondition := func(ctx context.Context, conditionType string, getCR func(context.Context) []metav1.Condition) *metav1.Condition {
+		conditions := getCR(ctx)
+		if conditions == nil {
+			return nil
+		}
+		return meta.FindStatusCondition(conditions, conditionType)
+	}
+
+	assertRejectsPasswordRef := func(conditionType string, getCR func(context.Context) []metav1.Condition) {
+		It("rejects password-ref with FIPS error", func(ctx SpecContext) {
+			Eventually(func(ctx context.Context) *metav1.Condition {
+				return findCondition(ctx, conditionType, getCR)
+			}).WithContext(ctx).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(
+				And(
+					Not(BeNil()),
+					WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionFalse)),
+					WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring("FIPS")),
+				),
+			)
+		})
+
+		It("does not retry (terminal error)", func(ctx SpecContext) {
+			Consistently(func(ctx context.Context) *metav1.Condition {
+				return findCondition(ctx, conditionType, getCR)
+			}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(
+				And(
+					Not(BeNil()),
+					WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionFalse)),
+					WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring("FIPS")),
+				),
+			)
+		})
+	}
+
+	Describe("CTlog", func() {
+		assertRejectsPasswordRef(ctlogactions.SignerCondition, func(ctx context.Context) []metav1.Condition {
+			cr := ctlog.Get(ctx, cli, namespace.Name, s.Name)
+			if cr == nil {
+				return nil
+			}
+			return cr.GetConditions()
+		})
+	})
+
+	Describe("Fulcio", func() {
+		assertRejectsPasswordRef(fulcioactions.CertCondition, func(ctx context.Context) []metav1.Condition {
+			cr := fulciohelpers.Get(ctx, cli, namespace.Name, s.Name)
+			if cr == nil {
+				return nil
+			}
+			return cr.GetConditions()
+		})
+	})
+
+	Describe("Rekor", func() {
+		assertRejectsPasswordRef(rekoractions.SignerCondition, func(ctx context.Context) []metav1.Condition {
+			cr := rekorhelpers.Get(ctx, cli, namespace.Name, s.Name)
+			if cr == nil {
+				return nil
+			}
+			return cr.GetConditions()
+		})
+	})
+
+	Describe("TSA", func() {
+		assertRejectsPasswordRef(tsaactions.TSASignerCondition, func(ctx context.Context) []metav1.Condition {
+			cr := tsahelpers.Get(ctx, cli, namespace.Name, s.Name)
+			if cr == nil {
+				return nil
+			}
+			return cr.GetConditions()
+		})
+	})
+})


### PR DESCRIPTION
## Summary
Reject password-protected private keys in FIPS mode and restrict client signing algorithms to FIPS-approved set for Fulcio and Rekor.
- Add PasswordRef callback to generateSigner framework that returns a TerminalError when a password reference is set in FIPS mode
- Pass --client-signing-algorithms flag with FIPS-approved ECDSA and RSA algorithms to Fulcio and Rekor deployments when FIPS is enabled
- Add unit and e2e tests for both features across all components