### PR TITLE
feat: validate user-provided crypto material for FIPS compliance

### DIFF
--- a/internal/action/fips/action.go
+++ b/internal/action/fips/action.go
@@ -1,0 +1,115 @@
+package fips
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/apis"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewAction creates a generic FIPS validation action that checks crypto
+// material and password refs before the signer action runs.
+func NewAction[T apis.ConditionsAwareObject](
+	conditionType string,
+	component string,
+	wrapper func(T) *wrapper[T],
+) action.Action[T] {
+	return &fipsAction[T]{
+		conditionType: conditionType,
+		component:     component,
+		wrapper:       wrapper,
+	}
+}
+
+type fipsAction[T apis.ConditionsAwareObject] struct {
+	action.BaseAction
+	conditionType string
+	component     string
+	wrapper       func(T) *wrapper[T]
+}
+
+func (i fipsAction[T]) Name() string {
+	return fmt.Sprintf("validate %s FIPS compliance", i.component)
+}
+
+func (i fipsAction[T]) CanHandle(_ context.Context, instance T) bool {
+	if !fipsutil.Enabled() {
+		return false
+	}
+
+	w := i.wrapper(instance)
+
+	c := meta.FindStatusCondition(instance.GetConditions(), constants.ReadyCondition)
+	switch {
+	case c == nil:
+		return false
+	case state.FromCondition(c) < state.Pending:
+		return false
+	case !w.IsEnabled():
+		return false
+	default:
+		cc := meta.FindStatusCondition(instance.GetConditions(), i.conditionType)
+		return cc == nil || cc.Status != metav1.ConditionTrue || instance.GetGeneration() != cc.ObservedGeneration
+	}
+}
+
+func (i fipsAction[T]) Handle(ctx context.Context, instance T) *action.Result {
+	w := i.wrapper(instance)
+
+	if w.PasswordRef() != nil {
+		err := reconcile.TerminalError(fipsutil.ErrPasswordRefInFIPS)
+		return i.Error(ctx, err, instance,
+			metav1.Condition{
+				Type:               i.conditionType,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Failure.String(),
+				Message:            err.Error(),
+				ObservedGeneration: instance.GetGeneration(),
+			},
+		)
+	}
+
+	if err := i.validateCryptoMaterial(ctx, w); err != nil {
+		if fipsutil.IsValidationError(err) {
+			return i.Error(ctx, reconcile.TerminalError(err), instance,
+				metav1.Condition{
+					Type:               i.conditionType,
+					Status:             metav1.ConditionFalse,
+					Reason:             state.Failure.String(),
+					Message:            err.Error(),
+					ObservedGeneration: instance.GetGeneration(),
+				},
+			)
+		}
+		return i.Continue()
+	}
+
+	instance.SetCondition(metav1.Condition{
+		Type:               i.conditionType,
+		Status:             metav1.ConditionTrue,
+		Reason:             "FIPSValid",
+		Message:            "All crypto material is FIPS-compliant",
+		ObservedGeneration: instance.GetGeneration(),
+	})
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+}
+
+func (i fipsAction[T]) validateCryptoMaterial(ctx context.Context, w *wrapper[T]) error {
+	refs, err := w.CryptoMaterial(ctx, i.Client)
+	if err != nil {
+		return err
+	}
+	for _, ref := range refs {
+		if err := ref.Validate(ref.Data); err != nil {
+			return fmt.Errorf("FIPS validation failed for %s: %w", ref.FieldPath, err)
+		}
+	}
+	return nil
+}

--- a/internal/action/fips/action_test.go
+++ b/internal/action/fips/action_test.go
@@ -1,0 +1,455 @@
+package fips
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	testCondition    = "TestSignerCondition"
+	testComponent    = "test-component"
+	testInstanceName = "test-instance"
+	testNamespace    = "default"
+)
+
+func testInstance(conditions ...metav1.Condition) *rhtasv1.Rekor {
+	instance := &rhtasv1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testInstanceName, Namespace: testNamespace, Generation: 1,
+		},
+	}
+	for _, c := range conditions {
+		meta.SetStatusCondition(&instance.Status.Conditions, c)
+	}
+	return instance
+}
+
+func pendingConditions() []metav1.Condition {
+	return []metav1.Condition{
+		{Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Pending.String()},
+		{Type: testCondition, Status: metav1.ConditionFalse, Reason: state.Pending.String()},
+	}
+}
+
+func testFIPSWrapper(
+	passwordRef func(*rhtasv1.Rekor) *rhtasv1.SecretKeySelector,
+	cryptoMaterial func(context.Context, *rhtasv1.Rekor, client.Client) ([]CryptoRef, error),
+) func(*rhtasv1.Rekor) *wrapper[*rhtasv1.Rekor] {
+	return Wrapper(Config[*rhtasv1.Rekor]{
+		PasswordRef:    passwordRef,
+		CryptoMaterial: cryptoMaterial,
+		IsEnabled:      func(_ *rhtasv1.Rekor) bool { return true },
+	})
+}
+
+func generateRSAKeyPEM(t *testing.T, bits int) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(key)
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func generateEd25519KeyPEM(t *testing.T) []byte {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestCanHandle(t *testing.T) {
+	original := fipsutil.Enabled
+	fipsutil.Enabled = func() bool { return true }
+	t.Cleanup(func() { fipsutil.Enabled = original })
+
+	tests := []struct {
+		name      string
+		instance  *rhtasv1.Rekor
+		canHandle bool
+	}{
+		{
+			name:      "no ReadyCondition",
+			instance:  testInstance(),
+			canHandle: false,
+		},
+		{
+			name: "ReadyCondition below Pending",
+			instance: testInstance(metav1.Condition{
+				Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.NotDefined.String(),
+			}),
+			canHandle: false,
+		},
+		{
+			name: "no component condition",
+			instance: testInstance(metav1.Condition{
+				Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Pending.String(),
+			}),
+			canHandle: true,
+		},
+		{
+			name:      "component condition false",
+			instance:  testInstance(pendingConditions()...),
+			canHandle: true,
+		},
+		{
+			name: "component condition true, matching generation",
+			instance: testInstance(
+				metav1.Condition{Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Pending.String()},
+				metav1.Condition{Type: testCondition, Status: metav1.ConditionTrue, Reason: "Resolved", ObservedGeneration: 1},
+			),
+			canHandle: false,
+		},
+		{
+			name: "component condition true, stale generation",
+			instance: testInstance(
+				metav1.Condition{Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Pending.String()},
+				metav1.Condition{Type: testCondition, Status: metav1.ConditionTrue, Reason: "Resolved", ObservedGeneration: 0},
+			),
+			canHandle: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			cli := testAction.FakeClientBuilder().Build()
+			a := testAction.PrepareAction(cli, NewAction(
+				testCondition, testComponent,
+				testFIPSWrapper(nil, nil),
+			))
+			g.Expect(a.CanHandle(t.Context(), tt.instance)).To(Equal(tt.canHandle))
+		})
+	}
+}
+
+func TestCanHandle_FIPSDisabled(t *testing.T) {
+	original := fipsutil.Enabled
+	fipsutil.Enabled = func() bool { return false }
+	t.Cleanup(func() { fipsutil.Enabled = original })
+
+	t.Run("returns false when FIPS is disabled", func(t *testing.T) {
+		g := NewWithT(t)
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().Build()
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			testFIPSWrapper(nil, nil),
+		))
+
+		g.Expect(a.CanHandle(t.Context(), instance)).To(BeFalse())
+	})
+}
+
+func TestCanHandle_IsEnabledFalse(t *testing.T) {
+	original := fipsutil.Enabled
+	fipsutil.Enabled = func() bool { return true }
+	t.Cleanup(func() { fipsutil.Enabled = original })
+
+	t.Run("returns false when IsEnabled returns false", func(t *testing.T) {
+		g := NewWithT(t)
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().Build()
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			Wrapper(Config[*rhtasv1.Rekor]{
+				IsEnabled: func(_ *rhtasv1.Rekor) bool { return false },
+			}),
+		))
+
+		g.Expect(a.CanHandle(t.Context(), instance)).To(BeFalse())
+	})
+}
+
+func TestHandle_FIPSPasswordRefGuard(t *testing.T) {
+	original := fipsutil.Enabled
+	fipsutil.Enabled = func() bool { return true }
+	t.Cleanup(func() { fipsutil.Enabled = original })
+
+	t.Run("rejects PasswordRef as terminal error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			testFIPSWrapper(
+				func(_ *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
+					return &rhtasv1.SecretKeySelector{
+						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "password-secret"},
+						Key:                  "password",
+					}
+				},
+				nil,
+			),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.Err).To(HaveOccurred())
+		g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+		g.Expect(errors.Is(result.Err, fipsutil.ErrPasswordRefInFIPS)).To(BeTrue())
+	})
+
+	t.Run("allows nil PasswordRef in FIPS mode", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			testFIPSWrapper(
+				func(_ *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
+					return nil
+				},
+				nil,
+			),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result).To(Equal(testAction.Return()))
+	})
+}
+
+func TestHandle_FIPSCryptoValidation(t *testing.T) {
+	original := fipsutil.Enabled
+	fipsutil.Enabled = func() bool { return true }
+	t.Cleanup(func() { fipsutil.Enabled = original })
+
+	cryptoMaterialWrapper := func(secretName string) func(*rhtasv1.Rekor) *wrapper[*rhtasv1.Rekor] {
+		return testFIPSWrapper(
+			nil,
+			func(_ context.Context, _ *rhtasv1.Rekor, c client.Client) ([]CryptoRef, error) {
+				secret := &corev1.Secret{}
+				if err := c.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: testNamespace}, secret); err != nil {
+					return nil, err
+				}
+				return []CryptoRef{{
+					FieldPath: "spec.signer.keyRef",
+					Data:      secret.Data["private"],
+					Validate:  fipsutil.ValidatePrivateKeyPEM,
+				}}, nil
+			},
+		)
+	}
+
+	t.Run("accepts Ed25519 key", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		instance := testInstance(pendingConditions()...)
+
+		keyPEM := generateEd25519KeyPEM(t)
+		keySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "ed25519-secret", Namespace: testNamespace},
+			Data:       map[string][]byte{"private": keyPEM},
+		}
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance, keySecret).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			cryptoMaterialWrapper("ed25519-secret"),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result).To(Equal(testAction.Return()))
+	})
+
+	t.Run("rejects RSA-1024 key as terminal error", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		instance := testInstance(pendingConditions()...)
+
+		keyPEM := generateRSAKeyPEM(t, 1024)
+		keySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "rsa1024-secret", Namespace: testNamespace},
+			Data:       map[string][]byte{"private": keyPEM},
+		}
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance, keySecret).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			cryptoMaterialWrapper("rsa1024-secret"),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.Err).To(HaveOccurred())
+		g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+		g.Expect(result.Err.Error()).To(ContainSubstring("FIPS validation failed"))
+
+		cc := meta.FindStatusCondition(instance.Status.Conditions, testCondition)
+		g.Expect(cc).ToNot(BeNil())
+		g.Expect(cc.Status).To(Equal(metav1.ConditionFalse))
+	})
+
+	t.Run("skips validation when CryptoMaterial callback is nil", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			testFIPSWrapper(nil, nil),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result).To(Equal(testAction.Return()))
+	})
+}
+
+func TestHandle_CryptoMaterialCallbackError(t *testing.T) {
+	original := fipsutil.Enabled
+	fipsutil.Enabled = func() bool { return true }
+	t.Cleanup(func() { fipsutil.Enabled = original })
+
+	t.Run("ValidationError from CryptoMaterial is terminal", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			testFIPSWrapper(
+				nil,
+				func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) ([]CryptoRef, error) {
+					return nil, fipsutil.NewValidationError(fmt.Errorf("invalid base64: illegal data"))
+				},
+			),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result).ToNot(BeNil())
+		g.Expect(result.Err).To(HaveOccurred())
+		g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+
+		cc := meta.FindStatusCondition(instance.Status.Conditions, testCondition)
+		g.Expect(cc).ToNot(BeNil())
+		g.Expect(cc.Status).To(Equal(metav1.ConditionFalse))
+	})
+
+	t.Run("plain error from CryptoMaterial is transient", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			testFIPSWrapper(
+				nil,
+				func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) ([]CryptoRef, error) {
+					return nil, fmt.Errorf("secret not found")
+				},
+			),
+		))
+
+		result := a.Handle(ctx, instance)
+
+		g.Expect(result).To(Equal(testAction.Continue()))
+	})
+}
+
+func TestHandle_ConditionSetOnSuccess(t *testing.T) {
+	original := fipsutil.Enabled
+	fipsutil.Enabled = func() bool { return true }
+	t.Cleanup(func() { fipsutil.Enabled = original })
+
+	t.Run("sets condition to True on successful validation", func(t *testing.T) {
+		g := NewWithT(t)
+		instance := testInstance(pendingConditions()...)
+
+		cli := testAction.FakeClientBuilder().
+			WithObjects(instance).
+			WithStatusSubresource(instance).
+			Build()
+
+		a := testAction.PrepareAction(cli, NewAction(
+			testCondition, testComponent,
+			Wrapper(Config[*rhtasv1.Rekor]{
+				IsEnabled: func(_ *rhtasv1.Rekor) bool { return true },
+			}),
+		))
+
+		result := a.Handle(t.Context(), instance)
+		g.Expect(result).To(Equal(testAction.Return()))
+
+		cc := meta.FindStatusCondition(instance.Status.Conditions, testCondition)
+		g.Expect(cc).ToNot(BeNil())
+		g.Expect(cc.Status).To(Equal(metav1.ConditionTrue))
+		g.Expect(cc.Reason).To(Equal("FIPSValid"))
+	})
+}

