### PR TITLE
test: replace context.TODO() with proper context in tests

### DIFF
--- a/internal/action/generateSigner/action_test.go
+++ b/internal/action/generateSigner/action_test.go
@@ -190,7 +190,7 @@ func TestCanHandle(t *testing.T) {
 				testCondition, testNameFormat, testComponent, testDeployment,
 				testWrapper("", tt.isEnabled, nil),
 			))
-			g.Expect(a.CanHandle(context.TODO(), tt.instance)).To(Equal(tt.canHandle))
+			g.Expect(a.CanHandle(t.Context(), tt.instance)).To(Equal(tt.canHandle))
 		})
 	}
 }
@@ -208,7 +208,7 @@ func TestHandle(t *testing.T) {
 		errSubstr  string
 		wantErr    error
 		requeues   bool
-		verify     func(Gomega, *rhtasv1.Rekor, client.Client)
+		verify     func(context.Context, Gomega, *rhtasv1.Rekor, client.Client)
 	}
 	tests := []struct {
 		name string
@@ -222,13 +222,13 @@ func TestHandle(t *testing.T) {
 				action:   testActionSetup{},
 			},
 			want: want{
-				verify: func(g Gomega, instance *rhtasv1.Rekor, cli client.Client) {
+				verify: func(ctx context.Context, g Gomega, instance *rhtasv1.Rekor, cli client.Client) {
 					g.Expect(instance.Status.Signer.KeyRef).ToNot(BeNil())
 					g.Expect(instance.Status.Signer.KeyRef.Name).To(Equal(secretName()))
 					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, testCondition)).To(BeTrue())
 
 					secret := &corev1.Secret{}
-					g.Expect(cli.Get(context.TODO(), client.ObjectKeyFromObject(&corev1.Secret{
+					g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Name: secretName(), Namespace: testNamespace},
 					}), secret)).To(Succeed())
 					g.Expect(secret.Immutable).ToNot(BeNil())
@@ -245,12 +245,12 @@ func TestHandle(t *testing.T) {
 				action:   testActionSetup{resolvedName: "user-secret"},
 			},
 			want: want{
-				verify: func(g Gomega, instance *rhtasv1.Rekor, cli client.Client) {
+				verify: func(ctx context.Context, g Gomega, instance *rhtasv1.Rekor, cli client.Client) {
 					g.Expect(instance.Status.Signer.KeyRef.Name).To(Equal("user-secret"))
 					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, testCondition)).To(BeTrue())
 
 					secret := &corev1.Secret{}
-					err := cli.Get(context.TODO(), client.ObjectKeyFromObject(&corev1.Secret{
+					err := cli.Get(ctx, client.ObjectKeyFromObject(&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{Name: secretName(), Namespace: testNamespace},
 					}), secret)
 					g.Expect(err).To(HaveOccurred())
@@ -267,7 +267,7 @@ func TestHandle(t *testing.T) {
 			want: want{
 				isError: true,
 				wantErr: ErrSecretNotFound,
-				verify: func(g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
 					cc := meta.FindStatusCondition(instance.Status.Conditions, testCondition)
 					g.Expect(cc).ToNot(BeNil())
 					g.Expect(cc.Status).To(Equal(metav1.ConditionFalse))
@@ -287,7 +287,7 @@ func TestHandle(t *testing.T) {
 				action:   testActionSetup{},
 			},
 			want: want{
-				verify: func(g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
 					g.Expect(instance.Status.Signer.KeyRef.Name).To(Equal(secretName()))
 					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, testCondition)).To(BeTrue())
 				},
@@ -301,7 +301,7 @@ func TestHandle(t *testing.T) {
 				action:   testActionSetup{},
 			},
 			want: want{
-				verify: func(g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
 					g.Expect(instance.Status.Signer.KeyRef.Name).To(Equal(secretName()))
 				},
 			},
@@ -361,7 +361,7 @@ func TestHandle(t *testing.T) {
 				intercept: cacheLagInterceptor(),
 			},
 			want: want{
-				verify: func(g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
 					g.Expect(instance.Status.Signer.KeyRef.Name).To(Equal(secretName()))
 					g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, testCondition)).To(BeTrue())
 				},
@@ -381,7 +381,7 @@ func TestHandle(t *testing.T) {
 				action: testActionSetup{},
 			},
 			want: want{
-				verify: func(g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.Rekor, _ client.Client) {
 					g.Expect(instance.Status.Signer.KeyRef.Name).To(Equal(secretName()))
 				},
 			},
@@ -391,7 +391,7 @@ func TestHandle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := tt.env.instance()
 
 			builder := testAction.FakeClientBuilder().
@@ -441,7 +441,7 @@ func TestHandle(t *testing.T) {
 			}
 
 			if tt.want.verify != nil {
-				tt.want.verify(g, instance, cli)
+				tt.want.verify(ctx, g, instance, cli)
 			}
 		})
 	}

--- a/internal/action/rbac/action_test.go
+++ b/internal/action/rbac/action_test.go
@@ -659,6 +659,7 @@ func testRunner(pre pre, want want, handleFn handleFn) func(t *testing.T) {
 }
 
 func TestRbac_CanHandle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		reason    state.State
@@ -711,6 +712,7 @@ func TestRbac_CanHandle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := testAction.FakeClientBuilder().Build()
 			a := testAction.PrepareAction(c, NewAction[*rhtasv1.Rekor]("component", "test", tt.opts...))
 			instance := rhtasv1.Rekor{}
@@ -721,7 +723,7 @@ func TestRbac_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})

--- a/internal/action/tree/action_test.go
+++ b/internal/action/tree/action_test.go
@@ -612,6 +612,7 @@ func testRunner(pre pre, want want, handleFn handleFn) func(t *testing.T) {
 }
 
 func TestResolveTree_CanHandle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		condition    metav1.ConditionStatus
@@ -658,6 +659,7 @@ func TestResolveTree_CanHandle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := testAction.FakeClientBuilder().Build()
 			a := testAction.PrepareAction(c, NewResolveTreeAction("test", defaultWrapper))
 			instance := rhtasv1.Rekor{
@@ -675,7 +677,7 @@ func TestResolveTree_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})

