### PR TITLE
fix: pin external repo checkouts to release-1.4 branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "securesign/tough"
+          ref: release-1.4
           path: tough
 
       - uses: actions/cache@v4
@@ -531,6 +532,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "securesign/sigstore-e2e"
+          ref: release-1.4
           path: e2e
 
       - name: Install Go


### PR DESCRIPTION
## Summary
- Add `ref: release-1.4` to `securesign/tough` and `securesign/sigstore-e2e` checkouts in CI workflow
- Without these, CI was testing against `develop` (tough) and `main` (sigstore-e2e) instead of `release-1.4`
- This was already correctly set on `release-1.3` but missed when `release-1.4` was cut

## Test plan
- [ ] Verify CI passes with the correct branches checked out

🤖 Generated with [Claude Code](https://claude.com/claude-code)