### PR TITLE
fix: remove unused error return from createConfigWithKeys

### DIFF
--- a/internal/controller/ctlog/utils/ctlog_config.go
+++ b/internal/controller/ctlog/utils/ctlog_config.go
@@ -135,26 +135,22 @@ func mustMarshalAny(pb proto.Message) *anypb.Any {
 	return ret
 }
 
-func createConfigWithKeys(certConfig *KeyConfig) (*Config, error) {
-	config := &Config{
+func createConfigWithKeys(certConfig *KeyConfig) *Config {
+	return &Config{
 		PubKey:          certConfig.PublicKey,
 		PrivKey:         certConfig.PrivateKey,
 		PrivKeyPassword: certConfig.PrivateKeyPass,
 	}
-	return config, nil
 }
 
 func CreateCtlogConfig(trillianUrl string, treeID int64, rootCerts []RootCertificate, keyConfig *KeyConfig) (map[string][]byte, error) {
-	ctlogConfig, err := createConfigWithKeys(keyConfig)
-	if err != nil {
-		return nil, err
-	}
+	ctlogConfig := createConfigWithKeys(keyConfig)
 	ctlogConfig.LogID = treeID
 	ctlogConfig.LogPrefix = "trusted-artifact-signer"
 	ctlogConfig.TrillianServerAddr = trillianUrl
 
 	for _, cert := range rootCerts {
-		if err = ctlogConfig.AddRootCertificate(cert); err != nil {
+		if err := ctlogConfig.AddRootCertificate(cert); err != nil {
 			return nil, fmt.Errorf("failed to add fulcio root: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix `unparam` linter finding: `createConfigWithKeys` always returned a nil error
- Remove the `error` from the return signature and simplify the caller in `CreateCtlogConfig`

## Test plan
- [x] `make lint` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)