--- a/internal/action/fips/doc.go
+++ b/internal/action/fips/doc.go
@@ -1,0 +1,50 @@
+// Package fips provides a generic action for validating cryptographic material
+// and settings against FIPS 140 compliance requirements.
+//
+// # Workflow
+//
+// The action runs before the signer action. When FIPS mode is disabled
+// (CanHandle returns false), the action is completely skipped.
+//
+// When FIPS mode is active, Handle performs two checks:
+//
+//  1. Password-ref guard: if PasswordRef() returns a non-nil selector,
+//     password-protected keys are forbidden in FIPS mode. Returns a TerminalError.
+//
+//  2. Crypto material validation: calls CryptoMaterial() to fetch user-provided
+//     secrets, then validates each [CryptoRef] using its Validate function.
+//     Returns a TerminalError for validation failures and Continue() for
+//     transient secret-read failures.
+//
+// On success, the action sets the FIPSCondition to True and persists the
+// status update.
+//
+// # Config Callbacks
+//
+// Each component provides a thin Config with these callbacks:
+//
+//   - PasswordRef: extract the password-ref selector from the instance.
+//     Returns nil when there is no password ref (no FIPS check needed).
+//   - CryptoMaterial: fetch and return user-provided crypto material for
+//     FIPS validation. Returns nil when there is no user-provided material.
+//   - IsEnabled: (optional) return false for paths that don't need validation
+//     (e.g., KMS, Tink). Nil defaults to true.
+//
+// # Usage
+//
+//	func NewFIPSValidationAction() action.Action[*rhtasv1.Rekor] {
+//	    return fips.NewAction(
+//	        actions.SignerCondition,
+//	        actions.ServerComponentName,
+//	        fips.Wrapper(fips.Config[*rhtasv1.Rekor]{
+//	            PasswordRef: func(i *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
+//	                if i.Spec.Signer.KeyRef != nil {
+//	                    return i.Spec.Signer.PasswordRef
+//	                }
+//	                return nil
+//	            },
+//	            CryptoMaterial: rekorCryptoMaterial,
+//	        }),
+//	    )
+//	}
+package fips

