### PR TITLE
refactor: decouple Fulcio server config types from operator CRD API

### DIFF
--- a/api/v1/fulcio_types.go
+++ b/api/v1/fulcio_types.go
@@ -66,17 +66,17 @@ type FulcioCert struct {
 }
 
 // FulcioConfig configuration of OIDC issuers
-// +kubebuilder:validation:XValidation:rule=(has(self.OIDCIssuers) && (size(self.OIDCIssuers) > 0)) || (has(self.MetaIssuers) && (size(self.MetaIssuers) > 0)),message=At least one of OIDCIssuers or MetaIssuers must be defined
+// +kubebuilder:validation:XValidation:rule=(has(self.oidcIssuers) && (size(self.oidcIssuers) > 0)) || (has(self.metaIssuers) && (size(self.metaIssuers) > 0)),message=At least one of oidcIssuers or metaIssuers must be defined
 // NOTE: the below validation (and a similar one for MetaIssuers) would be great to have, but unfortunately it can't be used because compiling it yields:
 // "Forbidden: estimated rule cost exceeds budget by factor of more than 100x". It is turned off for now, maybe this can be fixed in the future.
 // Note that the error message also suggests to use MaxItems/MaxLength on the involved arrays/strings, but that doesn't seem to work either.
-// kubebuilder:validation:XValidation:rule="!has(self.OIDCIssuers) || has(self.OIDCIssuers) && self.OIDCIssuers.all(i, (!has(i.CIProvider) || (has(i.CIProvider) && i.CIProvider in self.CIIssuerMetadata.map(n, n.IssuerName))))",message=All CIProvider values of OIDCIssuers must be present in CIIssuerMetadata
+// kubebuilder:validation:XValidation:rule="!has(self.oidcIssuers) || has(self.oidcIssuers) && self.oidcIssuers.all(i, (!has(i.ciProvider) || (has(i.ciProvider) && i.ciProvider in self.ciIssuerMetadata.map(n, n.issuerName))))",message=All CIProvider values of OIDCIssuers must be present in CIIssuerMetadata
 type FulcioConfig struct {
 	// OIDC Configuration
 	// +optional
 	// +listType=map
-	// +listMapKey=Issuer
-	OIDCIssuers []OIDCIssuer `json:"OIDCIssuers,omitempty" yaml:"oidc-issuers,omitempty"`
+	// +listMapKey=issuer
+	OIDCIssuers []OIDCIssuer `json:"oidcIssuers,omitempty"`
 
 	// A meta issuer has a templated URL of the form:
 	//   https://oidc.eks.*.amazonaws.com/id/*
@@ -87,108 +87,108 @@ type FulcioConfig struct {
 	// * https://container.googleapis.com/v1/projects/mattmoor-credit/locations/us-west1-b/clusters/tenant-cluster
 	// +optional
 	// +listType=map
-	// +listMapKey=Issuer
-	MetaIssuers []OIDCIssuer `json:"MetaIssuers,omitempty" yaml:"meta-issuers,omitempty"`
+	// +listMapKey=issuer
+	MetaIssuers []OIDCIssuer `json:"metaIssuers,omitempty"`
 
 	// Metadata used for the CIProvider identity provider principal
 	// +listType=map
-	// +listMapKey=IssuerName
-	CIIssuerMetadata []CIIssuerMetadata `json:"CIIssuerMetadata,omitempty" yaml:"ci-issuer-metadata,omitempty"`
+	// +listMapKey=issuerName
+	CIIssuerMetadata []CIIssuerMetadata `json:"ciIssuerMetadata,omitempty"`
 }
 
 type OIDCIssuer struct {
 	// The expected issuer of an OIDC token
-	IssuerURL string `json:"IssuerURL,omitempty" yaml:"issuer-url,omitempty"`
+	IssuerURL string `json:"issuerURL,omitempty"`
 	// The expected issuer of an OIDC token
 	//+required
 	//+kubebuilder:validation:MinLength=1
-	Issuer string `json:"Issuer" yaml:"issuer"`
+	Issuer string `json:"issuer"`
 	//+required
 	//+kubebuilder:validation:MinLength=1
-	ClientID string `json:"ClientID" yaml:"client-id"`
+	ClientID string `json:"clientID"`
 	// Used to determine the subject of the certificate and if additional
 	// certificate values are needed
 	//+required
 	//+kubebuilder:validation:Enum=buildkite-job;email;github-workflow;codefresh-workflow;gitlab-pipeline;chainguard-identity;kubernetes;spiffe;uri;username;ci-provider
-	Type string `json:"Type" yaml:"type"`
+	Type string `json:"type"`
 	// CIProvider is an optional configuration to map token claims to extensions for CI workflows
-	CIProvider string `json:"CIProvider,omitempty" yaml:"ci-provider,omitempty"`
+	CIProvider string `json:"ciProvider,omitempty"`
 	// Optional, if the issuer is in a different claim in the OIDC token
-	IssuerClaim string `json:"IssuerClaim,omitempty" yaml:"issuer-claim,omitempty"`
+	IssuerClaim string `json:"issuerClaim,omitempty"`
 	// The domain that must be present in the subject for 'uri' issuer types
 	// Also used to create an email for 'username' issuer types
-	SubjectDomain string `json:"SubjectDomain,omitempty" yaml:"subject-domain,omitempty"`
+	SubjectDomain string `json:"subjectDomain,omitempty"`
 	// SPIFFETrustDomain specifies the trust domain that 'spiffe' issuer types
 	// issue ID tokens for. Tokens with a different trust domain will be
 	// rejected.
-	SPIFFETrustDomain string `json:"SPIFFETrustDomain,omitempty" yaml:"spiffe-trust-domain,omitempty"`
+	SPIFFETrustDomain string `json:"spiffeTrustDomain,omitempty"`
 	// Optional, the challenge claim expected for the issuer
 	// Set if using a custom issuer
-	ChallengeClaim string `json:"ChallengeClaim,omitempty" yaml:"challenge-claim,omitempty"`
+	ChallengeClaim string `json:"challengeClaim,omitempty"`
 }
 
 type CIIssuerMetadata struct {
 	// Name of the issuer
 	//+required
 	//+kubebuilder:validation:MinLength=1
-	IssuerName string `json:"IssuerName" yaml:"issuer-name"`
+	IssuerName string `json:"issuerName"`
 	// Defaults contains key-value pairs that can be used for filling the templates from ExtensionTemplates
 	// If a key cannot be found on the token claims, the template will use the defaults
-	DefaultTemplateValues map[string]string `json:"DefaultTemplateValues,omitempty" yaml:"default-template-values,omitempty"`
+	DefaultTemplateValues map[string]string `json:"defaultTemplateValues,omitempty"`
 	// ExtensionTemplates contains a mapping between certificate extension and token claim
 	// Provide either strings following https://pkg.go.dev/text/template syntax,
 	// e.g "{{ .url }}/{{ .repository }}"
 	// or non-templated strings with token claim keys to be replaced,
 	// e.g "job_workflow_sha"
-	ExtensionTemplates Extensions `json:"ExtensionTemplates,omitempty" yaml:"extension-templates,omitempty"`
+	ExtensionTemplates Extensions `json:"extensionTemplates,omitempty"`
 	// Template for the Subject Alternative Name extension
 	// It's typically the same value as Build Signer URI
-	SubjectAlternativeNameTemplate string `json:"SubjectAlternativeNameTemplate,omitempty" yaml:"subject-alternative-name-template,omitempty"`
+	SubjectAlternativeNameTemplate string `json:"subjectAlternativeNameTemplate,omitempty"`
 }
 
 // Extensions contains all custom x509 extensions defined by Fulcio
 type Extensions struct {
 	// Reference to specific build instructions that are responsible for signing.
-	BuildSignerURI string `json:"BuildSignerURI,omitempty" yaml:"build-signer-uri,omitempty"` // 1.3.6.1.4.1.57264.1.9
+	BuildSignerURI string `json:"buildSignerURI,omitempty"` // 1.3.6.1.4.1.57264.1.9
 
 	// Immutable reference to the specific version of the build instructions that is responsible for signing.
-	BuildSignerDigest string `json:"BuildSignerDigest,omitempty" yaml:"build-signer-digest,omitempty"` // 1.3.6.1.4.1.57264.1.10
+	BuildSignerDigest string `json:"buildSignerDigest,omitempty"` // 1.3.6.1.4.1.57264.1.10
 
 	// Specifies whether the build took place in platform-hosted cloud infrastructure or customer/self-hosted infrastructure.
-	RunnerEnvironment string `json:"RunnerEnvironment,omitempty" yaml:"runner-environment,omitempty"` // 1.3.6.1.4.1.57264.1.11
+	RunnerEnvironment string `json:"runnerEnvironment,omitempty"` // 1.3.6.1.4.1.57264.1.11
 
 	// Source repository URL that the build was based on.
-	SourceRepositoryURI string `json:"SourceRepositoryURI,omitempty" yaml:"source-repository-uri,omitempty"` // 1.3.6.1.4.1.57264.1.12
+	SourceRepositoryURI string `json:"sourceRepositoryURI,omitempty"` // 1.3.6.1.4.1.57264.1.12
 
 	// Immutable reference to a specific version of the source code that the build was based upon.
-	SourceRepositoryDigest string `json:"SourceRepositoryDigest,omitempty" yaml:"source-repository-digest,omitempty"` // 1.3.6.1.4.1.57264.1.13
+	SourceRepositoryDigest string `json:"sourceRepositoryDigest,omitempty"` // 1.3.6.1.4.1.57264.1.13
 
 	// Source Repository Ref that the build run was based upon.
-	SourceRepositoryRef string `json:"SourceRepositoryRef,omitempty" yaml:"source-repository-ref,omitempty"` // 1.3.6.1.4.1.57264.1.14
+	SourceRepositoryRef string `json:"sourceRepositoryRef,omitempty"` // 1.3.6.1.4.1.57264.1.14
 
 	// Immutable identifier for the source repository the workflow was based upon.
-	SourceRepositoryIdentifier string `json:"SourceRepositoryIdentifier,omitempty" yaml:"source-repository-identifier,omitempty"` // 1.3.6.1.4.1.57264.1.15
+	SourceRepositoryIdentifier string `json:"sourceRepositoryIdentifier,omitempty"` // 1.3.6.1.4.1.57264.1.15
 
 	// Source repository owner URL of the owner of the source repository that the build was based on.
-	SourceRepositoryOwnerURI string `json:"SourceRepositoryOwnerURI,omitempty" yaml:"source-repository-owner-uri,omitempty"` // 1.3.6.1.4.1.57264.1.16
+	SourceRepositoryOwnerURI string `json:"sourceRepositoryOwnerURI,omitempty"` // 1.3.6.1.4.1.57264.1.16
 
 	// Immutable identifier for the owner of the source repository that the workflow was based upon.
-	SourceRepositoryOwnerIdentifier string `json:"SourceRepositoryOwnerIdentifier,omitempty" yaml:"source-repository-owner-identifier,omitempty"` // 1.3.6.1.4.1.57264.1.17
+	SourceRepositoryOwnerIdentifier string `json:"sourceRepositoryOwnerIdentifier,omitempty"` // 1.3.6.1.4.1.57264.1.17
 
 	// Build Config URL to the top-level/initiating build instructions.
-	BuildConfigURI string `json:"BuildConfigURI,omitempty" yaml:"build-config-uri,omitempty"` // 1.3.6.1.4.1.57264.1.18
+	BuildConfigURI string `json:"buildConfigURI,omitempty"` // 1.3.6.1.4.1.57264.1.18
 
 	// Immutable reference to the specific version of the top-level/initiating build instructions.
-	BuildConfigDigest string `json:"BuildConfigDigest,omitempty" yaml:"build-config-digest,omitempty"` // 1.3.6.1.4.1.57264.1.19
+	BuildConfigDigest string `json:"buildConfigDigest,omitempty"` // 1.3.6.1.4.1.57264.1.19
 
 	// Event or action that initiated the build.
-	BuildTrigger string `json:"BuildTrigger,omitempty" yaml:"build-trigger,omitempty"` // 1.3.6.1.4.1.57264.1.20
+	BuildTrigger string `json:"buildTrigger,omitempty"` // 1.3.6.1.4.1.57264.1.20
 
 	// Run Invocation URL to uniquely identify the build execution.
-	RunInvocationURI string `json:"RunInvocationURI,omitempty" yaml:"run-invocation-uri,omitempty"` // 1.3.6.1.4.1.57264.1.21
+	RunInvocationURI string `json:"runInvocationURI,omitempty"` // 1.3.6.1.4.1.57264.1.21
 
 	// Source repository visibility at the time of signing the certificate.
-	SourceRepositoryVisibilityAtSigning string `json:"SourceRepositoryVisibilityAtSigning,omitempty" yaml:"source-repository-visibility-at-signing,omitempty"` // 1.3.6.1.4.1.57264.1.22
+	SourceRepositoryVisibilityAtSigning string `json:"sourceRepositoryVisibilityAtSigning,omitempty"` // 1.3.6.1.4.1.57264.1.22
 }
 
 type FulcioCertStatus struct {

--- a/api/v1/fulcio_types_test.go
+++ b/api/v1/fulcio_types_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Fulcio", func() {
 
 				Expect(apierrors.IsInvalid(k8sClient.Create(context.Background(), invalidObject))).To(BeTrue())
 				Expect(k8sClient.Create(context.Background(), invalidObject)).
-					To(MatchError(ContainSubstring("At least one of OIDCIssuers or MetaIssuers must be defined")))
+					To(MatchError(ContainSubstring("At least one of oidcIssuers or metaIssuers must be defined")))
 			})
 
 			It("CIIssuerMetadata is set", func() {

--- a/api/v1/securesign_types.go
+++ b/api/v1/securesign_types.go
@@ -22,7 +22,7 @@ import (
 )
 
 // SecuresignSpec defines the desired state of Securesign
-// +kubebuilder:validation:XValidation:rule="has(self.fulcio.config.OIDCIssuers) || has(self.fulcio.config.MetaIssuers)",message="At least one OIDC issuer or meta issuer must be configured in fulcio.config"
+// +kubebuilder:validation:XValidation:rule="has(self.fulcio.config.oidcIssuers) || has(self.fulcio.config.metaIssuers)",message="At least one OIDC issuer or meta issuer must be configured in fulcio.config"
 // +kubebuilder:validation:XValidation:rule="!has(self.tuf.replicas) || !(self.tuf.replicas > 1) || (has(self.tuf.pvc.accessModes) && 'ReadWriteMany' in self.tuf.pvc.accessModes)",message="For tuf deployments with more than 1 replica, pvc.accessModes must include 'ReadWriteMany'."
 // +kubebuilder:validation:XValidation:rule="(has(self.rekor.attestations.enabled) && !self.rekor.attestations.enabled) || !self.rekor.attestations.url.startsWith('file://') || !has(self.rekor.replicas) || !(self.rekor.replicas > 1) || (has(self.rekor.attestations.pvc.accessModes) && 'ReadWriteMany' in self.rekor.attestations.pvc.accessModes)",message="When rich attestation storage is enabled, and it's URL starts with 'file://', then rekor pvc.accessModes must contain 'ReadWriteMany' for replicas greater than 1."
 type SecuresignSpec struct {

--- a/config/crd/bases/rhtas.redhat.com_fulcios.yaml
+++ b/config/crd/bases/rhtas.redhat.com_fulcios.yaml
@@ -1040,19 +1040,19 @@ spec:
               config:
                 description: Fulcio Configuration
                 properties:
-                  CIIssuerMetadata:
+                  ciIssuerMetadata:
                     description: Metadata used for the CIProvider identity provider
                       principal
                     items:
                       properties:
-                        DefaultTemplateValues:
+                        defaultTemplateValues:
                           additionalProperties:
                             type: string
                           description: |-
                             Defaults contains key-value pairs that can be used for filling the templates from ExtensionTemplates
                             If a key cannot be found on the token claims, the template will use the defaults
                           type: object
-                        ExtensionTemplates:
+                        extensionTemplates:
                           description: |-
                             ExtensionTemplates contains a mapping between certificate extension and token claim
                             Provide either strings following https://pkg.go.dev/text/template syntax,
@@ -1060,82 +1060,82 @@ spec:
                             or non-templated strings with token claim keys to be replaced,
                             e.g "job_workflow_sha"
                           properties:
-                            BuildConfigDigest:
+                            buildConfigDigest:
                               description: Immutable reference to the specific version
                                 of the top-level/initiating build instructions.
                               type: string
-                            BuildConfigURI:
+                            buildConfigURI:
                               description: Build Config URL to the top-level/initiating
                                 build instructions.
                               type: string
-                            BuildSignerDigest:
+                            buildSignerDigest:
                               description: Immutable reference to the specific version
                                 of the build instructions that is responsible for
                                 signing.
                               type: string
-                            BuildSignerURI:
+                            buildSignerURI:
                               description: Reference to specific build instructions
                                 that are responsible for signing.
                               type: string
-                            BuildTrigger:
+                            buildTrigger:
                               description: Event or action that initiated the build.
                               type: string
-                            RunInvocationURI:
+                            runInvocationURI:
                               description: Run Invocation URL to uniquely identify
                                 the build execution.
                               type: string
-                            RunnerEnvironment:
+                            runnerEnvironment:
                               description: Specifies whether the build took place
                                 in platform-hosted cloud infrastructure or customer/self-hosted
                                 infrastructure.
                               type: string
-                            SourceRepositoryDigest:
+                            sourceRepositoryDigest:
                               description: Immutable reference to a specific version
                                 of the source code that the build was based upon.
                               type: string
-                            SourceRepositoryIdentifier:
+                            sourceRepositoryIdentifier:
                               description: Immutable identifier for the source repository
                                 the workflow was based upon.
                               type: string
-                            SourceRepositoryOwnerIdentifier:
+                            sourceRepositoryOwnerIdentifier:
                               description: Immutable identifier for the owner of the
                                 source repository that the workflow was based upon.
                               type: string
-                            SourceRepositoryOwnerURI:
+                            sourceRepositoryOwnerURI:
                               description: Source repository owner URL of the owner
                                 of the source repository that the build was based
                                 on.
                               type: string
-                            SourceRepositoryRef:
+                            sourceRepositoryRef:
                               description: Source Repository Ref that the build run
                                 was based upon.
                               type: string
-                            SourceRepositoryURI:
+                            sourceRepositoryURI:
                               description: Source repository URL that the build was
                                 based on.
                               type: string
-                            SourceRepositoryVisibilityAtSigning:
+                            sourceRepositoryVisibilityAtSigning:
                               description: Source repository visibility at the time
                                 of signing the certificate.
                               type: string
                           type: object
-                        IssuerName:
+                        issuerName:
                           description: Name of the issuer
                           minLength: 1
                           type: string
-                        SubjectAlternativeNameTemplate:
+                        subjectAlternativeNameTemplate:
                           description: |-
                             Template for the Subject Alternative Name extension
                             It's typically the same value as Build Signer URI
                           type: string
                       required:
-                      - IssuerName
+                      - issuerName
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - IssuerName
+                    - issuerName
                     x-kubernetes-list-type: map
-                  MetaIssuers:
+                  metaIssuers:
                     description: |-
                       A meta issuer has a templated URL of the form:
                         https://oidc.eks.*.amazonaws.com/id/*
@@ -1146,41 +1146,41 @@ spec:
                       * https://container.googleapis.com/v1/projects/mattmoor-credit/locations/us-west1-b/clusters/tenant-cluster
                     items:
                       properties:
-                        CIProvider:
-                          description: CIProvider is an optional configuration to
-                            map token claims to extensions for CI workflows
-                          type: string
-                        ChallengeClaim:
+                        challengeClaim:
                           description: |-
                             Optional, the challenge claim expected for the issuer
                             Set if using a custom issuer
                           type: string
-                        ClientID:
+                        ciProvider:
+                          description: CIProvider is an optional configuration to
+                            map token claims to extensions for CI workflows
+                          type: string
+                        clientID:
                           minLength: 1
                           type: string
-                        Issuer:
+                        issuer:
                           description: The expected issuer of an OIDC token
                           minLength: 1
                           type: string
-                        IssuerClaim:
+                        issuerClaim:
                           description: Optional, if the issuer is in a different claim
                             in the OIDC token
                           type: string
-                        IssuerURL:
+                        issuerURL:
                           description: The expected issuer of an OIDC token
                           type: string
-                        SPIFFETrustDomain:
+                        spiffeTrustDomain:
                           description: |-
                             SPIFFETrustDomain specifies the trust domain that 'spiffe' issuer types
                             issue ID tokens for. Tokens with a different trust domain will be
                             rejected.
                           type: string
-                        SubjectDomain:
+                        subjectDomain:
                           description: |-
                             The domain that must be present in the subject for 'uri' issuer types
                             Also used to create an email for 'username' issuer types
                           type: string
-                        Type:
+                        type:
                           description: |-
                             Used to determine the subject of the certificate and if additional
                             certificate values are needed
@@ -1198,53 +1198,53 @@ spec:
                           - ci-provider
                           type: string
                       required:
-                      - ClientID
-                      - Issuer
-                      - Type
+                      - clientID
+                      - issuer
+                      - type
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - Issuer
+                    - issuer
                     x-kubernetes-list-type: map
-                  OIDCIssuers:
+                  oidcIssuers:
                     description: OIDC Configuration
                     items:
                       properties:
-                        CIProvider:
-                          description: CIProvider is an optional configuration to
-                            map token claims to extensions for CI workflows
-                          type: string
-                        ChallengeClaim:
+                        challengeClaim:
                           description: |-
                             Optional, the challenge claim expected for the issuer
                             Set if using a custom issuer
                           type: string
-                        ClientID:
+                        ciProvider:
+                          description: CIProvider is an optional configuration to
+                            map token claims to extensions for CI workflows
+                          type: string
+                        clientID:
                           minLength: 1
                           type: string
-                        Issuer:
+                        issuer:
                           description: The expected issuer of an OIDC token
                           minLength: 1
                           type: string
-                        IssuerClaim:
+                        issuerClaim:
                           description: Optional, if the issuer is in a different claim
                             in the OIDC token
                           type: string
-                        IssuerURL:
+                        issuerURL:
                           description: The expected issuer of an OIDC token
                           type: string
-                        SPIFFETrustDomain:
+                        spiffeTrustDomain:
                           description: |-
                             SPIFFETrustDomain specifies the trust domain that 'spiffe' issuer types
                             issue ID tokens for. Tokens with a different trust domain will be
                             rejected.
                           type: string
-                        SubjectDomain:
+                        subjectDomain:
                           description: |-
                             The domain that must be present in the subject for 'uri' issuer types
                             Also used to create an email for 'username' issuer types
                           type: string
-                        Type:
+                        type:
                           description: |-
                             Used to determine the subject of the certificate and if additional
                             certificate values are needed
@@ -1262,19 +1262,19 @@ spec:
                           - ci-provider
                           type: string
                       required:
-                      - ClientID
-                      - Issuer
-                      - Type
+                      - clientID
+                      - issuer
+                      - type
                       type: object
                     type: array
                     x-kubernetes-list-map-keys:
-                    - Issuer
+                    - issuer
                     x-kubernetes-list-type: map
                 type: object
                 x-kubernetes-validations:
-                - message: At least one of OIDCIssuers or MetaIssuers must be defined
-                  rule: (has(self.OIDCIssuers) && (size(self.OIDCIssuers) > 0)) ||
-                    (has(self.MetaIssuers) && (size(self.MetaIssuers) > 0))
+                - message: At least one of oidcIssuers or metaIssuers must be defined
+                  rule: (has(self.oidcIssuers) && (size(self.oidcIssuers) > 0)) ||
+                    (has(self.metaIssuers) && (size(self.metaIssuers) > 0))
               ctlog:
                 description: Ctlog service configuration
                 properties:

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -2338,19 +2338,19 @@ spec:
                   config:
                     description: Fulcio Configuration
                     properties:
-                      CIIssuerMetadata:
+                      ciIssuerMetadata:
                         description: Metadata used for the CIProvider identity provider
                           principal
                         items:
                           properties:
-                            DefaultTemplateValues:
+                            defaultTemplateValues:
                               additionalProperties:
                                 type: string
                               description: |-
                                 Defaults contains key-value pairs that can be used for filling the templates from ExtensionTemplates
                                 If a key cannot be found on the token claims, the template will use the defaults
                               type: object
-                            ExtensionTemplates:
+                            extensionTemplates:
                               description: |-
                                 ExtensionTemplates contains a mapping between certificate extension and token claim
                                 Provide either strings following https://pkg.go.dev/text/template syntax,
@@ -2358,84 +2358,84 @@ spec:
                                 or non-templated strings with token claim keys to be replaced,
                                 e.g "job_workflow_sha"
                               properties:
-                                BuildConfigDigest:
+                                buildConfigDigest:
                                   description: Immutable reference to the specific
                                     version of the top-level/initiating build instructions.
                                   type: string
-                                BuildConfigURI:
+                                buildConfigURI:
                                   description: Build Config URL to the top-level/initiating
                                     build instructions.
                                   type: string
-                                BuildSignerDigest:
+                                buildSignerDigest:
                                   description: Immutable reference to the specific
                                     version of the build instructions that is responsible
                                     for signing.
                                   type: string
-                                BuildSignerURI:
+                                buildSignerURI:
                                   description: Reference to specific build instructions
                                     that are responsible for signing.
                                   type: string
-                                BuildTrigger:
+                                buildTrigger:
                                   description: Event or action that initiated the
                                     build.
                                   type: string
-                                RunInvocationURI:
+                                runInvocationURI:
                                   description: Run Invocation URL to uniquely identify
                                     the build execution.
                                   type: string
-                                RunnerEnvironment:
+                                runnerEnvironment:
                                   description: Specifies whether the build took place
                                     in platform-hosted cloud infrastructure or customer/self-hosted
                                     infrastructure.
                                   type: string
-                                SourceRepositoryDigest:
+                                sourceRepositoryDigest:
                                   description: Immutable reference to a specific version
                                     of the source code that the build was based upon.
                                   type: string
-                                SourceRepositoryIdentifier:
+                                sourceRepositoryIdentifier:
                                   description: Immutable identifier for the source
                                     repository the workflow was based upon.
                                   type: string
-                                SourceRepositoryOwnerIdentifier:
+                                sourceRepositoryOwnerIdentifier:
                                   description: Immutable identifier for the owner
                                     of the source repository that the workflow was
                                     based upon.
                                   type: string
-                                SourceRepositoryOwnerURI:
+                                sourceRepositoryOwnerURI:
                                   description: Source repository owner URL of the
                                     owner of the source repository that the build
                                     was based on.
                                   type: string
-                                SourceRepositoryRef:
+                                sourceRepositoryRef:
                                   description: Source Repository Ref that the build
                                     run was based upon.
                                   type: string
-                                SourceRepositoryURI:
+                                sourceRepositoryURI:
                                   description: Source repository URL that the build
                                     was based on.
                                   type: string
-                                SourceRepositoryVisibilityAtSigning:
+                                sourceRepositoryVisibilityAtSigning:
                                   description: Source repository visibility at the
                                     time of signing the certificate.
                                   type: string
                               type: object
-                            IssuerName:
+                            issuerName:
                               description: Name of the issuer
                               minLength: 1
                               type: string
-                            SubjectAlternativeNameTemplate:
+                            subjectAlternativeNameTemplate:
                               description: |-
                                 Template for the Subject Alternative Name extension
                                 It's typically the same value as Build Signer URI
                               type: string
                           required:
-                          - IssuerName
+                          - issuerName
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
-                        - IssuerName
+                        - issuerName
                         x-kubernetes-list-type: map
-                      MetaIssuers:
+                      metaIssuers:
                         description: |-
                           A meta issuer has a templated URL of the form:
                             https://oidc.eks.*.amazonaws.com/id/*
@@ -2446,41 +2446,41 @@ spec:
                           * https://container.googleapis.com/v1/projects/mattmoor-credit/locations/us-west1-b/clusters/tenant-cluster
                         items:
                           properties:
-                            CIProvider:
-                              description: CIProvider is an optional configuration
-                                to map token claims to extensions for CI workflows
-                              type: string
-                            ChallengeClaim:
+                            challengeClaim:
                               description: |-
                                 Optional, the challenge claim expected for the issuer
                                 Set if using a custom issuer
                               type: string
-                            ClientID:
+                            ciProvider:
+                              description: CIProvider is an optional configuration
+                                to map token claims to extensions for CI workflows
+                              type: string
+                            clientID:
                               minLength: 1
                               type: string
-                            Issuer:
+                            issuer:
                               description: The expected issuer of an OIDC token
                               minLength: 1
                               type: string
-                            IssuerClaim:
+                            issuerClaim:
                               description: Optional, if the issuer is in a different
                                 claim in the OIDC token
                               type: string
-                            IssuerURL:
+                            issuerURL:
                               description: The expected issuer of an OIDC token
                               type: string
-                            SPIFFETrustDomain:
+                            spiffeTrustDomain:
                               description: |-
                                 SPIFFETrustDomain specifies the trust domain that 'spiffe' issuer types
                                 issue ID tokens for. Tokens with a different trust domain will be
                                 rejected.
                               type: string
-                            SubjectDomain:
+                            subjectDomain:
                               description: |-
                                 The domain that must be present in the subject for 'uri' issuer types
                                 Also used to create an email for 'username' issuer types
                               type: string
-                            Type:
+                            type:
                               description: |-
                                 Used to determine the subject of the certificate and if additional
                                 certificate values are needed
@@ -2498,53 +2498,53 @@ spec:
                               - ci-provider
                               type: string
                           required:
-                          - ClientID
-                          - Issuer
-                          - Type
+                          - clientID
+                          - issuer
+                          - type
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
-                        - Issuer
+                        - issuer
                         x-kubernetes-list-type: map
-                      OIDCIssuers:
+                      oidcIssuers:
                         description: OIDC Configuration
                         items:
                           properties:
-                            CIProvider:
-                              description: CIProvider is an optional configuration
-                                to map token claims to extensions for CI workflows
-                              type: string
-                            ChallengeClaim:
+                            challengeClaim:
                               description: |-
                                 Optional, the challenge claim expected for the issuer
                                 Set if using a custom issuer
                               type: string
-                            ClientID:
+                            ciProvider:
+                              description: CIProvider is an optional configuration
+                                to map token claims to extensions for CI workflows
+                              type: string
+                            clientID:
                               minLength: 1
                               type: string
-                            Issuer:
+                            issuer:
                               description: The expected issuer of an OIDC token
                               minLength: 1
                               type: string
-                            IssuerClaim:
+                            issuerClaim:
                               description: Optional, if the issuer is in a different
                                 claim in the OIDC token
                               type: string
-                            IssuerURL:
+                            issuerURL:
                               description: The expected issuer of an OIDC token
                               type: string
-                            SPIFFETrustDomain:
+                            spiffeTrustDomain:
                               description: |-
                                 SPIFFETrustDomain specifies the trust domain that 'spiffe' issuer types
                                 issue ID tokens for. Tokens with a different trust domain will be
                                 rejected.
                               type: string
-                            SubjectDomain:
+                            subjectDomain:
                               description: |-
                                 The domain that must be present in the subject for 'uri' issuer types
                                 Also used to create an email for 'username' issuer types
                               type: string
-                            Type:
+                            type:
                               description: |-
                                 Used to determine the subject of the certificate and if additional
                                 certificate values are needed
@@ -2562,20 +2562,20 @@ spec:
                               - ci-provider
                               type: string
                           required:
-                          - ClientID
-                          - Issuer
-                          - Type
+                          - clientID
+                          - issuer
+                          - type
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
-                        - Issuer
+                        - issuer
                         x-kubernetes-list-type: map
                     type: object
                     x-kubernetes-validations:
-                    - message: At least one of OIDCIssuers or MetaIssuers must be
+                    - message: At least one of oidcIssuers or metaIssuers must be
                         defined
-                      rule: (has(self.OIDCIssuers) && (size(self.OIDCIssuers) > 0))
-                        || (has(self.MetaIssuers) && (size(self.MetaIssuers) > 0))
+                      rule: (has(self.oidcIssuers) && (size(self.oidcIssuers) > 0))
+                        || (has(self.metaIssuers) && (size(self.metaIssuers) > 0))
                   ctlog:
                     description: Ctlog service configuration
                     properties:
@@ -10817,7 +10817,7 @@ spec:
             x-kubernetes-validations:
             - message: At least one OIDC issuer or meta issuer must be configured
                 in fulcio.config
-              rule: has(self.fulcio.config.OIDCIssuers) || has(self.fulcio.config.MetaIssuers)
+              rule: has(self.fulcio.config.oidcIssuers) || has(self.fulcio.config.metaIssuers)
             - message: For tuf deployments with more than 1 replica, pvc.accessModes
                 must include 'ReadWriteMany'.
               rule: '!has(self.tuf.replicas) || !(self.tuf.replicas > 1) || (has(self.tuf.pvc.accessModes)

--- a/internal/controller/fulcio/actions/server_config.go
+++ b/internal/controller/fulcio/actions/server_config.go
@@ -11,6 +11,7 @@ import (
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/controller/fulcio/utils"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
 	"github.com/securesign/operator/internal/utils/kubernetes"
@@ -42,39 +43,8 @@ func (i serverConfig) Name() string {
 	return "create server config"
 }
 
-type FulcioMapConfig struct {
-	OIDCIssuers      map[string]rhtasv1.OIDCIssuer       `yaml:"oidc-issuers"`
-	MetaIssuers      map[string]rhtasv1.OIDCIssuer       `yaml:"meta-issuers"`
-	CIIssuerMetadata map[string]rhtasv1.CIIssuerMetadata `yaml:"ci-issuer-metadata"`
-}
-
 func (i serverConfig) CanHandle(ctx context.Context, instance *rhtasv1.Fulcio) bool {
 	return state.FromInstance(instance, constants.ReadyCondition) >= state.Creating
-}
-
-func ConvertToFulcioMapConfig(fulcioConfig rhtasv1.FulcioConfig) *FulcioMapConfig {
-	OIDCIssuers := make(map[string]rhtasv1.OIDCIssuer)
-	MetaIssuers := make(map[string]rhtasv1.OIDCIssuer)
-	CIIssuerMetadata := make(map[string]rhtasv1.CIIssuerMetadata)
-
-	for _, issuer := range fulcioConfig.OIDCIssuers {
-		OIDCIssuers[issuer.Issuer] = issuer
-	}
-
-	for _, issuer := range fulcioConfig.MetaIssuers {
-		MetaIssuers[issuer.Issuer] = issuer
-	}
-
-	for _, metadata := range fulcioConfig.CIIssuerMetadata {
-		CIIssuerMetadata[metadata.IssuerName] = metadata
-	}
-
-	fulcioMapConfig := &FulcioMapConfig{
-		OIDCIssuers:      OIDCIssuers,
-		MetaIssuers:      MetaIssuers,
-		CIIssuerMetadata: CIIssuerMetadata,
-	}
-	return fulcioMapConfig
 }
 
 func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.Fulcio) *action.Result {
@@ -83,7 +53,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.Fulcio) *act
 	)
 	configLabel := labels.ForResource(ComponentName, DeploymentName, instance.Name, configResourceLabel)
 
-	config, err := yaml.Marshal(ConvertToFulcioMapConfig(instance.Spec.Config))
+	config, err := yaml.Marshal(utils.NewFulcioServerConfig(instance.Spec.Config))
 	if err != nil {
 		return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("could not marshal fulcio config: %w", err)), instance)
 	}

