### PR TITLE
feat: add SSA merge strategy markers for remaining list fields

### DIFF
--- a/api/v1/common.go
+++ b/api/v1/common.go
@@ -170,15 +170,21 @@ type Pvc struct {
 	StorageClass string `json:"storageClass,omitempty"`
 	// PVC AccessModes
 	//+kubebuilder:validation:MinItems:=1
+	// +listType=set
 	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 }
 
 type Auth struct {
 	// Environmental variables used to define authentication parameters
 	//+optional
+	// +listType=map
+	// +listMapKey=name
 	Env []core.EnvVar `json:"env,omitempty"`
 	// Secret ref to be mounted inside a pod, Mount path defaults to /var/run/secrets/tas/auth
 	//+optional
+	// +listType=map
+	// +listMapKey=name
+	// +listMapKey=key
 	SecretMount []SecretKeySelector `json:"secretMount,omitempty"`
 }
 

--- a/api/v1/timestampauthority_types.go
+++ b/api/v1/timestampauthority_types.go
@@ -76,6 +76,7 @@ type CertificateChain struct {
 	RootCA *TsaCertificateAuthority `json:"rootCA,omitempty"`
 	//Intermediate Certificate Authority Config
 	//+optional
+	// +listType=atomic
 	IntermediateCA []*TsaCertificateAuthority `json:"intermediateCA,omitempty"`
 	//Leaf Certificate Authority Config
 	//+optional
@@ -155,6 +156,7 @@ type NtpMonitoringConfig struct {
 	//Period (in seconds) for polling ntp servers
 	Period int `json:"period,omitempty"`
 	//List of servers to contact. Many DNS names resolves to multiple A records.
+	// +listType=set
 	Servers []string `json:"servers,omitempty"`
 }
 

--- a/config/crd/bases/rhtas.redhat.com_rekors.yaml
+++ b/config/crd/bases/rhtas.redhat.com_rekors.yaml
@@ -995,6 +995,7 @@ spec:
                           type: string
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: set
                       name:
                         description: Name of the PVC
                         maxLength: 253
@@ -1216,6 +1217,9 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   secretMount:
                     description: Secret ref to be mounted inside a pod, Mount path
                       defaults to /var/run/secrets/tas/auth
@@ -1238,6 +1242,10 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    - key
+                    x-kubernetes-list-type: map
                 type: object
               backFillRedis:
                 description: BackFillRedis CronJob Configuration

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -3728,6 +3728,7 @@ spec:
                               type: string
                             minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                           name:
                             description: Name of the PVC
                             maxLength: 253
@@ -3952,6 +3953,9 @@ spec:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       secretMount:
                         description: Secret ref to be mounted inside a pod, Mount
                           path defaults to /var/run/secrets/tas/auth
@@ -3974,6 +3978,10 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        - key
+                        x-kubernetes-list-type: map
                     type: object
                   backFillRedis:
                     description: BackFillRedis CronJob Configuration
@@ -5606,6 +5614,9 @@ spec:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       secretMount:
                         description: Secret ref to be mounted inside a pod, Mount
                           path defaults to /var/run/secrets/tas/auth
@@ -5628,6 +5639,10 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        - key
+                        x-kubernetes-list-type: map
                     type: object
                   database:
                     description: Define your database connection
@@ -5681,6 +5696,7 @@ spec:
                               type: string
                             minItems: 1
                             type: array
+                            x-kubernetes-list-type: set
                           name:
                             description: Name of the PVC
                             maxLength: 253
@@ -5797,9 +5813,9 @@ spec:
                   maxRecvMessageSize:
                     description: MaxRecvMessageSize sets the maximum size in bytes
                       for incoming gRPC messages handled by the Trillian logserver
-                      and logsigner
+                      and logsigner.
                     format: int64
-                    minimum: 1
+                    minimum: 0
                     type: integer
                   monitoring:
                     description: Enable Monitoring for Logsigner and Logserver
@@ -9015,6 +9031,7 @@ spec:
                             items:
                               type: string
                             type: array
+                            x-kubernetes-list-type: set
                         type: object
                       enabled:
                         description: Enable or disable NTP(Network Time Protocol)
@@ -9253,6 +9270,9 @@ spec:
                               - name
                               type: object
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
                           secretMount:
                             description: Secret ref to be mounted inside a pod, Mount
                               path defaults to /var/run/secrets/tas/auth
@@ -9275,6 +9295,10 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            - key
+                            x-kubernetes-list-type: map
                         type: object
                       certificateChain:
                         description: Configuration for the Certificate Chain
@@ -9320,6 +9344,7 @@ spec:
                               - organizationName
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           leafCA:
                             description: Leaf Certificate Authority Config
                             properties:
@@ -10593,6 +10618,7 @@ spec:
                           type: string
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: set
                       name:
                         description: Name of the PVC
                         maxLength: 253

--- a/config/crd/bases/rhtas.redhat.com_timestampauthorities.yaml
+++ b/config/crd/bases/rhtas.redhat.com_timestampauthorities.yaml
@@ -1070,6 +1070,7 @@ spec:
                         items:
                           type: string
                         type: array
+                        x-kubernetes-list-type: set
                     type: object
                   enabled:
                     description: Enable or disable NTP(Network Time Protocol) Monitoring,
@@ -1306,6 +1307,9 @@ spec:
                           - name
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
                       secretMount:
                         description: Secret ref to be mounted inside a pod, Mount
                           path defaults to /var/run/secrets/tas/auth
@@ -1328,6 +1332,10 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        - key
+                        x-kubernetes-list-type: map
                     type: object
                   certificateChain:
                     description: Configuration for the Certificate Chain
@@ -1373,6 +1381,7 @@ spec:
                           - organizationName
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       leafCA:
                         description: Leaf Certificate Authority Config
                         properties:

--- a/config/crd/bases/rhtas.redhat.com_trillians.yaml
+++ b/config/crd/bases/rhtas.redhat.com_trillians.yaml
@@ -206,6 +206,9 @@ spec:
                       - name
                       type: object
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
                   secretMount:
                     description: Secret ref to be mounted inside a pod, Mount path
                       defaults to /var/run/secrets/tas/auth
@@ -228,6 +231,10 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    - key
+                    x-kubernetes-list-type: map
                 type: object
               database:
                 description: Define your database connection
@@ -281,6 +288,7 @@ spec:
                           type: string
                         minItems: 1
                         type: array
+                        x-kubernetes-list-type: set
                       name:
                         description: Name of the PVC
                         maxLength: 253
@@ -394,9 +402,9 @@ spec:
                 type: array
               maxRecvMessageSize:
                 description: MaxRecvMessageSize sets the maximum size in bytes for
-                  incoming gRPC messages handled by the Trillian logserver and logsigner
+                  incoming gRPC messages handled by the Trillian logserver and logsigner.
                 format: int64
-                minimum: 1
+                minimum: 0
                 type: integer
               monitoring:
                 description: Enable Monitoring for Logsigner and Logserver

--- a/config/crd/bases/rhtas.redhat.com_tufs.yaml
+++ b/config/crd/bases/rhtas.redhat.com_tufs.yaml
@@ -1099,6 +1099,7 @@ spec:
                       type: string
                     minItems: 1
                     type: array
+                    x-kubernetes-list-type: set
                   name:
                     description: Name of the PVC
                     maxLength: 253


### PR DESCRIPTION
## Summary
- Add `+listType=map` with `+listMapKey=name` on `Auth.Env`
- Add `+listType=map` with `+listMapKey=name,key` on `Auth.SecretMount`
- Add `+listType=set` on `Pvc.AccessModes`
- Add `+listType=atomic` on `CertificateChain.IntermediateCA`
- Add `+listType=set` on `NtpMonitoringConfig.Servers`

Additive CRD change — no conversion needed. Complements the markers already added in #2026 (Fulcio), #2036 (TUF), and #2037 (CTLog).

## Test plan
- [x] `make generate manifests` succeeds
- [x] `go build ./...` passes
- [x] Verified markers propagate to all v1 CRDs (securesigns, timestampauthorities, rekors, trillians, tufs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)