--- a/internal/action/fips/types.go
+++ b/internal/action/fips/types.go
@@ -1,0 +1,89 @@
+package fips
+
+import (
+	"context"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/apis"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CryptoRef represents a piece of cryptographic material to be validated
+// for FIPS compliance.
+type CryptoRef struct {
+	FieldPath string
+	Data      []byte
+	Validate  func([]byte) error
+}
+
+// Config holds the component-specific callbacks for the generic FIPS
+// validation action.
+type Config[T apis.ConditionsAwareObject] struct {
+	// PasswordRef extracts the password-ref selector from the instance's spec.
+	// When non-nil and FIPS mode is active, Handle returns a TerminalError
+	// (password-protected keys are forbidden in FIPS).
+	// Nil disables the FIPS password-ref guard.
+	PasswordRef func(T) *rhtasv1.SecretKeySelector
+
+	// CryptoMaterial extracts user-provided crypto material from Kubernetes secrets
+	// for FIPS validation. Returns a slice of CryptoRef values to validate.
+	// Nil disables FIPS crypto validation.
+	CryptoMaterial func(context.Context, T, client.Client) ([]CryptoRef, error)
+
+	// IsEnabled returns false for paths that don't need FIPS validation
+	// (e.g., KMS, Tink). Nil defaults to true.
+	IsEnabled func(T) bool
+}
+
+// Wrapper creates a wrapper function from a Config, suitable for passing
+// to NewAction.
+func Wrapper[T apis.ConditionsAwareObject](cfg Config[T]) func(T) *wrapper[T] {
+	return func(obj T) *wrapper[T] {
+		return &wrapper[T]{
+			object: obj,
+			cfg:    cfg,
+		}
+	}
+}
+
+type wrapper[T apis.ConditionsAwareObject] struct {
+	object T
+	cfg    Config[T]
+}
+
+func (w *wrapper[T]) PasswordRef() *rhtasv1.SecretKeySelector {
+	if w.cfg.PasswordRef == nil {
+		return nil
+	}
+	return w.cfg.PasswordRef(w.object)
+}
+
+func (w *wrapper[T]) CryptoMaterial(ctx context.Context, c client.Client) ([]CryptoRef, error) {
+	if w.cfg.CryptoMaterial == nil {
+		return nil, nil
+	}
+	return w.cfg.CryptoMaterial(ctx, w.object, c)
+}
+
+func (w *wrapper[T]) IsEnabled() bool {
+	if w.cfg.IsEnabled == nil {
+		return true
+	}
+	return w.cfg.IsEnabled(w.object)
+}
+
+// AppendSecretRef fetches secret data and appends a CryptoRef. If ref is nil, it's a no-op.
+func AppendSecretRef(ctx context.Context, c client.Client, namespace string,
+	ref *rhtasv1.SecretKeySelector, fieldPath string,
+	validate func([]byte) error, refs *[]CryptoRef) error {
+	if ref == nil {
+		return nil
+	}
+	data, err := kubernetes.GetSecretData(ctx, c, namespace, ref)
+	if err != nil {
+		return err
+	}
+	*refs = append(*refs, CryptoRef{FieldPath: fieldPath, Data: data, Validate: validate})
+	return nil
+}

--- a/internal/action/generateSigner/action.go
+++ b/internal/action/generateSigner/action.go
@@ -14,7 +14,6 @@ import (
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
-	"github.com/securesign/operator/internal/utils/fips"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
 	corev1 "k8s.io/api/core/v1"
@@ -76,26 +75,6 @@ func (i signerAction[T]) CanHandle(_ context.Context, instance T) bool {
 
 func (i signerAction[T]) Handle(ctx context.Context, instance T) *action.Result {
 	w := i.wrapper(instance)
-
-	if fips.Enabled() && w.PasswordRef() != nil {
-		err := reconcile.TerminalError(fips.ErrPasswordRefInFIPS)
-		return i.Error(ctx, err, instance,
-			metav1.Condition{
-				Type:               i.conditionType,
-				Status:             metav1.ConditionFalse,
-				Reason:             state.Failure.String(),
-				Message:            err.Error(),
-				ObservedGeneration: instance.GetGeneration(),
-			},
-			metav1.Condition{
-				Type:               constants.ReadyCondition,
-				Status:             metav1.ConditionFalse,
-				Reason:             state.Pending.String(),
-				Message:            err.Error(),
-				ObservedGeneration: instance.GetGeneration(),
-			},
-		)
-	}
 
 	resolvedRef, err := w.ResolveRef(ctx, i.Client)
 	if err != nil {

--- a/internal/action/generateSigner/action_test.go
+++ b/internal/action/generateSigner/action_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
-	"github.com/securesign/operator/internal/utils/fips"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -445,89 +444,4 @@ func TestHandle(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestHandle_FIPSPasswordRefGuard(t *testing.T) {
-	original := fips.Enabled
-	fips.Enabled = func() bool { return true }
-	t.Cleanup(func() { fips.Enabled = original })
-
-	t.Run("rejects PasswordRef as terminal error", func(t *testing.T) {
-		g := NewWithT(t)
-		ctx := t.Context()
-		instance := testInstance(pendingConditions()...)
-
-		cli := testAction.FakeClientBuilder().
-			WithObjects(instance).
-			WithStatusSubresource(instance).
-			Build()
-
-		a := testAction.PrepareAction(cli, NewAction(
-			testCondition, testNameFormat, testComponent, testDeployment,
-			Wrapper(Config[*rhtasv1.Rekor]{
-				ResolveRef: func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) (*rhtasv1.SecretKeySelector, error) {
-					return nil, nil
-				},
-				GenerateData: func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) (map[string][]byte, error) {
-					return testData, nil
-				},
-				AlignStatus: func(r *rhtasv1.Rekor, ref rhtasv1.SecretKeySelector) {
-					r.Status.Signer.KeyRef = &rhtasv1.SecretKeySelector{
-						Key:                  "private",
-						LocalObjectReference: ref.LocalObjectReference,
-					}
-				},
-				IsEnabled: func(_ *rhtasv1.Rekor) bool { return true },
-				PasswordRef: func(_ *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
-					return &rhtasv1.SecretKeySelector{
-						LocalObjectReference: rhtasv1.LocalObjectReference{Name: "password-secret"},
-						Key:                  "password",
-					}
-				},
-			}),
-		))
-
-		result := a.Handle(ctx, instance)
-
-		g.Expect(result.Err).To(HaveOccurred())
-		g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
-		g.Expect(errors.Is(result.Err, fips.ErrPasswordRefInFIPS)).To(BeTrue())
-	})
-
-	t.Run("allows nil PasswordRef in FIPS mode", func(t *testing.T) {
-		g := NewWithT(t)
-		ctx := t.Context()
-		instance := testInstance(pendingConditions()...)
-
-		cli := testAction.FakeClientBuilder().
-			WithObjects(instance).
-			WithStatusSubresource(instance).
-			Build()
-
-		a := testAction.PrepareAction(cli, NewAction(
-			testCondition, testNameFormat, testComponent, testDeployment,
-			Wrapper(Config[*rhtasv1.Rekor]{
-				ResolveRef: func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) (*rhtasv1.SecretKeySelector, error) {
-					return nil, nil
-				},
-				GenerateData: func(_ context.Context, _ *rhtasv1.Rekor, _ client.Client) (map[string][]byte, error) {
-					return testData, nil
-				},
-				AlignStatus: func(r *rhtasv1.Rekor, ref rhtasv1.SecretKeySelector) {
-					r.Status.Signer.KeyRef = &rhtasv1.SecretKeySelector{
-						Key:                  "private",
-						LocalObjectReference: ref.LocalObjectReference,
-					}
-				},
-				IsEnabled: func(_ *rhtasv1.Rekor) bool { return true },
-				PasswordRef: func(_ *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
-					return nil
-				},
-			}),
-		))
-
-		result := a.Handle(ctx, instance)
-
-		g.Expect(result).To(Equal(testAction.Return()))
-	})
 }

--- a/internal/action/generateSigner/doc.go
+++ b/internal/action/generateSigner/doc.go
@@ -6,10 +6,9 @@
 // The action follows a create-once, verify-always pattern. Signer keys are
 // generated ONLY on fresh installation. After creation the secret is immutable
 // (Kubernetes enforces data immutability). Most errors are retriable —
-// terminal errors come from the FIPS password-ref guard in [signerAction.Handle],
-// from component-level [Config.ResolveRef] callbacks (e.g., invalid spec combinations
-// such as a missing private key or CA certificate), and from [Config.GenerateData]
-// callbacks.
+// terminal errors come from component-level [Config.ResolveRef] callbacks
+// (e.g., invalid spec combinations such as a missing private key or CA
+// certificate) and from [Config.GenerateData] callbacks.
 //
 // Handle executes the following decision tree on every reconcile:
 //
@@ -44,9 +43,6 @@
 //     adds TUF autodiscovery labels (e.g., fulcio_v1.crt.pem, tsa.certchain.pem).
 //     Also applied to user-provided secrets in the resolved path as a temporary
 //     workaround until dedicated resolve_pub_key actions are implemented.
-//   - PasswordRef: (optional) extract the password-ref selector from the instance.
-//     When set and FIPS mode is active, [signerAction.Handle] returns a terminal
-//     error if the selector is non-nil — password-protected keys are forbidden in FIPS.
 //
 // # Upgrade Path
 //
@@ -68,12 +64,6 @@
 //	            GenerateData: generateData,
 //	            AlignStatus:  alignStatus,
 //	            IsEnabled:    isEnabled,
-//	            PasswordRef: func(i *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
-//	                if i.Spec.Signer.KeyRef != nil {
-//	                    return i.Spec.Signer.PasswordRef
-//	                }
-//	                return nil
-//	            },
 //	        }),
 //	    )
 //	}

--- a/internal/action/generateSigner/types.go
+++ b/internal/action/generateSigner/types.go
@@ -38,12 +38,6 @@ type Config[T apis.ConditionsAwareObject] struct {
 	// to add labels, annotations, or modify the secret in any way.
 	// Nil is a no-op.
 	MutateSecret func(T, *corev1.Secret)
-
-	// PasswordRef extracts the password-ref selector from the instance's spec.
-	// When non-nil and FIPS mode is active, Handle returns a TerminalError
-	// if the selector is non-nil (password-protected keys are forbidden in FIPS).
-	// Nil disables the FIPS password-ref guard.
-	PasswordRef func(T) *rhtasv1.SecretKeySelector
 }
 
 func Wrapper[T apis.ConditionsAwareObject](cfg Config[T]) func(T) *wrapper[T] {
@@ -62,13 +56,6 @@ type wrapper[T apis.ConditionsAwareObject] struct {
 
 func (w *wrapper[T]) ResolveRef(ctx context.Context, c client.Client) (*rhtasv1.SecretKeySelector, error) {
 	return w.cfg.ResolveRef(ctx, w.object, c)
-}
-
-func (w *wrapper[T]) PasswordRef() *rhtasv1.SecretKeySelector {
-	if w.cfg.PasswordRef == nil {
-		return nil
-	}
-	return w.cfg.PasswordRef(w.object)
 }
 
 func (w *wrapper[T]) GenerateData(ctx context.Context, c client.Client) (map[string][]byte, error) {

--- a/internal/controller/ctlog/actions/fips_validation.go
+++ b/internal/controller/ctlog/actions/fips_validation.go
@@ -1,0 +1,84 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	fipsAction "github.com/securesign/operator/internal/action/fips"
+	ctlogUtils "github.com/securesign/operator/internal/controller/ctlog/utils"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewFIPSValidationAction() action.Action[*rhtasv1.CTlog] {
+	return fipsAction.NewAction(
+		fipsutil.FIPSCondition,
+		ComponentName,
+		fipsAction.Wrapper(fipsAction.Config[*rhtasv1.CTlog]{
+			PasswordRef: func(i *rhtasv1.CTlog) *rhtasv1.SecretKeySelector {
+				if i.Spec.PrivateKeyRef != nil {
+					return i.Spec.PrivateKeyPasswordRef //nolint:staticcheck
+				}
+				return nil
+			},
+			CryptoMaterial: ctlogCryptoMaterial,
+		}),
+	)
+}
+
+func ctlogCryptoMaterial(ctx context.Context, i *rhtasv1.CTlog, c client.Client) ([]fipsAction.CryptoRef, error) {
+	var refs []fipsAction.CryptoRef
+
+	// Signer keys
+	if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.PrivateKeyRef,
+		"spec.privateKeyRef", fipsutil.ValidatePrivateKeyPEM, &refs); err != nil {
+		return nil, err
+	}
+	if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.PublicKeyRef,
+		"spec.publicKeyRef", fipsutil.ValidatePublicKeyPEM, &refs); err != nil {
+		return nil, err
+	}
+
+	// TLS material
+	if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.TLS.CertRef,
+		"spec.tls.certificateRef", fipsutil.ValidateCertificateChainPEM, &refs); err != nil {
+		return nil, err
+	}
+	if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.TLS.PrivateKeyRef,
+		"spec.tls.privateKeyRef", fipsutil.ValidatePrivateKeyPEM, &refs); err != nil {
+		return nil, err
+	}
+
+	// Root certificates (populated by HandleFulcioCertAction before this action runs)
+	for idx := range i.Status.RootCertificates {
+		if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, &i.Status.RootCertificates[idx],
+			fmt.Sprintf("status.rootCertificates[%d]", idx), fipsutil.ValidateCertificateChainPEM, &refs); err != nil {
+			return nil, err
+		}
+	}
+
+	// Custom server config crypto material
+	if i.Spec.ServerConfigRef != nil {
+		secret, err := kubernetes.GetSecret(ctx, c, i.Namespace, i.Spec.ServerConfigRef.Name)
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range slices.Sorted(maps.Keys(secret.Data)) {
+			if key == ctlogUtils.ConfigKey || key == ctlogUtils.Password {
+				continue
+			}
+			refs = append(refs, fipsAction.CryptoRef{
+				FieldPath: fmt.Sprintf("spec.serverConfigRef[%s]", key),
+				Data:      secret.Data[key],
+				Validate:  fipsutil.ValidateCryptoMaterialIfPEM,
+			})
+		}
+	}
+
+	return refs, nil
+}

--- a/internal/controller/ctlog/actions/generate_signer.go
+++ b/internal/controller/ctlog/actions/generate_signer.go
@@ -36,12 +36,6 @@ func NewGenerateSignerAction() action.Action[*rhtasv1.CTlog] {
 				}
 				secret.Labels[labels.LabelNamespace+"/ctfe.pub"] = constants.KeyPublic
 			},
-			PasswordRef: func(i *rhtasv1.CTlog) *rhtasv1.SecretKeySelector {
-				if i.Spec.PrivateKeyRef != nil {
-					return i.Spec.PrivateKeyPasswordRef //nolint:staticcheck
-				}
-				return nil
-			},
 		}),
 	)
 }

--- a/internal/controller/ctlog/actions/generate_signer_test.go
+++ b/internal/controller/ctlog/actions/generate_signer_test.go
@@ -228,7 +228,7 @@ func TestCTlogKeys_PasswordRefRejectedInFIPS(t *testing.T) {
 		WithStatusSubresource(instance).
 		Build()
 
-	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	a := testAction.PrepareAction(c, NewFIPSValidationAction())
 	result := a.Handle(ctx, instance)
 
 	g.Expect(result.Err).To(HaveOccurred())
@@ -267,9 +267,8 @@ func TestCTlogKeys_UnencryptedKeyAllowedInFIPS(t *testing.T) {
 		WithStatusSubresource(instance).
 		Build()
 
-	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	a := testAction.PrepareAction(c, NewFIPSValidationAction())
 	result := a.Handle(ctx, instance)
 
-	g.Expect(result.Err).ToNot(HaveOccurred())
-	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, SignerCondition)).To(BeTrue())
+	g.Expect(result).To(Equal(testAction.Return()))
 }

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/securesign/operator/internal/controller"
 
 	"github.com/securesign/operator/internal/controller/ctlog/actions"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	v12 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
@@ -96,7 +97,8 @@ func (r *ctlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	target := instance.DeepCopy()
 	conditionSupplier := func(_ *rhtasv1.CTlog) []string {
-		return []string{actions.CertCondition, actions.SignerCondition, actions.ConfigCondition, actions.TLSCondition, trustmaterial.TrustMaterialCondition}
+		conditions := []string{actions.CertCondition, actions.SignerCondition, actions.ConfigCondition, actions.TLSCondition, trustmaterial.TrustMaterialCondition}
+		return fipsutil.AppendFIPSCondition(conditions)
 	}
 	acs := []action.Action[*rhtasv1.CTlog]{
 		transitions.NewToPendingPhaseAction[*rhtasv1.CTlog](),
@@ -107,6 +109,7 @@ func (r *ctlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		transitions.NewToCreatePhaseAction[*rhtasv1.CTlog](),
 
 		actions.NewHandleFulcioCertAction(),
+		actions.NewFIPSValidationAction(),
 		actions.NewGenerateSignerAction(),
 		actions.NewResolveTreeAction(),
 		actions.NewServerConfigAction(),

--- a/internal/controller/fulcio/actions/fips_validation.go
+++ b/internal/controller/fulcio/actions/fips_validation.go
@@ -1,0 +1,38 @@
+package actions
+
+import (
+	"context"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	fipsAction "github.com/securesign/operator/internal/action/fips"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewFIPSValidationAction() action.Action[*rhtasv1.Fulcio] {
+	return fipsAction.NewAction(
+		fipsutil.FIPSCondition,
+		ComponentName,
+		fipsAction.Wrapper(fipsAction.Config[*rhtasv1.Fulcio]{
+			PasswordRef: func(i *rhtasv1.Fulcio) *rhtasv1.SecretKeySelector {
+				if i.Spec.Certificate.PrivateKeyRef != nil {
+					return i.Spec.Certificate.PrivateKeyPasswordRef //nolint:staticcheck
+				}
+				return nil
+			},
+			CryptoMaterial: func(ctx context.Context, i *rhtasv1.Fulcio, c client.Client) ([]fipsAction.CryptoRef, error) {
+				var refs []fipsAction.CryptoRef
+				if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.Certificate.PrivateKeyRef,
+					"spec.certificate.privateKeyRef", fipsutil.ValidatePrivateKeyPEM, &refs); err != nil {
+					return nil, err
+				}
+				if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.Certificate.CARef,
+					"spec.certificate.caRef", fipsutil.ValidateCertificateChainPEM, &refs); err != nil {
+					return nil, err
+				}
+				return refs, nil
+			},
+		}),
+	)
+}

--- a/internal/controller/fulcio/actions/generate_signer.go
+++ b/internal/controller/fulcio/actions/generate_signer.go
@@ -45,12 +45,6 @@ func NewGenerateSignerAction() action.Action[*rhtasv1.Fulcio] {
 				}
 				secret.Labels[FulcioCALabel] = constants.KeyCert
 			},
-			PasswordRef: func(i *rhtasv1.Fulcio) *rhtasv1.SecretKeySelector {
-				if i.Spec.Certificate.PrivateKeyRef != nil {
-					return i.Spec.Certificate.PrivateKeyPasswordRef //nolint:staticcheck
-				}
-				return nil
-			},
 		}),
 	)
 }

