### PR TITLE
feat: make CTlog log prefix configurable

### DIFF
--- a/api/v1/ctlog_defaults.go
+++ b/api/v1/ctlog_defaults.go
@@ -6,5 +6,6 @@ func (s *CTlogSpec) SetDefaults() {
 	s.PodRequirements.SetDefaults()
 	s.Monitoring.SetDefaults()
 	s.Trillian.SetDefaults()
+	setDefault(&s.Prefix, "trusted-artifact-signer")
 	setDefault(&s.MaxCertChainSize, ptr.To(int64(153600)))
 }

--- a/api/v1/ctlog_types.go
+++ b/api/v1/ctlog_types.go
@@ -68,6 +68,12 @@ type CTlogSpec struct {
 	//+optional
 	ServerConfigRef *LocalObjectReference `json:"serverConfigRef,omitempty"`
 
+	// Prefix is the name of the log. The prefix cannot be empty and can
+	// contain "/" path separator characters to define global override handler prefix.
+	//+kubebuilder:validation:Pattern:="^[a-z0-9]([-a-z0-9/]*[a-z0-9])?$"
+	//+optional
+	Prefix string `json:"prefix,omitempty"`
+
 	// Configuration for enabling TLS (Transport Layer Security) encryption for manged service.
 	//+optional
 	TLS TLS `json:"tls,omitempty"`

--- a/api/v1alpha1/ctlog_conversion.go
+++ b/api/v1alpha1/ctlog_conversion.go
@@ -24,6 +24,7 @@ func (src *CTlog) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.TrustedCA = restored.Spec.TrustedCA
 	dst.Status.PublicKey = restored.Status.PublicKey
 	dst.Spec.Monitoring.ServiceMonitor = restored.Spec.Monitoring.ServiceMonitor
+	dst.Spec.Prefix = restored.Spec.Prefix
 	return nil
 }
 

--- a/api/v1alpha1/securesign_conversion.go
+++ b/api/v1alpha1/securesign_conversion.go
@@ -20,6 +20,7 @@ func (src *Securesign) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Ctlog.ImagePullSecrets = restored.Spec.Ctlog.ImagePullSecrets
 	dst.Spec.Ctlog.TrustedCA = restored.Spec.Ctlog.TrustedCA
 	dst.Spec.Ctlog.Monitoring.ServiceMonitor = restored.Spec.Ctlog.Monitoring.ServiceMonitor
+	dst.Spec.Ctlog.Prefix = restored.Spec.Ctlog.Prefix
 	dst.Spec.Rekor.ImagePullSecrets = restored.Spec.Rekor.ImagePullSecrets
 	dst.Spec.Rekor.Monitoring.ServiceMonitor = restored.Spec.Rekor.Monitoring.ServiceMonitor
 	dst.Spec.Trillian.ImagePullSecrets = restored.Spec.Trillian.ImagePullSecrets

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1024,6 +1024,7 @@ func autoConvert_v1_CTlogSpec_To_v1alpha1_CTlogSpec(in *v1.CTlogSpec, out *CTlog
 		return err
 	}
 	out.ServerConfigRef = (*LocalObjectReference)(unsafe.Pointer(in.ServerConfigRef))
+	// WARNING: in.Prefix requires manual conversion: does not exist in peer-type
 	if err := Convert_v1_TLS_To_v1alpha1_TLS(&in.TLS, &out.TLS, s); err != nil {
 		return err
 	}

--- a/config/crd/bases/rhtas.redhat.com_ctlogs.yaml
+++ b/config/crd/bases/rhtas.redhat.com_ctlogs.yaml
@@ -1046,6 +1046,12 @@ spec:
                   rule: '!has(self.serviceMonitor) || !has(self.serviceMonitor.enabled)
                     || !self.serviceMonitor.enabled || (has(self.metrics) && has(self.metrics.enabled)
                     && self.metrics.enabled)'
+              prefix:
+                description: |-
+                  Prefix is the name of the log. The prefix cannot be empty and can
+                  contain "/" path separator characters to define global override handler prefix.
+                pattern: ^[a-z0-9]([-a-z0-9/]*[a-z0-9])?$
+                type: string
               privateKeyPasswordRef:
                 description: |-
                   Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -1068,6 +1068,12 @@ spec:
                       rule: '!has(self.serviceMonitor) || !has(self.serviceMonitor.enabled)
                         || !self.serviceMonitor.enabled || (has(self.metrics) && has(self.metrics.enabled)
                         && self.metrics.enabled)'