--- a/internal/controller/ctlog/actions/handle_fulcio_root_test.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root_test.go
@@ -46,6 +46,7 @@ func readyFulcio() *rhtasv1.Fulcio {
 }
 
 func TestCertCan_Handle(t *testing.T) {
+	t.Parallel()
 
 	type env struct {
 		phase        state.State
@@ -191,6 +192,7 @@ func TestCertCan_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.env.objects...).
@@ -212,13 +214,14 @@ func TestCertCan_Handle(t *testing.T) {
 				Reason: tt.env.phase.String(),
 			})
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.want.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.want.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.want.canHandle)
 			}
 		})
 	}
 }
 func TestCert_Handle(t *testing.T) {
+	t.Parallel()
 
 	type env struct {
 		certificates []rhtasv1.SecretKeySelector
@@ -227,7 +230,7 @@ func TestCert_Handle(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, rhtasv1.CTlogStatus, client.WithWatch, <-chan watch.Event)
+		verify func(context.Context, Gomega, rhtasv1.CTlogStatus, client.WithWatch, <-chan watch.Event)
 	}
 	tests := []struct {
 		name string
@@ -249,7 +252,7 @@ func TestCert_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
 					g.Expect(status.RootCertificates).To(HaveLen(1))
@@ -257,7 +260,7 @@ func TestCert_Handle(t *testing.T) {
 					g.Expect(status.RootCertificates[0].Key).To(Equal(fulcioRootCertKey))
 
 					secret := &v1.Secret{}
-					g.Expect(cli.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: fmt.Sprintf(fulcioRootSecretFormat, "instance")}, secret)).To(Succeed())
+					g.Expect(cli.Get(ctx, client.ObjectKey{Namespace: "default", Name: fmt.Sprintf(fulcioRootSecretFormat, "instance")}, secret)).To(Succeed())
 					g.Expect(secret.Data).To(HaveKeyWithValue(fulcioRootCertKey, []byte(testCert)))
 
 					g.Expect(meta.IsStatusConditionTrue(status.Conditions, CertCondition)).To(BeTrue())
@@ -276,7 +279,7 @@ func TestCert_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.RequeueAfter(5 * time.Second),
-				verify: func(g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
 					g.Expect(status.RootCertificates).To(BeEmpty())
@@ -323,7 +326,7 @@ func TestCert_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
 					g.Expect(status.RootCertificates).Should(HaveLen(2))
@@ -363,7 +366,7 @@ func TestCert_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).Should(BeNil())
 
 					g.Expect(status.RootCertificates).Should(HaveLen(1))
@@ -409,7 +412,7 @@ func TestCert_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(status.RootCertificates).Should(HaveLen(1))
 					g.Expect(status.RootCertificates[0].Key).Should(Equal("key"))
 					g.Expect(status.RootCertificates[0].Name).Should(Equal("my-secret"))
@@ -448,9 +451,9 @@ func TestCert_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					secret := &v1.Secret{}
-					g.Expect(cli.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: fmt.Sprintf(fulcioRootSecretFormat, "instance")}, secret)).To(Succeed())
+					g.Expect(cli.Get(ctx, client.ObjectKey{Namespace: "default", Name: fmt.Sprintf(fulcioRootSecretFormat, "instance")}, secret)).To(Succeed())
 					g.Expect(secret.Data[fulcioRootCertKey]).To(Equal([]byte(testCert)))
 
 					g.Expect(meta.IsStatusConditionTrue(status.Conditions, CertCondition)).To(BeTrue())
@@ -486,7 +489,7 @@ func TestCert_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.CTlogStatus, cli client.WithWatch, configWatch <-chan watch.Event) {
 					g.Expect(meta.FindStatusCondition(status.Conditions, ConfigCondition)).To(BeNil())
 				},
 			},
@@ -494,8 +497,9 @@ func TestCert_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1.CTlog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "instance",
@@ -529,7 +533,7 @@ func TestCert_Handle(t *testing.T) {
 			if tt.want.verify != nil {
 				find := &rhtasv1.CTlog{}
 				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(instance), find)).To(Succeed())
-				tt.want.verify(g, find.Status, c, configSecretWatch.ResultChan())
+				tt.want.verify(ctx, g, find.Status, c, configSecretWatch.ResultChan())
 			}
 		})
 	}