--- a/internal/controller/fulcio/actions/generate_signer_test.go
+++ b/internal/controller/fulcio/actions/generate_signer_test.go
@@ -404,7 +404,7 @@ func TestFulcioCert_PasswordRefRejectedInFIPS(t *testing.T) {
 		WithStatusSubresource(instance).
 		Build()
 
-	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	a := testAction.PrepareAction(c, NewFIPSValidationAction())
 	result := a.Handle(ctx, instance)
 
 	g.Expect(result.Err).To(HaveOccurred())
@@ -427,6 +427,14 @@ func TestFulcioCert_UnencryptedKeyAllowedInFIPS(t *testing.T) {
 	unencryptedKey, err := utils.CreateCAKey(ecKey)
 	g.Expect(err).ToNot(HaveOccurred())
 
+	certConfig := &utils.FulcioCertConfig{
+		OrganizationName: "Test",
+		CommonName:       "test-ca",
+		PrivateKey:       unencryptedKey,
+	}
+	certPEM, err := utils.CreateFulcioCA(certConfig)
+	g.Expect(err).ToNot(HaveOccurred())
+
 	instance := fulcioInstance()
 	instance.Spec.Certificate = rhtasv1.FulcioCert{
 		PrivateKeyRef: &rhtasv1.SecretKeySelector{
@@ -447,15 +455,14 @@ func TestFulcioCert_UnencryptedKeyAllowedInFIPS(t *testing.T) {
 			},
 			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "user-cert", Namespace: "default"},
-				Data:       map[string][]byte{"cert": []byte("fake-cert")},
+				Data:       map[string][]byte{"cert": certPEM},
 			},
 		).
 		WithStatusSubresource(instance).
 		Build()
 
-	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	a := testAction.PrepareAction(c, NewFIPSValidationAction())
 	result := a.Handle(ctx, instance)
 
-	g.Expect(result.Err).ToNot(HaveOccurred())
-	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, CertCondition)).To(BeTrue())
+	g.Expect(result).To(Equal(testAction.Return()))
 }

--- a/internal/controller/fulcio/fulcio_controller.go
+++ b/internal/controller/fulcio/fulcio_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/securesign/operator/internal/action/trustmaterial"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	"k8s.io/apimachinery/pkg/types"
 
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
@@ -95,11 +96,13 @@ func (r *fulcioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	target := instance.DeepCopy()
 	conditionSupplier := func(_ *rhtasv1.Fulcio) []string {
-		return []string{actions.CertCondition, trustmaterial.TrustMaterialCondition}
+		conditions := []string{actions.CertCondition, trustmaterial.TrustMaterialCondition}
+		return fipsutil.AppendFIPSCondition(conditions)
 	}
 	acs := []action.Action[*rhtasv1.Fulcio]{
 		transitions.NewToPendingPhaseAction[*rhtasv1.Fulcio](),
 		transitions.NewEnsureConditionsAction[*rhtasv1.Fulcio](conditionSupplier),
+		actions.NewFIPSValidationAction(),
 		actions.NewGenerateSignerAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1.Fulcio](),
 		actions.NewRBACAction(),

--- a/internal/controller/rekor/actions/server/fips_validation.go
+++ b/internal/controller/rekor/actions/server/fips_validation.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	fipsAction "github.com/securesign/operator/internal/action/fips"
+	"github.com/securesign/operator/internal/controller/rekor/actions"
+	"github.com/securesign/operator/internal/utils"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewFIPSValidationAction() action.Action[*rhtasv1.Rekor] {
+	return fipsAction.NewAction(
+		fipsutil.FIPSCondition,
+		actions.ServerComponentName,
+		fipsAction.Wrapper(fipsAction.Config[*rhtasv1.Rekor]{
+			PasswordRef: func(i *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
+				if (i.Spec.Signer.KMS == signerKMSSecret || i.Spec.Signer.KMS == "") && i.Spec.Signer.KeyRef != nil {
+					return i.Spec.Signer.PasswordRef //nolint:staticcheck
+				}
+				return nil
+			},
+			CryptoMaterial: rekorCryptoMaterial,
+		}),
+	)
+}
+
+func rekorCryptoMaterial(ctx context.Context, i *rhtasv1.Rekor, c client.Client) ([]fipsAction.CryptoRef, error) {
+	var refs []fipsAction.CryptoRef
+
+	// Signer key (only for local secret-backed signers, not external KMS)
+	if (i.Spec.Signer.KMS == signerKMSSecret || i.Spec.Signer.KMS == "") && i.Spec.Signer.KeyRef != nil {
+		if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.Signer.KeyRef,
+			"spec.signer.keyRef", fipsutil.ValidatePrivateKeyPEM, &refs); err != nil {
+			return nil, err
+		}
+	}
+
+	// Redis TLS material
+	if utils.OptionalBool(i.Spec.SearchIndex.Create) {
+		if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.SearchIndex.TLS.CertRef,
+			"spec.searchIndex.tls.certificateRef", fipsutil.ValidateCertificateChainPEM, &refs); err != nil {
+			return nil, err
+		}
+		if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.SearchIndex.TLS.PrivateKeyRef,
+			"spec.searchIndex.tls.privateKeyRef", fipsutil.ValidatePrivateKeyPEM, &refs); err != nil {
+			return nil, err
+		}
+	}
+
+	// Sharding public keys
+	for idx, shard := range i.Spec.Sharding {
+		if shard.EncodedPublicKey == "" {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(shard.EncodedPublicKey)
+		if err != nil {
+			return nil, fipsutil.NewValidationError(fmt.Errorf("invalid base64 in spec.sharding[%d].encodedPublicKey: %w", idx, err))
+		}
+		refs = append(refs, fipsAction.CryptoRef{
+			FieldPath: fmt.Sprintf("spec.sharding[%d].encodedPublicKey", idx),
+			Data:      decoded,
+			Validate:  fipsutil.ValidatePublicKeyPEMOrDER,
+		})
+	}
+
+	return refs, nil
+}

--- a/internal/controller/rekor/actions/server/generate_signer.go
+++ b/internal/controller/rekor/actions/server/generate_signer.go
@@ -34,12 +34,6 @@ func NewGenerateSignerAction() action.Action[*rhtasv1.Rekor] {
 			GenerateData: generateData,
 			AlignStatus:  alignStatus,
 			IsEnabled:    isEnabled,
-			PasswordRef: func(i *rhtasv1.Rekor) *rhtasv1.SecretKeySelector {
-				if i.Spec.Signer.KeyRef != nil {
-					return i.Spec.Signer.PasswordRef //nolint:staticcheck
-				}
-				return nil
-			},
 		}),
 	)
 }

--- a/internal/controller/rekor/actions/server/generate_signer_test.go
+++ b/internal/controller/rekor/actions/server/generate_signer_test.go
@@ -214,7 +214,7 @@ func TestRekorSigner_PasswordRefRejectedInFIPS(t *testing.T) {
 		WithStatusSubresource(instance).
 		Build()
 
-	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	a := testAction.PrepareAction(c, NewFIPSValidationAction())
 	result := a.Handle(ctx, instance)
 
 	g.Expect(result.Err).To(HaveOccurred())
@@ -250,9 +250,8 @@ func TestRekorSigner_UnencryptedKeyAllowedInFIPS(t *testing.T) {
 		WithStatusSubresource(instance).
 		Build()
 
-	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	a := testAction.PrepareAction(c, NewFIPSValidationAction())
 	result := a.Handle(ctx, instance)
 
-	g.Expect(result.Err).ToNot(HaveOccurred())
-	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).To(BeTrue())
+	g.Expect(result).To(Equal(testAction.Return()))
 }

--- a/internal/controller/rekor/actions/server/sharding_config.go
+++ b/internal/controller/rekor/actions/server/sharding_config.go
@@ -73,6 +73,7 @@ func (i shardingConfig) Handle(ctx context.Context, instance *rhtasv1.Rekor) *ac
 			}
 		}
 	}
+
 	// invalidate
 	instance.Status.ServerConfigRef = nil
 

