### PR TITLE
fix(ci): bump container-retention-policy to v3.1.0 in Pruner workflow

### DIFF
--- a/.github/workflows/pruner.yaml
+++ b/.github/workflows/pruner.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Delete old dev images
     steps:
-      - uses: snok/container-retention-policy@v3.0.0
+      - uses: snok/container-retention-policy@v3.1.0
         with:
           account: securesign
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -17,7 +17,7 @@ jobs:
           image-tags: "dev-*"
           cut-off: 3d
           dry-run: false
-      - uses: snok/container-retention-policy@v3.0.0
+      - uses: snok/container-retention-policy@v3.1.0
         with:
           account: securesign
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -25,7 +25,7 @@ jobs:
           image-tags: "dev-*"
           cut-off: 3d
           dry-run: false
-      - uses: snok/container-retention-policy@v3.0.0
+      - uses: snok/container-retention-policy@v3.1.0
         with:
           account: securesign
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The [Pruner workflow](https://github.com/securesign/secure-sign-operator/actions/workflows/pruner.yaml) has failed every scheduled run since 2026-07-09 with `error: invalid value '***' for '--token <TOKEN>'`.
- GitHub rolled out a new JWT-based format for `GITHUB_TOKEN`/installation tokens in April 2026 ([changelog](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/)). `snok/container-retention-policy@v3.0.0` validates tokens with a strict regex that only matches the old fixed-length format, so it rejects the new token — this is [snok/container-retention-policy#129](https://github.com/snok/container-retention-policy/issues/129), fixed in `v3.1.0`.
- Bumped all three `snok/container-retention-policy` steps from `v3.0.0` to `v3.1.0`. Action inputs/outputs are unchanged between versions, so this is a drop-in fix.

## Test plan
- [ ] Confirm the next scheduled/dispatched Pruner run succeeds