+                  prefix:
+                    description: |-
+                      Prefix is the name of the log. The prefix cannot be empty and can
+                      contain "/" path separator characters to define global override handler prefix.
+                    pattern: ^[a-z0-9]([-a-z0-9/]*[a-z0-9])?$
+                    type: string
                   privateKeyPasswordRef:
                     description: |-
                       Deprecated: Legacy PEM encryption as specified in RFC 1423 is insecure by design

--- a/internal/controller/ctlog/actions/monitor/statefulset.go
+++ b/internal/controller/ctlog/actions/monitor/statefulset.go
@@ -34,7 +34,6 @@ const (
 	storageVolumeName = "monitor-storage"
 	tufRepoVolumeName = "tuf-repository"
 	mountPath         = "/data"
-	ctlogLogPrefix    = "trusted-artifact-signer"
 )
 
 func NewStatefulSetAction() action.Action[*rhtasv1.CTlog] {
@@ -162,7 +161,7 @@ func (i statefulSetAction) ensureMonitorStatefulSet(instance *rhtasv1.CTlog, sa 
 			"-c",
 			fmt.Sprintf(
 				`/ctlog_monitor --file=%s/checkpoint_log.txt --once=false --interval=%s --url=%s/%s --tuf-repository=%s --tuf-root-path="%s/root.json"`,
-				mountPath, interval.String(), ctlogServerHost, ctlogLogPrefix, tufServerHost, mountPath),
+				mountPath, interval.String(), ctlogServerHost, instance.Spec.Prefix, tufServerHost, mountPath),
 		}
 
 		container.Ports = []core.ContainerPort{

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -40,6 +40,7 @@ var serverConfigAnnotations = []string{
 	labels.LabelNamespace + "/trillianUrl",
 	labels.LabelNamespace + "/rootCertificatesHash",
 	labels.LabelNamespace + "/privateKeyRef",
+	labels.LabelNamespace + "/logPrefix",
 }
 
 func NewServerConfigAction() action.Action[*rhtasv1.CTlog] {
@@ -151,7 +152,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.CTlog) *acti
 	}
 
 	var cfg map[string][]byte
-	if cfg, err = ctlogUtils.CreateCtlogConfig(trillianUrl, *instance.Status.TreeID, rootCerts, certConfig); err != nil {
+	if cfg, err = ctlogUtils.CreateCtlogConfig(trillianUrl, *instance.Status.TreeID, rootCerts, certConfig, instance.Spec.Prefix); err != nil {
 		return i.Error(ctx, fmt.Errorf("could not create CTLog configuration: %w", err), instance, metav1.Condition{
 			Type:               ConfigCondition,
 			Status:             metav1.ConditionFalse,
@@ -363,6 +364,10 @@ func (i serverConfig) configMatchingAnnotations(instance *rhtasv1.CTlog, trillia
 
 	if instance.Status.PrivateKeyRef != nil {
 		annotations[labels.LabelNamespace+"/privateKeyRef"] = fmt.Sprintf("%s/%s", instance.Status.PrivateKeyRef.Name, instance.Status.PrivateKeyRef.Key)
+	}
+
+	if instance.Spec.Prefix != "" {
+		annotations[labels.LabelNamespace+"/logPrefix"] = instance.Spec.Prefix
 	}
 
 	return annotations

--- a/internal/controller/ctlog/actions/server_config_test.go
+++ b/internal/controller/ctlog/actions/server_config_test.go
@@ -531,6 +531,7 @@ func TestServerConfig_Update(t *testing.T) {
 			},
 			Spec: rhtasv1.CTlogSpec{
 				Trillian: rhtasv1.TrillianService{Port: ptr.To(int32(80))},
+				Prefix:   "trusted-artifact-signer",
 			},
 			Status: rhtasv1.CTlogStatus{
 				ServerConfigRef: &rhtasv1.LocalObjectReference{Name: "existing-config"},
@@ -575,6 +576,7 @@ func TestServerConfig_Update(t *testing.T) {
 			"rhtas.redhat.com/trillianUrl":          "trillian-logserver.default.svc:80",
 			"rhtas.redhat.com/rootCertificatesHash": hex.EncodeToString(h[:]),
 			"rhtas.redhat.com/privateKeyRef":        "secret/private",
+			"rhtas.redhat.com/logPrefix":            "trusted-artifact-signer",
 		}
 	}
 
@@ -585,6 +587,7 @@ func TestServerConfig_Update(t *testing.T) {
 				"trillian-logserver.default.svc:80", 123456,
 				[]ctlogUtils.RootCertificate{cert},
 				&ctlogUtils.KeyConfig{PrivateKey: privateKey, PublicKey: publicKey, PrivateKeyPass: []byte("secure")},
+				"trusted-artifact-signer",
 			)),
 		}
 	}
@@ -627,6 +630,7 @@ func TestServerConfig_Update(t *testing.T) {
 								"trillian-logserver.default.svc:80", 654321,
 								[]ctlogUtils.RootCertificate{cert},
 								&ctlogUtils.KeyConfig{PrivateKey: privateKey, PublicKey: publicKey, PrivateKeyPass: []byte("secure")},
+								"trusted-artifact-signer",
 							)),
 						},
 					},