--- a/internal/controller/rekor/rekor_controller.go
+++ b/internal/controller/rekor/rekor_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/securesign/operator/internal/controller"
 	redis "github.com/securesign/operator/internal/controller/rekor/actions/searchIndex/redis/actions"
 	"github.com/securesign/operator/internal/utils"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	"k8s.io/apimachinery/pkg/types"
 
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
@@ -101,7 +102,7 @@ func (r *rekorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	target := instance.DeepCopy()
 	conditionSupplier := func(rekor *rhtasv1.Rekor) []string {
-		components := []string{actions2.ServerCondition, actions2.SignerCondition, trustmaterial.TrustMaterialCondition}
+		components := fipsutil.AppendFIPSCondition([]string{actions2.ServerCondition, actions2.SignerCondition, trustmaterial.TrustMaterialCondition})
 		if utils.OptionalBool(rekor.Spec.RekorSearchUI.Enabled) {
 			components = append(components, actions2.UICondition)
 		}
@@ -116,6 +117,7 @@ func (r *rekorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 		redis.NewTlsAction(),
 		redis.NewGeneratePasswordAction(),
+		server.NewFIPSValidationAction(),
 		server.NewGenerateSignerAction(),
 
 		transitions.NewToCreatePhaseAction[*rhtasv1.Rekor](),

--- a/internal/controller/trillian/actions/fips_validation.go
+++ b/internal/controller/trillian/actions/fips_validation.go
@@ -1,0 +1,47 @@
+package actions
+
+import (
+	"context"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	fipsAction "github.com/securesign/operator/internal/action/fips"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewFIPSValidationAction() action.Action[*rhtasv1.Trillian] {
+	return fipsAction.NewAction(
+		fipsutil.FIPSCondition,
+		"trillian",
+		fipsAction.Wrapper(fipsAction.Config[*rhtasv1.Trillian]{
+			CryptoMaterial: trillianCryptoMaterial,
+		}),
+	)
+}
+
+func trillianCryptoMaterial(ctx context.Context, i *rhtasv1.Trillian, c client.Client) ([]fipsAction.CryptoRef, error) {
+	var refs []fipsAction.CryptoRef
+
+	tlsSources := []struct {
+		prefix string
+		tls    rhtasv1.TLS
+	}{
+		{"spec.logServer.tls", i.Spec.LogServer.TLS},
+		{"spec.logSigner.tls", i.Spec.LogSigner.TLS},
+		{"spec.db.tls", i.Spec.Db.TLS},
+	}
+
+	for _, src := range tlsSources {
+		if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, src.tls.CertRef,
+			src.prefix+".certificateRef", fipsutil.ValidateCertificateChainPEM, &refs); err != nil {
+			return nil, err
+		}
+		if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, src.tls.PrivateKeyRef,
+			src.prefix+".privateKeyRef", fipsutil.ValidatePrivateKeyPEM, &refs); err != nil {
+			return nil, err
+		}
+	}
+
+	return refs, nil
+}

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/securesign/operator/internal/controller/trillian/actions/db"
 	"github.com/securesign/operator/internal/controller/trillian/actions/logserver"
 	"github.com/securesign/operator/internal/controller/trillian/actions/logsigner"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	v12 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/events"
 
@@ -97,7 +98,8 @@ func (r *trillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	target := instance.DeepCopy()
 	conditionSupplier := func(_ *rhtasv1.Trillian) []string {
-		return []string{actions.ServerCondition, actions.SignerCondition, actions.DbCondition}
+		conditions := []string{actions.ServerCondition, actions.SignerCondition, actions.DbCondition}
+		return fipsutil.AppendFIPSCondition(conditions)
 	}
 	actions := []action.Action[*rhtasv1.Trillian]{
 		transitions.NewToPendingPhaseAction[*rhtasv1.Trillian](),
@@ -106,6 +108,8 @@ func (r *trillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		logserver.NewTlsAction(),
 		logsigner.NewTlsAction(),
 		db.NewTlsAction(),
+
+		actions.NewFIPSValidationAction(),
 
 		transitions.NewToCreatePhaseAction[*rhtasv1.Trillian](),
 		logserver.NewRBACAction(),

--- a/internal/controller/tsa/actions/fips_validation.go
+++ b/internal/controller/tsa/actions/fips_validation.go
@@ -1,0 +1,40 @@
+package actions
+
+import (
+	"context"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	fipsAction "github.com/securesign/operator/internal/action/fips"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewFIPSValidationAction() action.Action[*rhtasv1.TimestampAuthority] {
+	return fipsAction.NewAction(
+		fipsutil.FIPSCondition,
+		ComponentName,
+		fipsAction.Wrapper(fipsAction.Config[*rhtasv1.TimestampAuthority]{
+			PasswordRef: func(i *rhtasv1.TimestampAuthority) *rhtasv1.SecretKeySelector {
+				if i.Spec.Signer.File != nil && i.Spec.Signer.File.PrivateKeyRef != nil {
+					return i.Spec.Signer.File.PasswordRef //nolint:staticcheck
+				}
+				return nil
+			},
+			CryptoMaterial: func(ctx context.Context, i *rhtasv1.TimestampAuthority, c client.Client) ([]fipsAction.CryptoRef, error) {
+				var refs []fipsAction.CryptoRef
+				if i.Spec.Signer.File != nil {
+					if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.Signer.File.PrivateKeyRef,
+						"spec.signer.file.privateKeyRef", fipsutil.ValidatePrivateKeyPEM, &refs); err != nil {
+						return nil, err
+					}
+				}
+				if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, i.Spec.Signer.CertificateChain.CertificateChainRef,
+					"spec.signer.certificateChain.certificateChainRef", fipsutil.ValidateCertificateChainPEM, &refs); err != nil {
+					return nil, err
+				}
+				return refs, nil
+			},
+		}),
+	)
+}

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -42,12 +42,6 @@ func NewGenerateSignerAction() action.Action[*rhtasv1.TimestampAuthority] {
 				}
 				secret.Labels[labels.LabelNamespace+"/tsa.certchain.pem"] = tsaUtils.KeyCertificateChain
 			},
-			PasswordRef: func(i *rhtasv1.TimestampAuthority) *rhtasv1.SecretKeySelector {
-				if i.Spec.Signer.File != nil && i.Spec.Signer.File.PrivateKeyRef != nil {
-					return i.Spec.Signer.File.PasswordRef //nolint:staticcheck
-				}
-				return nil
-			},
 		}),
 	)
 }

--- a/internal/controller/tsa/actions/generate_signer_test.go
+++ b/internal/controller/tsa/actions/generate_signer_test.go
@@ -1,9 +1,18 @@
 package actions
 
 import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"testing"
+	"time"
 
 	. "github.com/onsi/gomega"
 	rhtasv1 "github.com/securesign/operator/api/v1"
@@ -301,7 +310,7 @@ func TestTSASigner_PasswordRefRejectedInFIPS(t *testing.T) {
 		WithStatusSubresource(instance).
 		Build()
 
-	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	a := testAction.PrepareAction(c, NewFIPSValidationAction())
 	result := a.Handle(ctx, instance)
 
 	g.Expect(result.Err).To(HaveOccurred())
@@ -338,24 +347,25 @@ func TestTSASigner_UnencryptedKeyAllowedInFIPS(t *testing.T) {
 		},
 	}
 
+	certChainPEM := generateTestCertChainPEM(t)
+
 	keySecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "user-key-secret", Namespace: "default"},
 		Data:       map[string][]byte{"leafPrivateKey": unencryptedKey},
 	}
 	certSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "user-cert-secret", Namespace: "default"},
-		Data:       map[string][]byte{"certificateChain": []byte("cert-data")},
+		Data:       map[string][]byte{"certificateChain": certChainPEM},
 	}
 	c := testAction.FakeClientBuilder().
 		WithObjects(instance, keySecret, certSecret).
 		WithStatusSubresource(instance).
 		Build()
 
-	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	a := testAction.PrepareAction(c, NewFIPSValidationAction())
 	result := a.Handle(ctx, instance)
 
-	g.Expect(result.Err).ToNot(HaveOccurred())
-	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, TSASignerCondition)).To(BeTrue())
+	g.Expect(result).To(Equal(testAction.Return()))
 }
 
 func TestTSASigner_AlignStatusFields(t *testing.T) {
@@ -509,4 +519,30 @@ func TestTSASigner_AlignStatusFields(t *testing.T) {
 			tt.testCase(g, instance)
 		})
 	}
+}
+
+func generateTestCertChainPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:       big.NewInt(1),
+		Subject:            pkix.Name{CommonName: "test-tsa-ca"},
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour),
+		IsCA:               true,
+		KeyUsage:           x509.KeyUsageCertSign,
+		SignatureAlgorithm: x509.ECDSAWithSHA384,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
 }

--- a/internal/controller/tsa/timestampauthority_controller.go
+++ b/internal/controller/tsa/timestampauthority_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
 	"github.com/securesign/operator/internal/controller/predicate"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 
