### PR TITLE
fix: propagate cluster proxy config to in-cluster cosign e2e Job

### DIFF
--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	v12 "k8s.io/api/apps/v1"
 	v13 "k8s.io/api/batch/v1"
@@ -54,6 +55,7 @@ func CreateClient() (client.Client, error) {
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
 
 	cfg, err := config.GetConfig()
 	if err != nil {

--- a/test/e2e/support/tas/cosign/cosign_inCluster.go
+++ b/test/e2e/support/tas/cosign/cosign_inCluster.go
@@ -6,11 +6,15 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/securesign/operator/internal/utils/kubernetes/job"
 	"github.com/securesign/operator/test/e2e/support"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +65,32 @@ func (c *InClusterCosign) VerifyByCosign(ctx context.Context, targetImageName st
 	}).WithContext(ctx).WithPolling(2 * time.Second).Should(Succeed())
 }
 
+func (c *InClusterCosign) proxyEnvVars(ctx context.Context) ([]v1.EnvVar, error) {
+	p := &configv1.Proxy{}
+	if err := c.cli.Get(ctx, types.NamespacedName{Name: "cluster"}, p); err != nil {
+		if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get Proxy/cluster: %w", err)
+	}
+	var envs []v1.EnvVar
+	if p.Status.HTTPProxy != "" {
+		envs = append(envs, v1.EnvVar{Name: "HTTP_PROXY", Value: p.Status.HTTPProxy})
+	}
+	if p.Status.HTTPSProxy != "" {
+		envs = append(envs, v1.EnvVar{Name: "HTTPS_PROXY", Value: p.Status.HTTPSProxy})
+	}
+	if p.Status.NoProxy != "" {
+		envs = append(envs, v1.EnvVar{Name: "NO_PROXY", Value: p.Status.NoProxy})
+	}
+	return envs, nil
+}
+
 func (c *InClusterCosign) executeInJob(ctx context.Context, script string) error {
+	proxyEnvs, err := c.proxyEnvVars(ctx)
+	if err != nil {
+		return err
+	}
 	j := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "cosign-",
@@ -87,6 +116,7 @@ func (c *InClusterCosign) executeInJob(ctx context.Context, script string) error
 							Image:   cosignImage,
 							Command: []string{"/bin/sh", "-c"},
 							Args:    []string{script},
+							Env:     proxyEnvs,
 							SecurityContext: &v1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(false),
 								Capabilities: &v1.Capabilities{
@@ -99,7 +129,7 @@ func (c *InClusterCosign) executeInJob(ctx context.Context, script string) error
 			},
 		},
 	}
-	err := c.cli.Create(ctx, j)
+	err = c.cli.Create(ctx, j)
 	if err != nil {
 		return fmt.Errorf("failed to create job: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Port of #2006 (release-1.4) to main branch
- Reads the OpenShift `Proxy/cluster` object and injects `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` env vars into the in-cluster cosign Job containers
- Gracefully handles non-OpenShift clusters via `meta.IsNoMatchError`

## Test plan
- [ ] e2e tests pass on proxy-configured OpenShift cluster
- [ ] e2e tests pass on non-proxy cluster (no regression)
- [ ] e2e tests pass on non-OpenShift (kind/k3s) cluster

Jira: SECURESIGN-4999

🤖 Generated with [Claude Code](https://claude.com/claude-code)