--- a/internal/controller/ctlog/actions/resolve_pub_key_test.go
+++ b/internal/controller/ctlog/actions/resolve_pub_key_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -20,26 +19,29 @@ import (
 const testCTlogPublicKey = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZFt6NEqMxaeU76lnlYzFUNjFQGHq\nNF46BPCTlP/FgfMZjN608cDXf3LM5hTbvNyCEabE+4MbOcEMXhDQUlYFvA==\n-----END PUBLIC KEY-----"
 
 func TestCTlogResolvePubKey_CanHandle(t *testing.T) {
+	t.Parallel()
 	a := NewResolvePubKeyAction()
 	t.Run("not ready", func(t *testing.T) {
+		t.Parallel()
 		instance := &rhtasv1.CTlog{}
-		if a.CanHandle(context.TODO(), instance) {
+		if a.CanHandle(t.Context(), instance) {
 			t.Error("expected false when no condition set")
 		}
 	})
 	t.Run("initialize phase", func(t *testing.T) {
+		t.Parallel()
 		instance := &rhtasv1.CTlog{}
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Initialize.String(),
 		})
-		if !a.CanHandle(context.TODO(), instance) {
+		if !a.CanHandle(t.Context(), instance) {
 			t.Error("expected true in Initialize phase")
 		}
 	})
 }
 
 func TestCTlogResolvePubKey_Handle(t *testing.T) {
-	g := NewWithT(t)
+	t.Parallel()
 	type want struct {
 		result    *action.Result
 		publicKey string
@@ -86,6 +88,8 @@ func TestCTlogResolvePubKey_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
 			ctx := t.Context()
 
 			instance := &rhtasv1.CTlog{
@@ -121,6 +125,7 @@ func TestCTlogResolvePubKey_Handle(t *testing.T) {
 }
 
 func TestCTlogResolvePubKey_Handle_SecretReadError(t *testing.T) {
+	t.Parallel()
 	g := NewWithT(t)
 	ctx := t.Context()
 

--- a/internal/controller/ctlog/actions/server_config_test.go
+++ b/internal/controller/ctlog/actions/server_config_test.go
@@ -42,6 +42,7 @@ var (
 )
 
 func TestServerConfig_CanHandle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                  string
 		status                metav1.ConditionStatus
@@ -131,6 +132,7 @@ func TestServerConfig_CanHandle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := testAction.FakeClientBuilder().Build()
 			a := testAction.PrepareAction(c, NewServerConfigAction())
 			instance := rhtasv1.CTlog{
@@ -154,7 +156,7 @@ func TestServerConfig_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -162,6 +164,7 @@ func TestServerConfig_CanHandle(t *testing.T) {
 }
 
 func TestServerConfig_Handle(t *testing.T) {
+	t.Parallel()
 	g := NewWithT(t)
 	labels := labels.ForResource(ComponentName, DeploymentName, "ctlog", serverConfigResourceName)
 
@@ -172,7 +175,7 @@ func TestServerConfig_Handle(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, *rhtasv1.CTlog, client.WithWatch)
+		verify func(context.Context, Gomega, *rhtasv1.CTlog, client.WithWatch)
 	}
 	tests := []struct {
 		name string
@@ -202,7 +205,7 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(Equal("config"))
 				},
@@ -240,7 +243,7 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
 				},
@@ -269,7 +272,7 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(Equal("new_config"))
 				},
@@ -308,7 +311,7 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.RequeueAfter(5 * time.Second),
-				verify: func(g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(BeNil())
 					g.Expect(instance.Status.Conditions).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 						"Message": ContainSubstring("Waiting for Fulcio root certificate: not-existing/cert"),
@@ -350,7 +353,7 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.RequeueAfter(5 * time.Second),
-				verify: func(g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(BeNil())
 					g.Expect(instance.Status.Conditions).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 						"Message": ContainSubstring("Waiting for Ctlog private key secret"),
@@ -401,10 +404,10 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(Not(BeNil()))
 
-					g.Expect(k8sErrors.IsNotFound(cli.Get(context.TODO(), client.ObjectKey{Name: "config", Namespace: "default"}, &v1.Secret{}))).To(BeTrue())
+					g.Expect(k8sErrors.IsNotFound(cli.Get(ctx, client.ObjectKey{Name: "config", Namespace: "default"}, &v1.Secret{}))).To(BeTrue())
 
 					secret, err := kubernetes.GetSecret(cli, "default", instance.Status.ServerConfigRef.Name)
 					g.Expect(err).ShouldNot(HaveOccurred())
@@ -463,7 +466,7 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(Not(BeNil()))
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(Not(Equal("config")))
 
@@ -479,7 +482,7 @@ func TestServerConfig_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1.CTlog{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "ctlog",
@@ -507,13 +510,14 @@ func TestServerConfig_Handle(t *testing.T) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.want.result)
 			}
 			if tt.want.verify != nil {
-				tt.want.verify(g, instance, c)
+				tt.want.verify(ctx, g, instance, c)
 			}
 		})
 	}
 }
 
 func TestServerConfig_Update(t *testing.T) {
+	t.Parallel()
 	g := NewWithT(t)
 
 	// -- local helpers scoped to this test function --
@@ -977,7 +981,7 @@ func TestServerConfig_Update(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			ctx := t.Context()
 			c := testAction.FakeClientBuilder().
 				WithObjects(&tt.env.instance).
 				WithStatusSubresource(&tt.env.instance).
@@ -997,6 +1001,7 @@ func TestServerConfig_Update(t *testing.T) {
 }
 
 func TestServerConfig_Prerequisites(t *testing.T) {
+	t.Parallel()
 	newBaseInstance := func() rhtasv1.CTlog {
 		return rhtasv1.CTlog{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1131,8 +1136,9 @@ func TestServerConfig_Prerequisites(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := tt.setup()
 
 			// Ensure ConfigCondition exists (required by CanHandle)

--- a/internal/controller/ctlog/ctlog_controller_test.go
+++ b/internal/controller/ctlog/ctlog_controller_test.go
@@ -74,7 +74,7 @@ var _ = Describe("CTlog controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/controller/ctlog/ctlog_hot_update_test.go
+++ b/internal/controller/ctlog/ctlog_hot_update_test.go
@@ -81,7 +81,7 @@ var _ = Describe("CTlog update test", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 3*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/controller/fulcio/actions/ingress_test.go
+++ b/internal/controller/fulcio/actions/ingress_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,7 +13,8 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -43,6 +43,7 @@ func TestIngress_CanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 			instance := rhtasv1.Fulcio{
 				Spec: rhtasv1.FulcioSpec{

--- a/internal/controller/fulcio/actions/resolve_pub_key_test.go
+++ b/internal/controller/fulcio/actions/resolve_pub_key_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	_ "embed"
 	"net/http"
 	"strings"
@@ -43,19 +42,22 @@ var testTrustBundleJSON = `{
 var expectedRootCert = strings.TrimSpace(testSigningCertPEM) + "\n" + strings.TrimSpace(testRootCertPEM)
 
 func TestFulcioResolvePubKey_CanHandle(t *testing.T) {
+	t.Parallel()
 	a := NewResolvePubKeyAction()
 	t.Run("not ready", func(t *testing.T) {
+		t.Parallel()
 		instance := &rhtasv1.Fulcio{}
-		if a.CanHandle(context.TODO(), instance) {
+		if a.CanHandle(t.Context(), instance) {
 			t.Error("expected false when no condition set")
 		}
 	})
 	t.Run("initialize phase", func(t *testing.T) {
+		t.Parallel()
 		instance := &rhtasv1.Fulcio{}
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Initialize.String(),
 		})
-		if !a.CanHandle(context.TODO(), instance) {
+		if !a.CanHandle(t.Context(), instance) {
 			t.Error("expected true in Initialize phase")
 		}
 	})

--- a/internal/controller/fulcio/actions/server_config_test.go
+++ b/internal/controller/fulcio/actions/server_config_test.go
@@ -30,6 +30,7 @@ var (
 )
 
 func TestServerConfig_CanHandle(t *testing.T) {
+	t.Parallel()
 	type env struct {
 		objects []client.Object
 	}
@@ -137,6 +138,7 @@ func TestServerConfig_CanHandle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.env.objects...).
@@ -162,7 +164,7 @@ func TestServerConfig_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -170,6 +172,7 @@ func TestServerConfig_CanHandle(t *testing.T) {
 }
 
 func TestConfig_Handle(t *testing.T) {
+	t.Parallel()
 	labels := labels.ForResource(ComponentName, DeploymentName, "fulcio", configResourceLabel)
 
 	type env struct {
@@ -179,7 +182,7 @@ func TestConfig_Handle(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, rhtasv1.FulcioStatus, client.WithWatch, <-chan watch.Event)
+		verify func(context.Context, Gomega, rhtasv1.FulcioStatus, client.WithWatch, <-chan watch.Event)
 	}
 	tests := []struct {
 		name string
@@ -207,7 +210,7 @@ func TestConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).Should(ContainSubstring("fulcio-config-"))
@@ -250,7 +253,7 @@ func TestConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).Should(Not(Equal("config")))
 
@@ -261,7 +264,7 @@ func TestConfig_Handle(t *testing.T) {
 							WithTransform(getEventType, Equal(watch.Deleted))),
 						)
 					}
-					cm, err := kubernetes.GetConfigMap(context.TODO(), cli, "default", status.ServerConfigRef.Name)
+					cm, err := kubernetes.GetConfigMap(ctx, cli, "default", status.ServerConfigRef.Name)
 					g.Expect(err).To(Not(HaveOccurred()))
 					g.Expect(cm.Data[serverConfigName]).To(Equal(string(configYaml)))
 				},
@@ -301,7 +304,7 @@ func TestConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).Should(Equal("config"))
 
@@ -343,7 +346,7 @@ func TestConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).Should(Not(Equal("config")))
 
@@ -354,7 +357,7 @@ func TestConfig_Handle(t *testing.T) {
 							WithTransform(getEventType, Equal(watch.Deleted)),
 						))
 					}
-					cm, err := kubernetes.GetConfigMap(context.TODO(), cli, "default", status.ServerConfigRef.Name)
+					cm, err := kubernetes.GetConfigMap(ctx, cli, "default", status.ServerConfigRef.Name)
 					g.Expect(err).To(Not(HaveOccurred()))
 					g.Expect(cm.Data[serverConfigName]).To(ContainSubstring("clientIdUpdated"))
 				},
@@ -404,7 +407,7 @@ func TestConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).ShouldNot(Equal("config"))
 
@@ -456,7 +459,7 @@ func TestConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(_ context.Context, g Gomega, status rhtasv1.FulcioStatus, cli client.WithWatch, events <-chan watch.Event) {
 					g.Expect(status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(status.ServerConfigRef.Name).Should(Not(Equal("config")))
 
@@ -471,8 +474,9 @@ func TestConfig_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1.Fulcio{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "fulcio",
@@ -502,7 +506,7 @@ func TestConfig_Handle(t *testing.T) {
 			if tt.want.verify != nil {
 				find := &rhtasv1.Fulcio{}
 				g.Expect(c.Get(ctx, client.ObjectKeyFromObject(instance), find)).To(Succeed())
-				tt.want.verify(g, find.Status, c, watchCm.ResultChan())
+				tt.want.verify(ctx, g, find.Status, c, watchCm.ResultChan())
 			}
 		})
 	}

--- a/internal/controller/fulcio/fulcio_controller_test.go
+++ b/internal/controller/fulcio/fulcio_controller_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Fulcio controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/controller/fulcio/fulcio_hot_update_test.go
+++ b/internal/controller/fulcio/fulcio_hot_update_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Fulcio hot update", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/controller/rekor/actions/server/ingress_test.go
+++ b/internal/controller/rekor/actions/server/ingress_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,7 +13,8 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -43,6 +43,7 @@ func TestIngress_CanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 			instance := rhtasv1.Rekor{
 				Spec: rhtasv1.RekorSpec{

--- a/internal/controller/rekor/actions/server/resolve_pub_key_test.go
+++ b/internal/controller/rekor/actions/server/resolve_pub_key_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"reflect"
@@ -26,6 +25,7 @@ import (
 var testPublicKey = "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEy5wMSNagtqLsSF+zf8gBVHm2VThGP69D\ngWyhhIm/BkemPBoD/BNq+/yvD2IjsV4unLp5Lcpv4UAGAPJHL/wm+tHD1nS4QKo/\nsXJ8Ezy1K+bM5DUEilcu4hGgQ7+RCG/H\n-----END PUBLIC KEY-----"
 
 func TestResolvePubKey_CanHandle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		reason    string
@@ -60,6 +60,7 @@ func TestResolvePubKey_CanHandle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			a := NewResolvePubKeyAction()
 			instance := rhtasv1.Rekor{
 				Status: rhtasv1.RekorStatus{PublicKey: tt.publicKey},
@@ -71,7 +72,7 @@ func TestResolvePubKey_CanHandle(t *testing.T) {
 					Reason: tt.reason,
 				})
 			}
-			if got := a.CanHandle(context.TODO(), &instance); got != tt.canHandle {
+			if got := a.CanHandle(t.Context(), &instance); got != tt.canHandle {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})

--- a/internal/controller/rekor/actions/server/sharding_config_test.go
+++ b/internal/controller/rekor/actions/server/sharding_config_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestShardingConfig_CanHandle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		phase     state.State
@@ -62,6 +63,7 @@ func TestShardingConfig_CanHandle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := testAction.FakeClientBuilder().Build()
 			a := testAction.PrepareAction(c, NewShardingConfigAction())
 			instance := rhtasv1.Rekor{
@@ -81,7 +83,7 @@ func TestShardingConfig_CanHandle(t *testing.T) {
 				})
 			}
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -101,7 +103,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, client.WithWatch, <-chan watch.Event)
+		verify func(context.Context, Gomega, client.WithWatch, <-chan watch.Event)
 	}
 	tests := []struct {
 		name string
@@ -117,14 +119,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKeyWithValue(shardingConfigName, ""))
 
 					g.Expect(events).To(HaveLen(1))
@@ -156,14 +158,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKey(shardingConfigName))
 
 					rlr := make([]rhtasv1.RekorLogRange, 0)
@@ -214,15 +216,15 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 					g.Expect(r.Status.ServerConfigRef.Name).ShouldNot(Equal(cmName + "old"))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKey(shardingConfigName))
 
 					rlr := make([]rhtasv1.RekorLogRange, 0)
@@ -269,15 +271,15 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 					g.Expect(r.Status.ServerConfigRef.Name).ShouldNot(Equal(cmName + "old"))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKey(shardingConfigName))
 
 					rlr := make([]rhtasv1.RekorLogRange, 0)
@@ -317,14 +319,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(Equal(cmName + "old"))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKeyWithValue(shardingConfigName, ""))
 
 					rlr := make([]rhtasv1.RekorLogRange, 0)
@@ -364,14 +366,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(Equal(cmName + "old"))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKey(shardingConfigName))
 
 					rlr := make([]rhtasv1.RekorLogRange, 0)
@@ -392,15 +394,15 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).ShouldNot(Equal(cmName + "deleted"))
 					g.Expect(r.Status.ServerConfigRef.Name).Should(ContainSubstring(cmName))
 
 					cm := v1.ConfigMap{}
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: r.Status.ServerConfigRef.Name, Namespace: rekorNN.Namespace}, &cm)).To(Succeed())
 					g.Expect(cm.Data).Should(HaveKeyWithValue(shardingConfigName, ""))
 
 					g.Expect(events).To(HaveLen(1))
@@ -430,9 +432,9 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).ShouldNot(Equal(cmName + "old"))
 
@@ -476,14 +478,14 @@ func TestShardingConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, c client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch, events <-chan watch.Event) {
 					r := rhtasv1.Rekor{}
-					g.Expect(c.Get(context.TODO(), rekorNN, &r)).To(Succeed())
+					g.Expect(c.Get(ctx, rekorNN, &r)).To(Succeed())
 					g.Expect(r.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(r.Status.ServerConfigRef.Name).Should(Not(Equal(cmName + "old")))
 
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: cmName + "old", Namespace: rekorNN.Namespace}, &v1.ConfigMap{})).To(HaveOccurred())
-					g.Expect(c.Get(context.TODO(), types.NamespacedName{Name: "keep", Namespace: rekorNN.Namespace}, &v1.ConfigMap{})).To(Succeed())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: cmName + "old", Namespace: rekorNN.Namespace}, &v1.ConfigMap{})).To(HaveOccurred())
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: "keep", Namespace: rekorNN.Namespace}, &v1.ConfigMap{})).To(Succeed())
 
 					g.Expect(events).To(HaveLen(2))
 					g.Expect(events).To(Receive(
@@ -502,8 +504,9 @@ func TestShardingConfig_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1.Rekor{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rekor",
@@ -533,7 +536,7 @@ func TestShardingConfig_Handle(t *testing.T) {
 			}
 			watchCm.Stop()
 			if tt.want.verify != nil {
-				tt.want.verify(g, c, watchCm.ResultChan())
+				tt.want.verify(ctx, g, c, watchCm.ResultChan())
 			}
 		})
 	}

--- a/internal/controller/rekor/actions/ui/ingress_test.go
+++ b/internal/controller/rekor/actions/ui/ingress_test.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,7 +13,8 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -54,6 +54,7 @@ func TestIngress_CanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 			instance := rhtasv1.Rekor{
 				Spec: rhtasv1.RekorSpec{

--- a/internal/controller/rekor/rekor_attestation_test.go
+++ b/internal/controller/rekor/rekor_attestation_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Rekor controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			By("Deleting the Namespace to perform the tests")

--- a/internal/controller/rekor/rekor_controller_test.go
+++ b/internal/controller/rekor/rekor_controller_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Rekor controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/controller/rekor/rekor_hot_update_test.go
+++ b/internal/controller/rekor/rekor_hot_update_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Rekor hot update test", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/controller/trillian/actions/db/handle_secret_test.go
+++ b/internal/controller/trillian/actions/db/handle_secret_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestHandleSecret_CanHandle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		instance  rhtasv1.Trillian
@@ -137,6 +138,7 @@ func TestHandleSecret_CanHandle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			c := testAction.FakeClientBuilder().Build()
 			a := testAction.PrepareAction(c, NewHandleSecretAction())
 
@@ -146,7 +148,7 @@ func TestHandleSecret_CanHandle(t *testing.T) {
 				Status: tt.condition,
 			})
 
-			if got := a.CanHandle(context.TODO(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
+			if got := a.CanHandle(t.Context(), &instance); !reflect.DeepEqual(got, tt.canHandle) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.canHandle)
 			}
 		})
@@ -154,6 +156,7 @@ func TestHandleSecret_CanHandle(t *testing.T) {
 }
 
 func TestHandleSecret_Handle(t *testing.T) {
+	t.Parallel()
 	namespacedName := types.NamespacedName{Namespace: "default", Name: "trillian"}
 	type env struct {
 		spec    rhtasv1.TrillianSpec
@@ -162,7 +165,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, client.WithWatch, <-chan watch.Event)
+		verify func(context.Context, Gomega, client.WithWatch, <-chan watch.Event)
 	}
 	tests := []struct {
 		name string
@@ -181,9 +184,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionTrue))
@@ -207,9 +210,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionTrue))
@@ -239,9 +242,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionTrue))
@@ -271,9 +274,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					g.Expect(instance.Status.Db.DatabaseSecretRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.Db.DatabaseSecretRef.Name).To(Equal("connection"))
@@ -295,9 +298,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -322,9 +325,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -357,9 +360,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -389,9 +392,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -420,9 +423,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -471,9 +474,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -536,9 +539,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -621,9 +624,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.WithWatch, events <-chan watch.Event) {
+				verify: func(ctx context.Context, g Gomega, cli client.WithWatch, events <-chan watch.Event) {
 					instance := &rhtasv1.Trillian{}
-					g.Expect(cli.Get(context.TODO(), namespacedName, instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, namespacedName, instance)).To(Succeed())
 
 					condition := meta.FindStatusCondition(instance.GetConditions(), actions.DbCondition)
 					g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
@@ -647,8 +650,9 @@ func TestHandleSecret_Handle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
-			ctx := context.TODO()
+			ctx := t.Context()
 			instance := &rhtasv1.Trillian{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "trillian",
@@ -681,7 +685,7 @@ func TestHandleSecret_Handle(t *testing.T) {
 
 			watchSecrets.Stop()
 			if tt.want.verify != nil {
-				tt.want.verify(g, c, watchSecrets.ResultChan())
+				tt.want.verify(ctx, g, c, watchSecrets.ResultChan())
 			}
 		})
 	}

--- a/internal/controller/trillian/actions/logserver/service_test.go
+++ b/internal/controller/trillian/actions/logserver/service_test.go
@@ -1,7 +1,6 @@
 package logserver
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -23,7 +22,8 @@ const (
 )
 
 func TestMigrateToHeadless(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 
 	tests := []struct {
 		name           string
@@ -85,6 +85,7 @@ func TestMigrateToHeadless(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 
 			c := testAction.FakeClientBuilder().
@@ -123,7 +124,8 @@ func TestMigrateToHeadless(t *testing.T) {
 }
 
 func TestCreateServiceAction_Handle_CreatesHeadless(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 	g := NewWithT(t)
 
 	instance := &rhtasv1.Trillian{
@@ -161,7 +163,8 @@ func TestCreateServiceAction_Handle_CreatesHeadless(t *testing.T) {
 }
 
 func TestCreateServiceAction_Handle_MigratesClusterIP(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 	g := NewWithT(t)
 
 	instance := &rhtasv1.Trillian{

--- a/internal/controller/trillian/actions/logserver/tls_test.go
+++ b/internal/controller/trillian/actions/logserver/tls_test.go
@@ -1,7 +1,6 @@
 package logserver
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestTlsAction_CanHandle(t *testing.T) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	g := NewWithT(t)
 
 	type env struct {

--- a/internal/controller/trillian/actions/logsigner/tls_test.go
+++ b/internal/controller/trillian/actions/logsigner/tls_test.go
@@ -1,7 +1,6 @@
 package logsigner
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,7 +13,8 @@ import (
 )
 
 func TestTlsAction_CanHandle(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 	g := NewWithT(t)
 
 	type env struct {

--- a/internal/controller/trillian/trillian_controller_test.go
+++ b/internal/controller/trillian/trillian_controller_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Trillian controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/controller/tsa/actions/ingress_test.go
+++ b/internal/controller/tsa/actions/ingress_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,7 +13,8 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -43,6 +43,7 @@ func TestIngress_CanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 			instance := rhtasv1.TimestampAuthority{
 				Spec: rhtasv1.TimestampAuthoritySpec{

--- a/internal/controller/tsa/actions/ntpMonitoring_test.go
+++ b/internal/controller/tsa/actions/ntpMonitoring_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func Test_NewNtpMonitoringAction(t *testing.T) {
+	t.Parallel()
 	g := NewWithT(t)
 
 	action := NewNtpMonitoringAction()
@@ -29,6 +30,7 @@ func Test_NewNtpMonitoringAction(t *testing.T) {
 }
 
 func Test_NTPName(t *testing.T) {
+	t.Parallel()
 	g := NewWithT(t)
 
 	action := NewNtpMonitoringAction()
@@ -36,6 +38,7 @@ func Test_NTPName(t *testing.T) {
 }
 
 func Test_NTPCanHandle(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		testCase func(*rhtasv1.TimestampAuthority)
@@ -100,11 +103,12 @@ func Test_NTPCanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 			action := NewNtpMonitoringAction()
 			instance := common.GenerateTSAInstance()
 			tt.testCase(instance)
-			g.Expect(action.CanHandle(context.TODO(), instance)).To(Equal(tt.expected))
+			g.Expect(action.CanHandle(t.Context(), instance)).To(Equal(tt.expected))
 		})
 	}
 }
@@ -113,7 +117,7 @@ func Test_NTPHandle(t *testing.T) {
 	tests := []struct {
 		name     string
 		setup    func(instance *rhtasv1.TimestampAuthority) (client.WithWatch, action.Action[*rhtasv1.TimestampAuthority])
-		testCase func(Gomega, action.Action[*rhtasv1.TimestampAuthority], client.WithWatch, *rhtasv1.TimestampAuthority) bool
+		testCase func(context.Context, Gomega, action.Action[*rhtasv1.TimestampAuthority], client.WithWatch, *rhtasv1.TimestampAuthority) bool
 	}{
 		{
 			name: "Succeeds with config specified",
@@ -121,11 +125,11 @@ func Test_NTPHandle(t *testing.T) {
 				instance.Status.Conditions[0].Reason = state.Creating.String()
 				return common.TsaTestSetup(instance, t, nil, NewNtpMonitoringAction(), []client.Object{}...)
 			},
-			testCase: func(g Gomega, _ action.Action[*rhtasv1.TimestampAuthority], client client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
+			testCase: func(ctx context.Context, g Gomega, _ action.Action[*rhtasv1.TimestampAuthority], client client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
 				g.Expect(instance.Status.NtpConfigRef).NotTo(BeNil(), "Status NtpConfigRef should not be nil")
 
 				cm := &corev1.ConfigMap{}
-				err := client.Get(context.TODO(), types.NamespacedName{Name: instance.Status.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
+				err := client.Get(ctx, types.NamespacedName{Name: instance.Status.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
 				g.Expect(err).NotTo(HaveOccurred(), "Unable to find config map")
 
 				g.Expect(instance.Status.NtpConfigRef.Name).To(Equal(cm.Name), "Config Map name mismatch")
@@ -161,13 +165,13 @@ func Test_NTPHandle(t *testing.T) {
 				obj := []client.Object{config}
 				return common.TsaTestSetup(instance, t, nil, NewNtpMonitoringAction(), obj...)
 			},
-			testCase: func(g Gomega, _ action.Action[*rhtasv1.TimestampAuthority], client client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
+			testCase: func(ctx context.Context, g Gomega, _ action.Action[*rhtasv1.TimestampAuthority], client client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
 				g.Expect(instance.Status.NtpConfigRef).NotTo(BeNil(), "Status NtpConfigRef should not be nil")
 
 				g.Expect(instance.Status.NtpConfigRef.Name).To(Equal(instance.Spec.NTPMonitoring.Config.NtpConfigRef.Name), "Config Map mismatch")
 
 				cm := &corev1.ConfigMap{}
-				err := client.Get(context.TODO(), types.NamespacedName{Name: instance.Status.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
+				err := client.Get(ctx, types.NamespacedName{Name: instance.Status.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
 				g.Expect(err).NotTo(HaveOccurred(), "Unable to find config map")
 
 				cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
@@ -183,25 +187,25 @@ func Test_NTPHandle(t *testing.T) {
 				instance.Status.Conditions[0].Reason = state.Creating.String()
 				return common.TsaTestSetup(instance, t, nil, NewNtpMonitoringAction(), []client.Object{}...)
 			},
-			testCase: func(g Gomega, a action.Action[*rhtasv1.TimestampAuthority], cli client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
+			testCase: func(ctx context.Context, g Gomega, a action.Action[*rhtasv1.TimestampAuthority], cli client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
 				g.Expect(instance.Status.NtpConfigRef).NotTo(BeNil(), "Status NtpConfigRef should not be nil")
 
 				cm := &corev1.ConfigMap{}
-				err := cli.Get(context.TODO(), types.NamespacedName{Name: instance.Status.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
+				err := cli.Get(ctx, types.NamespacedName{Name: instance.Status.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
 				g.Expect(err).NotTo(HaveOccurred(), "Unable to find config map")
 				g.Expect(instance.Status.NtpConfigRef.Name).To(Equal(cm.Name), "Config Map name mismatch")
 
 				g.Eventually(func(g Gomega) error {
-					g.Expect(cli.Get(context.TODO(), client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
 					instance.Spec.NTPMonitoring.Config.NumServers = 2
-					return cli.Update(context.TODO(), instance)
+					return cli.Update(ctx, instance)
 				}).Should(Succeed())
 
 				g.Expect(err).NotTo(HaveOccurred(), "Error updating instance")
 
-				_ = a.Handle(context.TODO(), instance)
+				_ = a.Handle(ctx, instance)
 
-				err = cli.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, instance)
+				err = cli.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, instance)
 				g.Expect(err).NotTo(HaveOccurred(), "Error re-fetching instance")
 
 				g.Expect(instance.Spec.NTPMonitoring.Config.NumServers).To(Equal(2), "NumServers mismatch")
@@ -219,27 +223,27 @@ func Test_NTPHandle(t *testing.T) {
 				instance.Status.Conditions[0].Reason = state.Creating.String()
 				return common.TsaTestSetup(instance, t, nil, NewNtpMonitoringAction(), []client.Object{}...)
 			},
-			testCase: func(g Gomega, a action.Action[*rhtasv1.TimestampAuthority], cli client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
+			testCase: func(ctx context.Context, g Gomega, a action.Action[*rhtasv1.TimestampAuthority], cli client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
 				g.Expect(instance.Status.NtpConfigRef).NotTo(BeNil(), "Status NtpConfigRef should not be nil")
 
 				cm := &corev1.ConfigMap{}
-				err := cli.Get(context.TODO(), types.NamespacedName{Name: instance.Status.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
+				err := cli.Get(ctx, types.NamespacedName{Name: instance.Status.NtpConfigRef.Name, Namespace: instance.GetNamespace()}, cm)
 				g.Expect(err).NotTo(HaveOccurred(), "Unable to find config map")
 
 				g.Eventually(func(g Gomega) error {
-					g.Expect(cli.Get(context.TODO(), client.ObjectKeyFromObject(instance), instance)).To(Succeed())
+					g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(instance), instance)).To(Succeed())
 					instance.Spec.NTPMonitoring.Config.NumServers = 2
-					return cli.Update(context.TODO(), instance)
+					return cli.Update(ctx, instance)
 				}).Should(Succeed())
 
 				oldConfigMapName := instance.Status.NtpConfigRef.Name
 
-				_ = a.Handle(context.TODO(), instance)
+				_ = a.Handle(ctx, instance)
 
 				newConfigMapName := instance.Status.NtpConfigRef.Name
 				g.Expect(newConfigMapName).NotTo(Equal(oldConfigMapName), "New ConfigMap should have a different name from the old ConfigMap")
 
-				err = cli.Get(context.TODO(), types.NamespacedName{Name: oldConfigMapName, Namespace: instance.GetNamespace()}, &corev1.ConfigMap{})
+				err = cli.Get(ctx, types.NamespacedName{Name: oldConfigMapName, Namespace: instance.GetNamespace()}, &corev1.ConfigMap{})
 				g.Expect(errors.IsNotFound(err)).To(BeTrue(), "Old ConfigMap should be deleted")
 
 				cond := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
@@ -256,7 +260,7 @@ func Test_NTPHandle(t *testing.T) {
 				instance.Spec.NTPMonitoring.Config = nil
 				return common.TsaTestSetup(instance, t, nil, NewNtpMonitoringAction(), []client.Object{}...)
 			},
-			testCase: func(g Gomega, a action.Action[*rhtasv1.TimestampAuthority], cli client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
+			testCase: func(ctx context.Context, g Gomega, a action.Action[*rhtasv1.TimestampAuthority], cli client.WithWatch, instance *rhtasv1.TimestampAuthority) bool {
 				g.Expect(instance.Status.NtpConfigRef).To(BeNil(), "Status NtpConfigRef should be nil when config is nil")
 
 				l := map[string]string{
@@ -264,7 +268,7 @@ func Test_NTPHandle(t *testing.T) {
 				}
 
 				list := &corev1.ConfigMapList{}
-				g.Expect(cli.List(context.TODO(), list, &client.ListOptions{LabelSelector: apilabels.SelectorFromSet(l)})).To(Succeed())
+				g.Expect(cli.List(ctx, list, &client.ListOptions{LabelSelector: apilabels.SelectorFromSet(l)})).To(Succeed())
 				g.Expect(list.Items).To(BeEmpty(), "List should be empty")
 
 				return true
@@ -274,11 +278,12 @@ func Test_NTPHandle(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewWithT(t)
+			ctx := t.Context()
 			instance := common.GenerateTSAInstance()
 			client, action := tt.setup(instance)
 			g.Expect(client).NotTo(BeNil(), "Client should not be nil")
 			g.Expect(action).NotTo(BeNil(), "Action should not be nil")
-			g.Expect(tt.testCase(g, action, client, instance)).To(BeTrue())
+			g.Expect(tt.testCase(ctx, g, action, client, instance)).To(BeTrue())
 		})
 	}
 }

--- a/internal/controller/tsa/actions/resolve_pub_key_test.go
+++ b/internal/controller/tsa/actions/resolve_pub_key_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	_ "embed"
 	"net/http"
 	"strings"
@@ -28,19 +27,22 @@ var testCertChainPEMRaw string
 var testCertChainPEM = strings.TrimSpace(testCertChainPEMRaw)
 
 func TestTSAResolvePubKey_CanHandle(t *testing.T) {
+	t.Parallel()
 	a := NewResolvePubKeyAction()
 	t.Run("not ready", func(t *testing.T) {
+		t.Parallel()
 		instance := &rhtasv1.TimestampAuthority{}
-		if a.CanHandle(context.TODO(), instance) {
+		if a.CanHandle(t.Context(), instance) {
 			t.Error("expected false when no condition set")
 		}
 	})
 	t.Run("initialize phase", func(t *testing.T) {
+		t.Parallel()
 		instance := &rhtasv1.TimestampAuthority{}
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Initialize.String(),
 		})
-		if !a.CanHandle(context.TODO(), instance) {
+		if !a.CanHandle(t.Context(), instance) {
 			t.Error("expected true in Initialize phase")
 		}
 	})

--- a/internal/controller/tsa/timestampauthority_controller_test.go
+++ b/internal/controller/tsa/timestampauthority_controller_test.go
@@ -99,7 +99,7 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/controller/tsa/tsa_hot_update_test.go
+++ b/internal/controller/tsa/tsa_hot_update_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
@@ -220,7 +220,7 @@ var _ = Describe("Timestamp Authority hot update", func() {
 
 			By("Creating new certificate chain and signer keys")
 			secret := tsa.CreateSecrets(Namespace, "tsa-test-secret", true)
-			Expect(suite.Client().Create(context.TODO(), secret)).NotTo(HaveOccurred())
+			Expect(suite.Client().Create(ctx, secret)).NotTo(HaveOccurred())
 
 			By("Status field changed for cert chain")
 			Eventually(func(g Gomega) string {

--- a/internal/controller/tuf/actions/ingress_test.go
+++ b/internal/controller/tuf/actions/ingress_test.go
@@ -1,7 +1,6 @@
 package actions
 
 import (
-	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -14,7 +13,8 @@ import (
 )
 
 func TestIngress_CanHandle(t *testing.T) {
-	ctx := context.TODO()
+	t.Parallel()
+	ctx := t.Context()
 	tests := []struct {
 		name           string
 		conditions     []metav1.Condition
@@ -43,6 +43,7 @@ func TestIngress_CanHandle(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 			instance := rhtasv1.Tuf{
 				Spec: rhtasv1.TufSpec{

--- a/internal/controller/tuf/tuf_controller_test.go
+++ b/internal/controller/tuf/tuf_controller_test.go
@@ -83,7 +83,7 @@ var _ = Describe("TUF controller", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			Eventually(func() error {
-				return suite.Client().Delete(context.TODO(), found)
+				return suite.Client().Delete(ctx, found)
 			}, 2*time.Minute, time.Second).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST

--- a/internal/testing/common/tsa/tsa.go
+++ b/internal/testing/common/tsa/tsa.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"context"
 	"testing"
 
 	rhtasv1 "github.com/securesign/operator/api/v1"
@@ -67,23 +66,23 @@ func TsaTestSetup(instance *rhtasv1.TimestampAuthority, t *testing.T, client cli
 	if client == nil {
 		client = testAction.FakeClientBuilder().WithObjects(instance).WithStatusSubresource(instance).Build()
 	}
-	if err := client.Get(context.TODO(), types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}, instance); err != nil {
+	if err := client.Get(t.Context(), types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}, instance); err != nil {
 		t.Error(err)
 		return nil, nil
 	}
 
 	for _, obj := range initObjs {
-		if err := client.Create(context.TODO(), obj); err != nil {
+		if err := client.Create(t.Context(), obj); err != nil {
 			t.Error(err)
 			return nil, nil
 		}
 	}
 
 	a := testAction.PrepareAction(client, action)
-	if !a.CanHandle(context.TODO(), instance) {
+	if !a.CanHandle(t.Context(), instance) {
 		return nil, nil
 	}
 
-	_ = a.Handle(context.TODO(), instance)
+	_ = a.Handle(t.Context(), instance)
 	return client, a
 }

--- a/internal/utils/kubernetes/config_map_test.go
+++ b/internal/utils/kubernetes/config_map_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -14,6 +13,7 @@ import (
 )
 
 func TestEnsureImmutableConfigMap(t *testing.T) {
+	t.Parallel()
 	data := map[string]string{"test": "data"}
 	tests := []struct {
 		name      string
@@ -98,7 +98,8 @@ func TestEnsureImmutableConfigMap(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).

--- a/internal/utils/kubernetes/ensure/deployment/deployment_test.go
+++ b/internal/utils/kubernetes/ensure/deployment/deployment_test.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -21,8 +20,10 @@ import (
 const name = "dp"
 
 func TestEnsureTrustedCA(t *testing.T) {
+	t.Parallel()
 	t.Run("update existing object", func(t *testing.T) {
-		ctx := context.TODO()
+		t.Parallel()
+		ctx := t.Context()
 		g := gomega.NewWithT(t)
 		c := testAction.FakeClientBuilder().
 			WithObjects(&v1.Deployment{
@@ -88,8 +89,10 @@ func TestEnsureTrustedCA(t *testing.T) {
 }
 
 func TestEnsureTLS(t *testing.T) {
+	t.Parallel()
 	t.Run("update existing object", func(t *testing.T) {
-		ctx := context.TODO()
+		t.Parallel()
+		ctx := t.Context()
 		g := gomega.NewWithT(t)
 		c := testAction.FakeClientBuilder().
 			WithObjects(&v1.Deployment{
@@ -163,6 +166,7 @@ func TestEnsureTLS(t *testing.T) {
 }
 
 func TestPodRequirements(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		requirements  rhtasv1.PodRequirements
 		containerName string
@@ -251,6 +255,7 @@ func TestPodRequirements(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := gomega.NewWithT(t)
 			dp := &v1.Deployment{}
 			fn := PodRequirements(tt.args.requirements, tt.args.containerName)

--- a/internal/utils/kubernetes/ensure/ensure_test.go
+++ b/internal/utils/kubernetes/ensure/ensure_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func Test_Ensure(t *testing.T) {
+	t.Parallel()
 	addAnnotations := func(object client.Object, annotations map[string]string) client.Object {
 		object.SetAnnotations(annotations)
 		return object
@@ -51,7 +52,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 				g.Expect(obj.Spec.Ports).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 					"Port":       Equal(int32(80)),
 					"TargetPort": Equal(intstr.FromInt32(80)),
@@ -78,7 +79,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 				g.Expect(obj.Labels).Should(HaveKeyWithValue("new", "label"))
 				g.Expect(obj.Labels).ShouldNot(HaveKey("old"))
 
@@ -109,7 +110,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 				g.Expect(obj.Labels).Should(HaveKeyWithValue("unmanaged", "value"))
 				g.Expect(obj.Labels).ShouldNot(HaveKeyWithValue("managed", "value"))
 				g.Expect(obj.Spec.Ports).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
@@ -143,7 +144,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 				g.Expect(obj.Annotations).Should(HaveKeyWithValue("new", "annotation"))
 				g.Expect(obj.Annotations).ShouldNot(HaveKey("old"))
 
@@ -175,7 +176,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 				g.Expect(obj.Annotations).Should(HaveKeyWithValue("unmanaged", "value"))
 				g.Expect(obj.Annotations).ShouldNot(HaveKeyWithValue("managed", "value"))
 
@@ -201,7 +202,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 
 				g.Expect(obj.Spec.Ports).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 					"Port":       Equal(int32(443)),
@@ -243,7 +244,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "test",
 				}
 				obj := &rhtasv1.Securesign{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 				g.Expect(obj.Status.RekorStatus.Url).To(Equal("old status"))
 			},
 		},
@@ -263,7 +264,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 
 				g.Expect(obj.Spec.Ports).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 					"Port":       Equal(int32(80)),
@@ -291,7 +292,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 
 				g.Expect(obj.Spec.Ports).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 					"Port":       Equal(int32(80)),
@@ -319,7 +320,7 @@ func Test_Ensure(t *testing.T) {
 					Name:      "service",
 				}
 				obj := &v1.Service{}
-				g.Expect(cli.Get(context.TODO(), nn, obj)).To(Succeed())
+				g.Expect(cli.Get(ctx, nn, obj)).To(Succeed())
 
 				g.Expect(obj.Spec.Ports).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 					"Port":       Equal(int32(443)),
@@ -330,6 +331,7 @@ func Test_Ensure(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := NewWithT(t)
 			c := fakeClientBuilder().
 				WithObjects(tt.env.objects...).

--- a/internal/utils/kubernetes/ingress_test.go
+++ b/internal/utils/kubernetes/ingress_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -16,6 +15,7 @@ import (
 )
 
 func TestEnsureIngressSpec(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -98,7 +98,8 @@ func TestEnsureIngressSpec(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).

--- a/internal/utils/kubernetes/role_binding_test.go
+++ b/internal/utils/kubernetes/role_binding_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -15,6 +14,7 @@ import (
 )
 
 func TestEnsureRoleBinding(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -61,7 +61,8 @@ func TestEnsureRoleBinding(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
@@ -90,6 +91,7 @@ func TestEnsureRoleBinding(t *testing.T) {
 }
 
 func TestEnsureClusterRoleBinding(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -136,7 +138,8 @@ func TestEnsureClusterRoleBinding(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).

--- a/internal/utils/kubernetes/role_test.go
+++ b/internal/utils/kubernetes/role_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -13,6 +12,7 @@ import (
 )
 
 func TestEnsureRoleRules(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -64,7 +64,8 @@ func TestEnsureRoleRules(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
@@ -98,6 +99,7 @@ func TestEnsureRoleRules(t *testing.T) {
 }
 
 func TestEnsureClusterRoleRules(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -149,7 +151,8 @@ func TestEnsureClusterRoleRules(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).

--- a/internal/utils/kubernetes/secret_test.go
+++ b/internal/utils/kubernetes/secret_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestExistsSecret(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		objects   []client.Object
@@ -48,13 +49,14 @@ func TestExistsSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
 				WithInterceptorFuncs(tt.intercept).
 				Build()
 
-			exists, err := ExistsSecret(context.TODO(), c, "default", "my-secret")
+			exists, err := ExistsSecret(t.Context(), c, "default", "my-secret")
 			g.Expect(exists).To(gomega.Equal(tt.exists))
 			if tt.wantErr {
 				g.Expect(err).To(gomega.HaveOccurred())
@@ -66,6 +68,7 @@ func TestExistsSecret(t *testing.T) {
 }
 
 func TestEnsureSecret(t *testing.T) {
+	t.Parallel()
 	data := map[string][]byte{"test": []byte("data")}
 	tests := []struct {
 		name      string
@@ -150,7 +153,8 @@ func TestEnsureSecret(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).

--- a/internal/utils/kubernetes/service_test.go
+++ b/internal/utils/kubernetes/service_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -13,6 +12,7 @@ import (
 )
 
 func TestService(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -58,7 +58,8 @@ func TestService(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).
@@ -83,6 +84,7 @@ func TestService(t *testing.T) {
 }
 
 func TestHeadlessService(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		objects []client.Object
@@ -112,7 +114,8 @@ func TestHeadlessService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).

--- a/internal/utils/tls/tls_test.go
+++ b/internal/utils/tls/tls_test.go
@@ -1,7 +1,6 @@
 package tls
 
 import (
-	"context"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -27,6 +26,7 @@ func (f fakeTlsClient) GetTrustedCA() *rhtasv1.LocalObjectReference {
 }
 
 func TestCAPath(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		objects  []client.Object
@@ -107,7 +107,8 @@ func TestCAPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
+			t.Parallel()
+			ctx := t.Context()
 			g := gomega.NewWithT(t)
 			c := testAction.FakeClientBuilder().
 				WithObjects(tt.objects...).


### PR DESCRIPTION
Replaces `context.TODO()` with proper context in tests.

`context.TODO()` was used in three places where a real context was already obtainable, silencing correctness issues in tests:

- Ginkgo `AfterEach` cleanups use the `ctx` already in scope instead of a disconnected `context.TODO()`, so cleanup respects the test's actual context/timeout instead of a context that's never cancelled.
- Plain Go tests use `t.Context()` instead of `context.TODO()`, so the context is tied to the test's lifecycle.
- Table-literal `verify`/`testCase` closures (defined before any `t.Run` exists, so no `t` was in scope) now take a `ctx context.Context` parameter, threaded from `t.Context()` in the enclosing `t.Run`, instead of falling back to `context.TODO()`.

Also adds `t.Parallel()` to plain Go tests that don't mutate shared state, to speed up the suite. Skipped where a test does mutate shared state (HTTP client builder mocks, `fips.Enabled` override, `config.Openshift`), to avoid introducing flakiness.