@@ -94,11 +95,13 @@ func (r *timestampAuthorityReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	target := instance.DeepCopy()
 	conditionSupplier := func(_ *rhtasv1.TimestampAuthority) []string {
-		return []string{actions.TSASignerCondition, trustmaterial.TrustMaterialCondition}
+		conditions := []string{actions.TSASignerCondition, trustmaterial.TrustMaterialCondition}
+		return fipsutil.AppendFIPSCondition(conditions)
 	}
 	actions := []action.Action[*rhtasv1.TimestampAuthority]{
 		transitions.NewToPendingPhaseAction[*rhtasv1.TimestampAuthority](),
 		transitions.NewEnsureConditionsAction[*rhtasv1.TimestampAuthority](conditionSupplier),
+		actions.NewFIPSValidationAction(),
 		actions.NewGenerateSignerAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1.TimestampAuthority](),
 		actions.NewRBACAction(),

--- a/internal/controller/tuf/actions/fips_validation.go
+++ b/internal/controller/tuf/actions/fips_validation.go
@@ -1,0 +1,50 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	fipsAction "github.com/securesign/operator/internal/action/fips"
+	tufConstants "github.com/securesign/operator/internal/controller/tuf/constants"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewFIPSValidationAction() action.Action[*rhtasv1.Tuf] {
+	return fipsAction.NewAction(
+		fipsutil.FIPSCondition,
+		tufConstants.ComponentName,
+		fipsAction.Wrapper(fipsAction.Config[*rhtasv1.Tuf]{
+			CryptoMaterial: tufCryptoMaterial,
+		}),
+	)
+}
+
+func tufCryptoMaterial(ctx context.Context, i *rhtasv1.Tuf, c client.Client) ([]fipsAction.CryptoRef, error) {
+	var refs []fipsAction.CryptoRef
+
+	specHasRef := make(map[string]bool)
+	for _, key := range i.Spec.Keys {
+		if key.SecretRef != nil {
+			specHasRef[key.Name] = true
+			if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, key.SecretRef,
+				fmt.Sprintf("spec.keys[%s].secretRef", key.Name), fipsutil.ValidateCryptoMaterialPEM, &refs); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for _, ks := range i.Status.Keys {
+		if ks.SecretRef == nil || specHasRef[ks.Name] {
+			continue
+		}
+		if err := fipsAction.AppendSecretRef(ctx, c, i.Namespace, ks.SecretRef,
+			fmt.Sprintf("status.keys[%s] (autodiscovered)", ks.Name), fipsutil.ValidateCryptoMaterialPEM, &refs); err != nil {
+			return nil, err
+		}
+	}
+
+	return refs, nil
+}

--- a/internal/controller/tuf/actions/resolve_keys.go
+++ b/internal/controller/tuf/actions/resolve_keys.go
@@ -78,7 +78,17 @@ func (i resolveKeysAction) Handle(ctx context.Context, instance *rhtasv1.Tuf) *a
 		trustMaterial, err := discoverFromStatus(ctx, i.Client, instance.Namespace, key.Name)
 		if err != nil {
 			if errors.Is(err, reconcile.TerminalError(nil)) {
-				return i.Error(ctx, err, instance)
+				msg := err.Error()
+				if inner := errors.Unwrap(err); inner != nil {
+					msg = inner.Error()
+				}
+				return i.Error(ctx, err, instance,
+					v1.Condition{
+						Type:    key.Name,
+						Status:  v1.ConditionFalse,
+						Reason:  state.Failure.String(),
+						Message: msg,
+					})
 			}
 			meta.SetStatusCondition(&instance.Status.Conditions, v1.Condition{Type: constants.ReadyCondition,
 				Status: v1.ConditionFalse, Reason: state.Pending.String(), Message: "Resolving keys",

--- a/internal/controller/tuf/tuf_controller.go
+++ b/internal/controller/tuf/tuf_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/securesign/operator/internal/controller/predicate"
 	"github.com/securesign/operator/internal/controller/tuf/actions"
 	"github.com/securesign/operator/internal/controller/tuf/constants"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	v1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
 	v13 "k8s.io/api/networking/v1"
@@ -100,13 +101,14 @@ func (r *tufReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			conditions = append(conditions, k.Name)
 		}
 		conditions = append(conditions, constants.RepositoryCondition)
-		return conditions
+		return fipsutil.AppendFIPSCondition(conditions)
 	}
 	acs := []action.Action[*rhtasv1.Tuf]{
 		transitions.NewToPendingPhaseAction[*rhtasv1.Tuf](),
 		transitions.NewEnsureConditionsAction[*rhtasv1.Tuf](conditionSupplier),
 
 		actions.NewResolveKeysAction(),
+		actions.NewFIPSValidationAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1.Tuf](),
 		actions.NewRBACInitJobAction(),
 		actions.NewRBACAction(),

--- a/internal/utils/fips/errors.go
+++ b/internal/utils/fips/errors.go
@@ -1,0 +1,32 @@
+package fips
+
+import "errors"
+
+var (
+	ErrNonFIPSPrivateKey  = errors.New("private key does not use a FIPS-approved algorithm")
+	ErrNonFIPSPublicKey   = errors.New("public key does not use a FIPS-approved algorithm")
+	ErrNonFIPSCertificate = errors.New("certificate does not use a FIPS-approved algorithm")
+	ErrInvalidPEM         = errors.New("failed to decode PEM data")
+	ErrInvalidDER         = errors.New("failed to parse DER data")
+)
+
+type ValidationError struct{ err error }
+
+func (e *ValidationError) Error() string { return e.err.Error() }
+func (e *ValidationError) Unwrap() error { return e.err }
+
+func NewValidationError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var ve *ValidationError
+	if errors.As(err, &ve) {
+		return err
+	}
+	return &ValidationError{err: err}
+}
+
+func IsValidationError(err error) bool {
+	var ve *ValidationError
+	return errors.As(err, &ve)
+}

--- a/internal/utils/fips/fips.go
+++ b/internal/utils/fips/fips.go
@@ -9,4 +9,14 @@ var Enabled = fips140.Enabled
 
 var ErrPasswordRefInFIPS = errors.New("password-protected private keys are not allowed in FIPS mode: remove the password reference and provide an unencrypted key")
 
-const ClientSigningAlgorithms = "ecdsa-sha2-256-nistp256,ecdsa-sha2-384-nistp384,ecdsa-sha2-512-nistp521,rsa-sign-pkcs1-2048-sha256,rsa-sign-pkcs1-3072-sha256,rsa-sign-pkcs1-4096-sha256"
+const (
+	ClientSigningAlgorithms = "ecdsa-sha2-256-nistp256,ecdsa-sha2-384-nistp384,ecdsa-sha2-512-nistp521,rsa-sign-pkcs1-2048-sha256,rsa-sign-pkcs1-3072-sha256,rsa-sign-pkcs1-4096-sha256,ed25519,ed25519-ph"
+	FIPSCondition           = "FIPSCompliant"
+)
+
+func AppendFIPSCondition(conditions []string) []string {
+	if Enabled() {
+		return append(conditions, FIPSCondition)
+	}
+	return conditions
+}

--- a/internal/utils/fips/rules.go
+++ b/internal/utils/fips/rules.go
@@ -1,0 +1,84 @@
+package fips
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+)
+
+const minRSAKeySize = 2048
+
+var fipsApprovedCurves = map[elliptic.Curve]bool{
+	elliptic.P256(): true,
+	elliptic.P384(): true,
+	elliptic.P521(): true,
+}
+
+var fipsApprovedSignatureAlgorithms = map[x509.SignatureAlgorithm]bool{
+	x509.ECDSAWithSHA256:  true,
+	x509.ECDSAWithSHA384:  true,
+	x509.ECDSAWithSHA512:  true,
+	x509.SHA256WithRSA:    true,
+	x509.SHA384WithRSA:    true,
+	x509.SHA512WithRSA:    true,
+	x509.SHA256WithRSAPSS: true,
+	x509.SHA384WithRSAPSS: true,
+	x509.SHA512WithRSAPSS: true,
+	x509.PureEd25519:      true,
+}
+
+func validatePrivateKey(key crypto.PrivateKey) error {
+	switch k := key.(type) {
+	case *ecdsa.PrivateKey:
+		return validateECDSACurve(k.Curve, ErrNonFIPSPrivateKey)
+	case *rsa.PrivateKey:
+		return validateRSAKeySize(k.N.BitLen(), ErrNonFIPSPrivateKey)
+	case ed25519.PrivateKey:
+		return nil
+	default:
+		return fmt.Errorf("%w: %T is not FIPS-approved; use ECDSA (P-256, P-384, P-521), RSA (>= %d bits), or Ed25519",
+			ErrNonFIPSPrivateKey, key, minRSAKeySize)
+	}
+}
+
+func validatePublicKey(key crypto.PublicKey) error {
+	switch k := key.(type) {
+	case *ecdsa.PublicKey:
+		return validateECDSACurve(k.Curve, ErrNonFIPSPublicKey)
+	case *rsa.PublicKey:
+		return validateRSAKeySize(k.N.BitLen(), ErrNonFIPSPublicKey)
+	case ed25519.PublicKey:
+		return nil
+	default:
+		return fmt.Errorf("%w: %T is not FIPS-approved; use ECDSA (P-256, P-384, P-521), RSA (>= %d bits), or Ed25519",
+			ErrNonFIPSPublicKey, key, minRSAKeySize)
+	}
+}
+
+func validateSignatureAlgorithm(alg x509.SignatureAlgorithm) error {
+	if fipsApprovedSignatureAlgorithms[alg] {
+		return nil
+	}
+	return fmt.Errorf("%w: %s is not FIPS-approved; use SHA256/384/512 with RSA or ECDSA, or PureEd25519",
+		ErrNonFIPSCertificate, alg)
+}
+
+func validateECDSACurve(curve elliptic.Curve, sentinel error) error {
+	if fipsApprovedCurves[curve] {
+		return nil
+	}
+	return fmt.Errorf("%w: elliptic curve %s is not FIPS-approved; use P-256, P-384, or P-521",
+		sentinel, curve.Params().Name)
+}
+
+func validateRSAKeySize(bits int, sentinel error) error {
+	if bits >= minRSAKeySize {
+		return nil
+	}
+	return fmt.Errorf("%w: RSA key is %d bits, FIPS requires >= %d bits",
+		sentinel, bits, minRSAKeySize)
+}

--- a/internal/utils/fips/validate.go
+++ b/internal/utils/fips/validate.go
@@ -1,0 +1,215 @@
+package fips
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+const (
+	pemTypeCertificate = "CERTIFICATE"
+	pemTypePublicKey   = "PUBLIC KEY"
+	pemTypePrivateKey  = "PRIVATE KEY"
+	pemTypeRSAKey      = "RSA PRIVATE KEY"
+	pemTypeECKey       = "EC PRIVATE KEY"
+)
+
+// ValidatePrivateKeyPEM parses a PEM-encoded private key and returns an error
+// if the key algorithm or parameters are not FIPS-approved.
+// Accepts PKCS#8, PKCS#1 (RSA), and SEC 1 (EC) PEM blocks.
+func ValidatePrivateKeyPEM(pemData []byte) (retErr error) {
+	defer func() { retErr = NewValidationError(retErr) }()
+
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return fmt.Errorf("%w: no PEM block found in private key data", ErrInvalidPEM)
+	}
+
+	key, err := parsePrivateKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidPEM, err)
+	}
+	return validatePrivateKey(key)
+}
+
+// ValidatePublicKeyPEM parses a PEM-encoded public key (PKIX/SubjectPublicKeyInfo)
+// and returns an error if the key algorithm or parameters are not FIPS-approved.
+func ValidatePublicKeyPEM(pemData []byte) (retErr error) {
+	defer func() { retErr = NewValidationError(retErr) }()
+
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return fmt.Errorf("%w: no PEM block found in public key data", ErrInvalidPEM)
+	}
+
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidPEM, err)
+	}
+	return validatePublicKey(key)
+}
+
+// ValidatePublicKeyDER parses a DER-encoded public key and validates FIPS compliance.
+func ValidatePublicKeyDER(derData []byte) (retErr error) {
+	defer func() { retErr = NewValidationError(retErr) }()
+
+	key, err := x509.ParsePKIXPublicKey(derData)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidDER, err)
+	}
+	return validatePublicKey(key)
+}
+
+// ValidatePublicKeyPEMOrDER tries PEM decoding first; if the data is not PEM-encoded,
+// falls back to DER parsing. Returns an error if the key is not FIPS-approved.
+func ValidatePublicKeyPEMOrDER(data []byte) error {
+	block, _ := pem.Decode(data)
+	if block != nil {
+		if block.Type != pemTypePublicKey {
+			return NewValidationError(fmt.Errorf("%w: expected %q PEM block, got %q", ErrInvalidPEM, pemTypePublicKey, block.Type))
+		}
+		key, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return NewValidationError(fmt.Errorf("%w: %w", ErrInvalidPEM, err))
+		}
+		return NewValidationError(validatePublicKey(key))
+	}
+	return ValidatePublicKeyDER(data)
+}
+
+// ValidateCertificateChainPEM parses a PEM bundle containing one or more certificates
+// and validates that every certificate in the chain uses FIPS-approved algorithms.
+func ValidateCertificateChainPEM(pemData []byte) (retErr error) {
+	defer func() { retErr = NewValidationError(retErr) }()
+
+	rest := pemData
+	idx := 0
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != pemTypeCertificate {
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("%w: certificate at index %d: %w", ErrInvalidPEM, idx, err)
+		}
+		if err := validatePublicKey(cert.PublicKey); err != nil {
+			return fmt.Errorf("certificate at index %d: %w", idx, err)
+		}
+		if err := validateSignatureAlgorithm(cert.SignatureAlgorithm); err != nil {
+			return fmt.Errorf("certificate at index %d: %w", idx, err)
+		}
+		idx++
+	}
+
+	if idx == 0 {
+		return fmt.Errorf("%w: no certificates found in PEM data", ErrInvalidPEM)
+	}
+	return nil
+}
+
+// ValidateCryptoMaterialPEM auto-detects the PEM block type (CERTIFICATE, PUBLIC KEY,
+// or private key variants) and validates FIPS compliance for every block in the bundle.
+func ValidateCryptoMaterialPEM(pemData []byte) (retErr error) {
+	defer func() { retErr = NewValidationError(retErr) }()
+
+	rest := pemData
+	count := 0
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if err := validateSingleBlock(block); err != nil {
+			return err
+		}
+		count++
+	}
+	if count == 0 {
+		return fmt.Errorf("%w: no PEM block found", ErrInvalidPEM)
+	}
+	return nil
+}
+
+// ValidateCryptoMaterialIfPEM validates FIPS compliance only when data is
+// PEM-encoded crypto material. Returns nil for non-PEM data (e.g. protobuf
+// config, passwords) and for PEM blocks with unrecognized types, avoiding
+// false rejections of non-crypto PEM data. Unlike ValidateCryptoMaterialPEM,
+// this function iterates all PEM blocks in the data, validating each
+// recognized crypto block individually.
+func ValidateCryptoMaterialIfPEM(data []byte) (retErr error) {
+	defer func() { retErr = NewValidationError(retErr) }()
+
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if !isCryptoPEMBlockType(block.Type) {
+			continue
+		}
+		if err := validateSingleBlock(block); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSingleBlock(block *pem.Block) error {
+	switch block.Type {
+	case pemTypeCertificate:
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidPEM, err)
+		}
+		if err := validatePublicKey(cert.PublicKey); err != nil {
+			return err
+		}
+		return validateSignatureAlgorithm(cert.SignatureAlgorithm)
+	case pemTypePublicKey:
+		key, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidPEM, err)
+		}
+		return validatePublicKey(key)
+	case pemTypePrivateKey, pemTypeRSAKey, pemTypeECKey:
+		key, err := parsePrivateKey(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrInvalidPEM, err)
+		}
+		return validatePrivateKey(key)
+	default:
+		return fmt.Errorf("%w: unsupported PEM block type %q", ErrInvalidPEM, block.Type)
+	}
+}
+
+func isCryptoPEMBlockType(blockType string) bool {
+	switch blockType {
+	case pemTypeCertificate, pemTypePublicKey, pemTypePrivateKey, pemTypeRSAKey, pemTypeECKey:
+		return true
+	default:
+		return false
+	}
+}
+
+// parsePrivateKey tries PKCS#8, PKCS#1, and SEC 1 formats in sequence.
+func parsePrivateKey(der []byte) (interface{}, error) {
+	if key, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return key, nil
+	}
+	if key, err := x509.ParseECPrivateKey(der); err == nil {
+		return key, nil
+	}
+	return nil, fmt.Errorf("failed to parse private key in any supported format (PKCS#8, PKCS#1, SEC 1)")
+}