--- a/internal/controller/fulcio/utils/fulcio_config_types.go
+++ b/internal/controller/fulcio/utils/fulcio_config_types.go
@@ -1,0 +1,111 @@
+package utils
+
+import rhtasv1 "github.com/securesign/operator/api/v1"
+
+type FulcioServerConfig struct {
+	OIDCIssuers      map[string]OIDCIssuer       `yaml:"oidc-issuers"`
+	MetaIssuers      map[string]OIDCIssuer       `yaml:"meta-issuers"`
+	CIIssuerMetadata map[string]CIIssuerMetadata `yaml:"ci-issuer-metadata"`
+}
+
+type OIDCIssuer struct {
+	IssuerURL         string `yaml:"issuer-url,omitempty"`
+	Issuer            string `yaml:"issuer"`
+	ClientID          string `yaml:"client-id"`
+	Type              string `yaml:"type"`
+	CIProvider        string `yaml:"ci-provider,omitempty"`
+	IssuerClaim       string `yaml:"issuer-claim,omitempty"`
+	SubjectDomain     string `yaml:"subject-domain,omitempty"`
+	SPIFFETrustDomain string `yaml:"spiffe-trust-domain,omitempty"`
+	ChallengeClaim    string `yaml:"challenge-claim,omitempty"`
+}
+
+type CIIssuerMetadata struct {
+	IssuerName                     string            `yaml:"issuer-name"`
+	DefaultTemplateValues          map[string]string `yaml:"default-template-values,omitempty"`
+	ExtensionTemplates             Extensions        `yaml:"extension-templates,omitempty"`
+	SubjectAlternativeNameTemplate string            `yaml:"subject-alternative-name-template,omitempty"`
+}
+
+type Extensions struct {
+	BuildSignerURI                      string `yaml:"build-signer-uri,omitempty"`
+	BuildSignerDigest                   string `yaml:"build-signer-digest,omitempty"`
+	RunnerEnvironment                   string `yaml:"runner-environment,omitempty"`
+	SourceRepositoryURI                 string `yaml:"source-repository-uri,omitempty"`
+	SourceRepositoryDigest              string `yaml:"source-repository-digest,omitempty"`
+	SourceRepositoryRef                 string `yaml:"source-repository-ref,omitempty"`
+	SourceRepositoryIdentifier          string `yaml:"source-repository-identifier,omitempty"`
+	SourceRepositoryOwnerURI            string `yaml:"source-repository-owner-uri,omitempty"`
+	SourceRepositoryOwnerIdentifier     string `yaml:"source-repository-owner-identifier,omitempty"`
+	BuildConfigURI                      string `yaml:"build-config-uri,omitempty"`
+	BuildConfigDigest                   string `yaml:"build-config-digest,omitempty"`
+	BuildTrigger                        string `yaml:"build-trigger,omitempty"`
+	RunInvocationURI                    string `yaml:"run-invocation-uri,omitempty"`
+	SourceRepositoryVisibilityAtSigning string `yaml:"source-repository-visibility-at-signing,omitempty"`
+}
+
+func NewFulcioServerConfig(fulcioConfig rhtasv1.FulcioConfig) *FulcioServerConfig {
+	oidcIssuers := make(map[string]OIDCIssuer)
+	metaIssuers := make(map[string]OIDCIssuer)
+	ciIssuerMetadata := make(map[string]CIIssuerMetadata)
+
+	for _, issuer := range fulcioConfig.OIDCIssuers {
+		oidcIssuers[issuer.Issuer] = convertOIDCIssuer(issuer)
+	}
+
+	for _, issuer := range fulcioConfig.MetaIssuers {
+		metaIssuers[issuer.Issuer] = convertOIDCIssuer(issuer)
+	}
+
+	for _, metadata := range fulcioConfig.CIIssuerMetadata {
+		ciIssuerMetadata[metadata.IssuerName] = convertCIIssuerMetadata(metadata)
+	}
+
+	return &FulcioServerConfig{
+		OIDCIssuers:      oidcIssuers,
+		MetaIssuers:      metaIssuers,
+		CIIssuerMetadata: ciIssuerMetadata,
+	}
+}
+
+func convertOIDCIssuer(in rhtasv1.OIDCIssuer) OIDCIssuer {
+	return OIDCIssuer{
+		IssuerURL:         in.IssuerURL,
+		Issuer:            in.Issuer,
+		ClientID:          in.ClientID,
+		Type:              in.Type,
+		CIProvider:        in.CIProvider,
+		IssuerClaim:       in.IssuerClaim,
+		SubjectDomain:     in.SubjectDomain,
+		SPIFFETrustDomain: in.SPIFFETrustDomain,
+		ChallengeClaim:    in.ChallengeClaim,
+	}
+}
+
+func convertCIIssuerMetadata(in rhtasv1.CIIssuerMetadata) CIIssuerMetadata {
+	return CIIssuerMetadata{
+		IssuerName:                     in.IssuerName,
+		DefaultTemplateValues:          in.DefaultTemplateValues,
+		ExtensionTemplates:             convertExtensions(in.ExtensionTemplates),
+		SubjectAlternativeNameTemplate: in.SubjectAlternativeNameTemplate,
+	}
+}
+
+func convertExtensions(in rhtasv1.Extensions) Extensions {
+	return Extensions{
+		BuildSignerURI:                      in.BuildSignerURI,
+		BuildSignerDigest:                   in.BuildSignerDigest,
+		RunnerEnvironment:                   in.RunnerEnvironment,
+		SourceRepositoryURI:                 in.SourceRepositoryURI,
+		SourceRepositoryDigest:              in.SourceRepositoryDigest,
+		SourceRepositoryRef:                 in.SourceRepositoryRef,
+		SourceRepositoryIdentifier:          in.SourceRepositoryIdentifier,
+		SourceRepositoryOwnerURI:            in.SourceRepositoryOwnerURI,
+		SourceRepositoryOwnerIdentifier:     in.SourceRepositoryOwnerIdentifier,
+		BuildConfigURI:                      in.BuildConfigURI,
+		BuildConfigDigest:                   in.BuildConfigDigest,
+		BuildTrigger:                        in.BuildTrigger,
+		RunInvocationURI:                    in.RunInvocationURI,
+		SourceRepositoryVisibilityAtSigning: in.SourceRepositoryVisibilityAtSigning,
+	}
+}