@@ -876,6 +880,7 @@ func TestServerConfig_Update(t *testing.T) {
 								"trillian-logserver.custom.svc:80", 9999999,
 								[]ctlogUtils.RootCertificate{cert},
 								&ctlogUtils.KeyConfig{PrivateKey: privateKey, PublicKey: publicKey, PrivateKeyPass: []byte("secure")},
+								"trusted-artifact-signer",
 							)),
 						},
 					},
@@ -917,6 +922,7 @@ func TestServerConfig_Update(t *testing.T) {
 								"trillian-logserver.custom.svc:80", 9999999,
 								[]ctlogUtils.RootCertificate{cert},
 								&ctlogUtils.KeyConfig{PrivateKey: privateKey, PublicKey: publicKey, PrivateKeyPass: []byte("secure")},
+								"trusted-artifact-signer",
 							)),
 						},
 					},
@@ -960,6 +966,7 @@ func TestServerConfig_Update(t *testing.T) {
 								"trillian-logserver.custom.svc:80", 9999999,
 								[]ctlogUtils.RootCertificate{cert},
 								&ctlogUtils.KeyConfig{PrivateKey: privateKey, PublicKey: publicKey, PrivateKeyPass: []byte("secure")},
+								"trusted-artifact-signer",
 							)),
 						},
 					},
@@ -1011,6 +1018,7 @@ func TestServerConfig_Prerequisites(t *testing.T) {
 			},
 			Spec: rhtasv1.CTlogSpec{
 				Trillian: rhtasv1.TrillianService{Port: ptr.To(int32(80))},
+				Prefix:   "trusted-artifact-signer",
 			},
 			Status: rhtasv1.CTlogStatus{
 				ServerConfigRef: &rhtasv1.LocalObjectReference{Name: "existing-config"},

--- a/internal/controller/ctlog/utils/ctlog_config.go
+++ b/internal/controller/ctlog/utils/ctlog_config.go
@@ -143,10 +143,10 @@ func createConfigWithKeys(certConfig *KeyConfig) *Config {
 	}
 }
 
-func CreateCtlogConfig(trillianUrl string, treeID int64, rootCerts []RootCertificate, keyConfig *KeyConfig) (map[string][]byte, error) {
+func CreateCtlogConfig(trillianUrl string, treeID int64, rootCerts []RootCertificate, keyConfig *KeyConfig, logPrefix string) (map[string][]byte, error) {
 	ctlogConfig := createConfigWithKeys(keyConfig)
 	ctlogConfig.LogID = treeID
-	ctlogConfig.LogPrefix = "trusted-artifact-signer"
+	ctlogConfig.LogPrefix = logPrefix
 	ctlogConfig.TrillianServerAddr = trillianUrl
 
 	for _, cert := range rootCerts {


### PR DESCRIPTION
## Summary
- Adds `prefix` field to `CTlogSpec` with default `"trusted-artifact-signer"`, replacing the hardcoded value in server config generation and monitor statefulset
- Wires the field through `CreateCtlogConfig`, conversion roundtrip (both standalone CTlog and embedded Securesign), and CRD manifests

## Test plan
- [x] All CTlog controller tests pass
- [x] CTlog conversion roundtrip fuzz test passes (hub-spoke-hub)
- [x] Securesign conversion roundtrip fuzz test passes
- [x] Verified removing the conversion restore line causes test failure
- [ ] Deploy on cluster and verify CTlog starts with default prefix
- [ ] Deploy with custom prefix and verify it propagates to server config and monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)