--- a/internal/utils/fips/validate_test.go
+++ b/internal/utils/fips/validate_test.go
@@ -1,0 +1,489 @@
+package fips
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func mustGenerateECKey(t *testing.T, curve elliptic.Curve) *ecdsa.PrivateKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func mustGenerateRSAKey(t *testing.T, bits int) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func mustMarshalECPrivateKeyPEM(t *testing.T, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func mustMarshalPKCS8PrivateKeyPEM(t *testing.T, key interface{}) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func mustMarshalPKCS1PrivateKeyPEM(t *testing.T, key *rsa.PrivateKey) []byte {
+	t.Helper()
+	der := x509.MarshalPKCS1PrivateKey(key)
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func mustMarshalPublicKeyPEM(t *testing.T, key interface{}) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "PUBLIC KEY", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func mustMarshalPublicKeyDER(t *testing.T, key interface{}) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return der
+}
+
+func mustCreateSelfSignedCert(t *testing.T, key interface{}, sigAlg x509.SignatureAlgorithm) []byte {
+	t.Helper()
+
+	var pubKey interface{}
+	switch k := key.(type) {
+	case *ecdsa.PrivateKey:
+		pubKey = &k.PublicKey
+	case *rsa.PrivateKey:
+		pubKey = &k.PublicKey
+	case ed25519.PrivateKey:
+		pubKey = k.Public()
+	default:
+		t.Fatalf("unsupported key type: %T", key)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:       big.NewInt(1),
+		Subject:            pkix.Name{CommonName: "test"},
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Hour),
+		SignatureAlgorithm: sigAlg,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pubKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestValidatePrivateKeyPEM(t *testing.T) {
+	tests := []struct {
+		name    string
+		pemData func(t *testing.T) []byte
+		wantErr bool
+	}{
+		{
+			name: "ECDSA P-256 passes",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalECPrivateKeyPEM(t, mustGenerateECKey(t, elliptic.P256()))
+			},
+		},
+		{
+			name: "ECDSA P-384 passes",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalECPrivateKeyPEM(t, mustGenerateECKey(t, elliptic.P384()))
+			},
+		},
+		{
+			name: "ECDSA P-521 passes",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalECPrivateKeyPEM(t, mustGenerateECKey(t, elliptic.P521()))
+			},
+		},
+		{
+			name: "RSA 2048 passes",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPKCS1PrivateKeyPEM(t, mustGenerateRSAKey(t, 2048))
+			},
+		},
+		{
+			name: "RSA 4096 passes",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPKCS8PrivateKeyPEM(t, mustGenerateRSAKey(t, 4096))
+			},
+		},
+		{
+			name: "PKCS8 wrapped ECDSA P-256 passes",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPKCS8PrivateKeyPEM(t, mustGenerateECKey(t, elliptic.P256()))
+			},
+		},
+		{
+			name: "Ed25519 passes",
+			pemData: func(t *testing.T) []byte {
+				_, priv, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return mustMarshalPKCS8PrivateKeyPEM(t, priv)
+			},
+		},
+		{
+			name: "RSA 1024 fails",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPKCS1PrivateKeyPEM(t, mustGenerateRSAKey(t, 1024))
+			},
+			wantErr: true,
+		},
+		{
+			name:    "invalid PEM fails",
+			pemData: func(_ *testing.T) []byte { return []byte("not a pem") },
+			wantErr: true,
+		},
+		{
+			name:    "empty input fails",
+			pemData: func(_ *testing.T) []byte { return nil },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePrivateKeyPEM(tt.pemData(t))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePrivateKeyPEM() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidatePublicKeyPEM(t *testing.T) {
+	tests := []struct {
+		name    string
+		pemData func(t *testing.T) []byte
+		wantErr bool
+	}{
+		{
+			name: "ECDSA P-256 passes",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPublicKeyPEM(t, &mustGenerateECKey(t, elliptic.P256()).PublicKey)
+			},
+		},
+		{
+			name: "RSA 2048 passes",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPublicKeyPEM(t, &mustGenerateRSAKey(t, 2048).PublicKey)
+			},
+		},
+		{
+			name: "Ed25519 passes",
+			pemData: func(t *testing.T) []byte {
+				pub, _, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return mustMarshalPublicKeyPEM(t, pub)
+			},
+		},
+		{
+			name:    "invalid PEM fails",
+			pemData: func(_ *testing.T) []byte { return []byte("not a pem") },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePublicKeyPEM(tt.pemData(t))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePublicKeyPEM() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidatePublicKeyDER(t *testing.T) {
+	tests := []struct {
+		name    string
+		derData func(t *testing.T) []byte
+		wantErr bool
+	}{
+		{
+			name: "ECDSA P-256 passes",
+			derData: func(t *testing.T) []byte {
+				return mustMarshalPublicKeyDER(t, &mustGenerateECKey(t, elliptic.P256()).PublicKey)
+			},
+		},
+		{
+			name: "Ed25519 passes",
+			derData: func(t *testing.T) []byte {
+				pub, _, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return mustMarshalPublicKeyDER(t, pub)
+			},
+		},
+		{
+			name:    "invalid DER fails",
+			derData: func(_ *testing.T) []byte { return []byte("garbage") },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePublicKeyDER(tt.derData(t))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePublicKeyDER() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCertificateChainPEM(t *testing.T) {
+	tests := []struct {
+		name    string
+		pemData func(t *testing.T) []byte
+		wantErr bool
+	}{
+		{
+			name: "single valid cert passes",
+			pemData: func(t *testing.T) []byte {
+				key := mustGenerateECKey(t, elliptic.P256())
+				return mustCreateSelfSignedCert(t, key, x509.ECDSAWithSHA256)
+			},
+		},
+		{
+			name: "two valid certs pass",
+			pemData: func(t *testing.T) []byte {
+				key1 := mustGenerateECKey(t, elliptic.P256())
+				key2 := mustGenerateECKey(t, elliptic.P384())
+				cert1 := mustCreateSelfSignedCert(t, key1, x509.ECDSAWithSHA256)
+				cert2 := mustCreateSelfSignedCert(t, key2, x509.ECDSAWithSHA384)
+				return append(cert1, cert2...)
+			},
+		},
+		{
+			name: "one bad cert in chain fails",
+			pemData: func(t *testing.T) []byte {
+				goodKey := mustGenerateECKey(t, elliptic.P256())
+				badKey := mustGenerateRSAKey(t, 2048)
+				goodCert := mustCreateSelfSignedCert(t, goodKey, x509.ECDSAWithSHA256)
+				badCert := mustCreateSelfSignedCert(t, badKey, x509.SHA1WithRSA)
+				return append(goodCert, badCert...)
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no certificates fails",
+			pemData: func(_ *testing.T) []byte { return []byte("not a cert") },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCertificateChainPEM(tt.pemData(t))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCertificateChainPEM() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCryptoMaterialPEM(t *testing.T) {
+	tests := []struct {
+		name    string
+		pemData func(t *testing.T) []byte
+		wantErr bool
+	}{
+		{
+			name: "detects and validates certificate",
+			pemData: func(t *testing.T) []byte {
+				key := mustGenerateECKey(t, elliptic.P256())
+				return mustCreateSelfSignedCert(t, key, x509.ECDSAWithSHA256)
+			},
+		},
+		{
+			name: "detects and validates public key",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPublicKeyPEM(t, &mustGenerateECKey(t, elliptic.P256()).PublicKey)
+			},
+		},
+		{
+			name: "detects and validates PKCS8 private key",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPKCS8PrivateKeyPEM(t, mustGenerateECKey(t, elliptic.P256()))
+			},
+		},
+		{
+			name: "detects and validates EC private key",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalECPrivateKeyPEM(t, mustGenerateECKey(t, elliptic.P256()))
+			},
+		},
+		{
+			name: "detects and validates RSA private key",
+			pemData: func(t *testing.T) []byte {
+				return mustMarshalPKCS1PrivateKeyPEM(t, mustGenerateRSAKey(t, 2048))
+			},
+		},
+		{
+			name:    "empty input fails",
+			pemData: func(_ *testing.T) []byte { return nil },
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCryptoMaterialPEM(tt.pemData(t))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCryptoMaterialPEM() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateCryptoMaterialPEM_NoDoubleWrap(t *testing.T) {
+	key := mustGenerateRSAKey(t, 1024)
+	certPEM := mustCreateSelfSignedCert(t, key, x509.SHA256WithRSA)
+
+	err := ValidateCryptoMaterialPEM(certPEM)
+	if err == nil {
+		t.Fatal("expected error for RSA-1024 cert, got nil")
+	}
+
+	var ve *ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatal("expected ValidationError, got", err)
+	}
+	inner := errors.Unwrap(err)
+	var innerVE *ValidationError
+	if errors.As(inner, &innerVE) {
+		t.Errorf("double-wrapped ValidationError: Unwrap returned another ValidationError: %v", inner)
+	}
+}
+
+func TestValidateCryptoMaterialIfPEM(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    func(t *testing.T) []byte
+		wantErr bool
+	}{
+		{
+			name: "non-PEM data returns nil",
+			data: func(_ *testing.T) []byte { return []byte("not pem data") },
+		},
+		{
+			name: "unrecognized PEM block type returns nil",
+			data: func(_ *testing.T) []byte {
+				return pem.EncodeToMemory(&pem.Block{Type: "CUSTOM BLOCK", Bytes: []byte("data")})
+			},
+		},
+		{
+			name: "single valid certificate passes",
+			data: func(t *testing.T) []byte {
+				key := mustGenerateECKey(t, elliptic.P256())
+				return mustCreateSelfSignedCert(t, key, x509.ECDSAWithSHA256)
+			},
+		},
+		{
+			name: "single invalid certificate fails",
+			data: func(t *testing.T) []byte {
+				key := mustGenerateRSAKey(t, 2048)
+				return mustCreateSelfSignedCert(t, key, x509.SHA1WithRSA)
+			},
+			wantErr: true,
+		},
+		{
+			name: "cert + valid private key bundle passes",
+			data: func(t *testing.T) []byte {
+				key := mustGenerateECKey(t, elliptic.P256())
+				cert := mustCreateSelfSignedCert(t, key, x509.ECDSAWithSHA256)
+				keyPEM := mustMarshalECPrivateKeyPEM(t, key)
+				return append(cert, keyPEM...)
+			},
+		},
+		{
+			name: "valid cert + invalid private key bundle fails on private key",
+			data: func(t *testing.T) []byte {
+				ecKey := mustGenerateECKey(t, elliptic.P256())
+				cert := mustCreateSelfSignedCert(t, ecKey, x509.ECDSAWithSHA256)
+				rsaKey := mustGenerateRSAKey(t, 1024)
+				keyPEM := mustMarshalPKCS1PrivateKeyPEM(t, rsaKey)
+				return append(cert, keyPEM...)
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-crypto block + valid crypto block passes",
+			data: func(t *testing.T) []byte {
+				custom := pem.EncodeToMemory(&pem.Block{Type: "CUSTOM", Bytes: []byte("data")})
+				key := mustGenerateECKey(t, elliptic.P256())
+				keyPEM := mustMarshalECPrivateKeyPEM(t, key)
+				return append(custom, keyPEM...)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCryptoMaterialIfPEM(tt.data(t))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCryptoMaterialIfPEM() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/test/e2e/fips/fips_crypto_validation_test.go
+++ b/test/e2e/fips/fips_crypto_validation_test.go
@@ -1,0 +1,227 @@
+//go:build fips
+
+package fips
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	fulcioactions "github.com/securesign/operator/internal/controller/fulcio/actions"
+	"github.com/securesign/operator/test/e2e/support"
+	"github.com/securesign/operator/test/e2e/support/postgresql"
+	"github.com/securesign/operator/test/e2e/support/steps"
+	"github.com/securesign/operator/test/e2e/support/tas/fulcio"
+	"github.com/securesign/operator/test/e2e/support/tas/securesign"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func generateEd25519SelfSignedCert() (keyPEM, certPEM []byte, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-ed25519-ca"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var certBuf bytes.Buffer
+	if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return nil, nil, err
+	}
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	var keyBuf bytes.Buffer
+	if err := pem.Encode(&keyBuf, &pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return nil, nil, err
+	}
+
+	return keyBuf.Bytes(), certBuf.Bytes(), nil
+}
+
+func generateECDSASelfSignedCert(curve elliptic.Curve, sigAlg x509.SignatureAlgorithm) (keyPEM, certPEM []byte, err error) {
+	key, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:       big.NewInt(1),
+		Subject:            pkix.Name{CommonName: "test-ecdsa-ca"},
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:               true,
+		KeyUsage:           x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		SignatureAlgorithm: sigAlg,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var certBuf bytes.Buffer
+	if err := pem.Encode(&certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certDER}); err != nil {
+		return nil, nil, err
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	var keyBuf bytes.Buffer
+	if err := pem.Encode(&keyBuf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}); err != nil {
+		return nil, nil, err
+	}
+
+	return keyBuf.Bytes(), certBuf.Bytes(), nil
+}
+
+var _ = Describe("FIPS crypto material validation", Ordered, func() {
+	cli, _ := support.CreateClient()
+
+	Describe("accepts Ed25519 user-provided keys", Ordered, func() {
+		var namespace *v1.Namespace
+
+		BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+			namespace = new
+		}))
+
+		BeforeAll(func(ctx SpecContext) {
+			Expect(postgresql.CreateDB(ctx, cli, namespace.Name, postgresql.DefaultSecretName, "fips-compliant-password")).To(Succeed())
+			postgresql.WaitAndLoadSchema(ctx, cli, namespace.Name)
+
+			keyPEM, certPEM, err := generateEd25519SelfSignedCert()
+			Expect(err).ToNot(HaveOccurred())
+
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-fulcio-secret",
+					Namespace: namespace.Name,
+				},
+				Data: map[string][]byte{
+					"private": keyPEM,
+					"cert":    certPEM,
+				},
+			}
+			Expect(cli.Create(ctx, secret)).To(Succeed())
+
+			s := securesign.Create(namespace.Name, "test-ed25519",
+				securesign.WithFipsDefaults(namespace.Name),
+				func(s *rhtasv1.Securesign) {
+					s.Spec.Fulcio.Certificate = rhtasv1.FulcioCert{
+						PrivateKeyRef: &rhtasv1.SecretKeySelector{
+							LocalObjectReference: rhtasv1.LocalObjectReference{Name: "my-fulcio-secret"},
+							Key:                  "private",
+						},
+						CARef: &rhtasv1.SecretKeySelector{
+							LocalObjectReference: rhtasv1.LocalObjectReference{Name: "my-fulcio-secret"},
+							Key:                  "cert",
+						},
+					}
+				},
+			)
+			Expect(cli.Create(ctx, s)).To(Succeed())
+		})
+
+		It("passes FIPS validation for Fulcio cert", func(ctx SpecContext) {
+			Eventually(func(ctx context.Context) *metav1.Condition {
+				cr := fulcio.Get(ctx, cli, namespace.Name, "test-ed25519")
+				if cr == nil {
+					return nil
+				}
+				return meta.FindStatusCondition(cr.GetConditions(), fulcioactions.CertCondition)
+			}).WithContext(ctx).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(
+				And(
+					Not(BeNil()),
+					WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
+				),
+			)
+		})
+	})
+
+	Describe("accepts ECDSA P-384 user-provided keys", Ordered, func() {
+		var namespace *v1.Namespace
+
+		BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+			namespace = new
+		}))
+
+		BeforeAll(func(ctx SpecContext) {
+			Expect(postgresql.CreateDB(ctx, cli, namespace.Name, postgresql.DefaultSecretName, "fips-compliant-password")).To(Succeed())
+			postgresql.WaitAndLoadSchema(ctx, cli, namespace.Name)
+
+			keyPEM, certPEM, err := generateECDSASelfSignedCert(elliptic.P384(), x509.ECDSAWithSHA384)
+			Expect(err).ToNot(HaveOccurred())
+
+			secret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-fulcio-secret",
+					Namespace: namespace.Name,
+				},
+				Data: map[string][]byte{
+					"private": keyPEM,
+					"cert":    certPEM,
+				},
+			}
+			Expect(cli.Create(ctx, secret)).To(Succeed())
+
+			s := securesign.Create(namespace.Name, "test-ecdsa",
+				securesign.WithFipsDefaults(namespace.Name),
+				func(s *rhtasv1.Securesign) {
+					s.Spec.Fulcio.Certificate = rhtasv1.FulcioCert{
+						PrivateKeyRef: &rhtasv1.SecretKeySelector{
+							LocalObjectReference: rhtasv1.LocalObjectReference{Name: "my-fulcio-secret"},
+							Key:                  "private",
+						},
+						CARef: &rhtasv1.SecretKeySelector{
+							LocalObjectReference: rhtasv1.LocalObjectReference{Name: "my-fulcio-secret"},
+							Key:                  "cert",
+						},
+					}
+				},
+			)
+			Expect(cli.Create(ctx, s)).To(Succeed())
+		})
+
+		It("passes FIPS validation for Fulcio cert", func(ctx SpecContext) {
+			Eventually(func(ctx context.Context) *metav1.Condition {
+				cr := fulcio.Get(ctx, cli, namespace.Name, "test-ecdsa")
+				if cr == nil {
+					return nil
+				}
+				return meta.FindStatusCondition(cr.GetConditions(), fulcioactions.CertCondition)
+			}).WithContext(ctx).WithTimeout(2 * time.Minute).WithPolling(5 * time.Second).Should(
+				And(
+					Not(BeNil()),
+					WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
+				),
+			)
+		})
+	})
+})

