### PR TITLE
chore: initialise 1.3.7 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
   IMG: ghcr.io/securesign/secure-sign-operator:dev-${{ github.sha }}
   BUNDLE_IMG: ghcr.io/securesign/secure-sign-operator-bundle:dev-${{ github.sha }}
   CATALOG_IMG: ghcr.io/securesign/secure-sign-operator-fbc:dev-${{ github.sha }}
-  NEW_OLM_CHANNEL: rhtas-operator.v1.3.6
+  NEW_OLM_CHANNEL: rhtas-operator.v1.3.7
   OCP_VERSION: ${{ vars.OLM_INDEX_VERSION }}
 
 jobs:

--- a/.tekton/rhtas-operator-bundle-pull-request.yaml
+++ b/.tekton/rhtas-operator-bundle-pull-request.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.6"
+    value: "1.3.7"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rhtas-operator-bundle-push.yaml
+++ b/.tekton/rhtas-operator-bundle-push.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.6"
+    value: "1.3.7"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rhtas-operator-pull-request.yaml
+++ b/.tekton/rhtas-operator-pull-request.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.6"
+    value: "1.3.7"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/rhtas-operator-push.yaml
+++ b/.tekton/rhtas-operator-push.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   params:
   - name: release-version
-    value: "1.3.6"
+    value: "1.3.7"
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/Dockerfile.rhtas-operator.rh
+++ b/Dockerfile.rhtas-operator.rh
@@ -1,4 +1,4 @@
-ARG VERSION="1.3.6"
+ARG VERSION="1.3.7"
 #
 # Build the manager binary
 FROM registry.redhat.io/ubi9/go-toolset:9.8-1783931515@sha256:d8698410eb806fedd5c0ddbd08e981436051e0ed2113b8e402736e7ee578f6f4 AS builder

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.3.6
+VERSION ?= 1.3.7
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION="1.3.6"
+ARG VERSION="1.3.7"
 ARG CHANNELS="stable,stable-v1.3"
 ARG DEFAULT_CHANNEL="stable"
 ARG BUNDLE_GEN_FLAGS="-q --overwrite=false --version $VERSION --channels=$CHANNELS --default-channel=$DEFAULT_CHANNEL"

--- a/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhtas-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     operators.openshift.io/valid-subscription: '["Red Hat Trusted Artifact Signer"]'
     repository: https://github.com/securesign/secure-sign-operator
     support: Red Hat
-  name: rhtas-operator.v1.3.6
+  name: rhtas-operator.v1.3.7
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -112,4 +112,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/securesign/secure-sign-operator
-  version: 1.3.6
+  version: 1.3.7


### PR DESCRIPTION
Initialize 1.3.7 release.

Updates VERSION to `1.3.7` and sets TEST_UPGRADE_CHANNEL to `stable-v1.3`.