--- a/test/e2e/update/fulcio_test.go
+++ b/test/e2e/update/fulcio_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/securesign/operator/test/e2e/support/tas"
 
 	fulcioAction "github.com/securesign/operator/internal/controller/fulcio/actions"
+	fulcioUtils "github.com/securesign/operator/internal/controller/fulcio/utils"
 	"github.com/securesign/operator/test/e2e/support/tas/ctlog"
 	"github.com/securesign/operator/test/e2e/support/tas/fulcio"
 	"github.com/securesign/operator/test/e2e/support/tas/securesign"
@@ -285,7 +286,7 @@ var _ = Describe("Fulcio update", Ordered, func() {
 
 			cm := &v1.ConfigMap{}
 			Expect(cli.Get(ctx, types.NamespacedName{Namespace: namespace.Name, Name: f.Status.ServerConfigRef.Name}, cm)).To(Succeed())
-			config := &fulcioAction.FulcioMapConfig{}
+			config := &fulcioUtils.FulcioServerConfig{}
 			Expect(yaml.Unmarshal([]byte(cm.Data["config.yaml"]), config)).To(Succeed())
 			Expect(config.OIDCIssuers).To(HaveKey("fake"))
 		})


### PR DESCRIPTION
  Introduce distinct internal structs for Fulcio server config YAML
  serialization, removing the direct dependency on API types. Fix
  PascalCase JSON tags in v1 API to follow Kubernetes camelCase convention.

Assisted-by: Claude Code (claude-opus-4-6)