--- a/test/e2e/fips/fips_password_ref_test.go
+++ b/test/e2e/fips/fips_password_ref_test.go
@@ -9,10 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	rhtasv1 "github.com/securesign/operator/api/v1"
-	ctlogactions "github.com/securesign/operator/internal/controller/ctlog/actions"
-	fulcioactions "github.com/securesign/operator/internal/controller/fulcio/actions"
-	rekoractions "github.com/securesign/operator/internal/controller/rekor/actions"
-	tsaactions "github.com/securesign/operator/internal/controller/tsa/actions"
+	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	"github.com/securesign/operator/test/e2e/support"
 	"github.com/securesign/operator/test/e2e/support/postgresql"
 	"github.com/securesign/operator/test/e2e/support/steps"
@@ -82,7 +79,7 @@ var _ = Describe("FIPS password-ref rejection", Ordered, func() {
 	}
 
 	Describe("CTlog", func() {
-		assertRejectsPasswordRef(ctlogactions.SignerCondition, func(ctx context.Context) []metav1.Condition {
+		assertRejectsPasswordRef(fipsutil.FIPSCondition, func(ctx context.Context) []metav1.Condition {
 			cr := ctlog.Get(ctx, cli, namespace.Name, s.Name)
 			if cr == nil {
 				return nil
@@ -92,7 +89,7 @@ var _ = Describe("FIPS password-ref rejection", Ordered, func() {
 	})
 
 	Describe("Fulcio", func() {
-		assertRejectsPasswordRef(fulcioactions.CertCondition, func(ctx context.Context) []metav1.Condition {
+		assertRejectsPasswordRef(fipsutil.FIPSCondition, func(ctx context.Context) []metav1.Condition {
 			cr := fulciohelpers.Get(ctx, cli, namespace.Name, s.Name)
 			if cr == nil {
 				return nil
@@ -102,7 +99,7 @@ var _ = Describe("FIPS password-ref rejection", Ordered, func() {
 	})
 
 	Describe("Rekor", func() {
-		assertRejectsPasswordRef(rekoractions.SignerCondition, func(ctx context.Context) []metav1.Condition {
+		assertRejectsPasswordRef(fipsutil.FIPSCondition, func(ctx context.Context) []metav1.Condition {
 			cr := rekorhelpers.Get(ctx, cli, namespace.Name, s.Name)
 			if cr == nil {
 				return nil
@@ -112,7 +109,7 @@ var _ = Describe("FIPS password-ref rejection", Ordered, func() {
 	})
 
 	Describe("TSA", func() {
-		assertRejectsPasswordRef(tsaactions.TSASignerCondition, func(ctx context.Context) []metav1.Condition {
+		assertRejectsPasswordRef(fipsutil.FIPSCondition, func(ctx context.Context) []metav1.Condition {
 			cr := tsahelpers.Get(ctx, cli, namespace.Name, s.Name)
 			if cr == nil {
 				return nil

--- a/test/e2e/lifecycle/key_rotation_test.go
+++ b/test/e2e/lifecycle/key_rotation_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Key rotation test", Ordered, func() {
 					{
 						TreeID:           *oldTreeId,
 						TreeLength:       logLength,
-						EncodedPublicKey: base64.StdEncoding.EncodeToString(oldRekorSigner),
+						EncodedPublicKey: base64.StdEncoding.EncodeToString(oldRekorPub),
 					},
 				}
 


### PR DESCRIPTION
## Summary

Adds FIPS 140 compliance validation for user-provided cryptographic material across all components (CTlog, Fulcio, Rekor, TSA, Trillian, TUF).

A dedicated generic `fips.NewAction[T]` runs before the signer action in each controller's pipeline, validating private keys, public keys, and certificates against FIPS-approved algorithms and key sizes. Validation failures are terminal errors; transient failures (e.g. secret not yet available) allow retry.

- **`internal/action/fips/`** — Generic FIPS validation action with per-component `Config` callbacks
- **`internal/utils/fips/`** — PEM/DER validation functions, FIPS rules, and `ValidationError` type
- **6 `fips_validation.go` files** — Per-component wiring mapping spec fields to validation functions
- **`AppendSecretRef` / `AppendFIPSCondition` helpers** — Reduce boilerplate across controllers
