### PR TITLE
fix: thread context through kubernetes.GetSecret and GetSecretData

### DIFF
--- a/internal/controller/ctlog/actions/handle_fulcio_root.go
+++ b/internal/controller/ctlog/actions/handle_fulcio_root.go
@@ -99,7 +99,7 @@ func (g handleFulcioCert) Handle(ctx context.Context, instance *rhtasv1.CTlog) *
 		}
 
 		if previouslyResolved {
-			existing, readErr := k8sutils.GetSecretData(g.Client, instance.Namespace, &instance.Status.RootCertificates[0])
+			existing, readErr := k8sutils.GetSecretData(ctx, g.Client, instance.Namespace, &instance.Status.RootCertificates[0])
 			if readErr == nil && bytes.Equal(existing, signingCert) {
 				return g.Continue()
 			}

--- a/internal/controller/ctlog/actions/resolve_pub_key.go
+++ b/internal/controller/ctlog/actions/resolve_pub_key.go
@@ -35,11 +35,11 @@ func (r ctlogTrustMaterialResolver) SetTrustMaterial(instance *rhtasv1.CTlog, pe
 	instance.Status.PublicKey = pem
 }
 
-func (r ctlogTrustMaterialResolver) Resolve(_ context.Context, cli client.Client, instance *rhtasv1.CTlog) ([]byte, error) {
+func (r ctlogTrustMaterialResolver) Resolve(ctx context.Context, cli client.Client, instance *rhtasv1.CTlog) ([]byte, error) {
 	if instance.Status.PublicKeyRef == nil {
 		return nil, fmt.Errorf("%w: ctlog", ErrPublicKeyRefNotSet)
 	}
-	data, err := k8sutils.GetSecretData(cli, instance.Namespace, instance.Status.PublicKeyRef)
+	data, err := k8sutils.GetSecretData(ctx, cli, instance.Namespace, instance.Status.PublicKeyRef)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s: %w", ErrSecretRead, instance.Status.PublicKeyRef.Name, err)
 	}

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -83,7 +83,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.CTlog) *acti
 
 	// Validate existing secret before attempting recreation
 	if instance.Status.ServerConfigRef != nil && instance.Status.ServerConfigRef.Name != "" {
-		if err := i.validateExistingSecret(instance, trillianUrl); err != nil {
+		if err := i.validateExistingSecret(ctx, instance, trillianUrl); err != nil {
 			if errors.Is(err, errSecretInvalid) {
 				// Secret needs recreation - log and continue
 				i.Logger.Info("Server config secret needs recreation", "secret", instance.Status.ServerConfigRef.Name)
@@ -120,7 +120,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.CTlog) *acti
 
 	configLabels := labels.ForResource(ComponentName, DeploymentName, instance.Name, serverConfigResourceName)
 
-	rootCerts, err := i.handleRootCertificates(instance)
+	rootCerts, err := i.handleRootCertificates(ctx, instance)
 	if err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:               ConfigCondition,
@@ -135,7 +135,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.CTlog) *acti
 		return i.RequeueAfter(5 * time.Second)
 	}
 
-	certConfig, err := i.handlePrivateKey(instance)
+	certConfig, err := i.handlePrivateKey(ctx, instance)
 	if err != nil {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
 			Type:               ConfigCondition,
@@ -168,7 +168,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.CTlog) *acti
 		},
 	}
 
-	configAnnotations := i.configMatchingAnnotations(instance, trillianUrl)
+	configAnnotations := i.configMatchingAnnotations(ctx, instance, trillianUrl)
 
 	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
 		newConfig,
@@ -210,7 +210,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.CTlog) *acti
 }
 
 func (i serverConfig) handleCustomConfig(ctx context.Context, instance *rhtasv1.CTlog) *action.Result {
-	secret, err := kubernetes.GetSecret(i.Client, instance.Namespace, instance.Spec.ServerConfigRef.Name)
+	secret, err := kubernetes.GetSecret(ctx, i.Client, instance.Namespace, instance.Spec.ServerConfigRef.Name)
 	if err != nil {
 		return i.Error(ctx, fmt.Errorf("error accessing custom server config secret: %w", err), instance,
 			metav1.Condition{
@@ -279,19 +279,19 @@ func (i serverConfig) cleanup(ctx context.Context, instance *rhtasv1.CTlog, conf
 	}
 }
 
-func (i serverConfig) handlePrivateKey(instance *rhtasv1.CTlog) (*ctlogUtils.KeyConfig, error) {
+func (i serverConfig) handlePrivateKey(ctx context.Context, instance *rhtasv1.CTlog) (*ctlogUtils.KeyConfig, error) {
 	if instance == nil {
 		return nil, nil
 	}
-	private, err := kubernetes.GetSecretData(i.Client, instance.Namespace, instance.Status.PrivateKeyRef)
+	private, err := kubernetes.GetSecretData(ctx, i.Client, instance.Namespace, instance.Status.PrivateKeyRef)
 	if err != nil {
 		return nil, err
 	}
-	public, err := kubernetes.GetSecretData(i.Client, instance.Namespace, instance.Status.PublicKeyRef)
+	public, err := kubernetes.GetSecretData(ctx, i.Client, instance.Namespace, instance.Status.PublicKeyRef)
 	if err != nil {
 		return nil, err
 	}
-	password, err := kubernetes.GetSecretData(i.Client, instance.Namespace, instance.Status.PrivateKeyPasswordRef)
+	password, err := kubernetes.GetSecretData(ctx, i.Client, instance.Namespace, instance.Status.PrivateKeyPasswordRef)
 	if err != nil {
 		return nil, err
 	}
@@ -303,11 +303,11 @@ func (i serverConfig) handlePrivateKey(instance *rhtasv1.CTlog) (*ctlogUtils.Key
 	}, nil
 }
 
-func (i serverConfig) handleRootCertificates(instance *rhtasv1.CTlog) ([]ctlogUtils.RootCertificate, error) {
+func (i serverConfig) handleRootCertificates(ctx context.Context, instance *rhtasv1.CTlog) ([]ctlogUtils.RootCertificate, error) {
 	certs := make([]ctlogUtils.RootCertificate, 0)
 
 	for _, selector := range instance.Status.RootCertificates {
-		data, err := kubernetes.GetSecretData(i.Client, instance.Namespace, &selector)
+		data, err := kubernetes.GetSecretData(ctx, i.Client, instance.Namespace, &selector)
 		if err != nil {
 			return nil, fmt.Errorf("%s/%s: %w", selector.Name, selector.Key, err)
 		}
@@ -322,8 +322,8 @@ func (i serverConfig) handleRootCertificates(instance *rhtasv1.CTlog) ([]ctlogUt
 //   - nil if the secret is valid
 //   - errSecretInvalid if the secret needs recreation (not a failure)
 //   - other error for API errors - reconciliation should fail
-func (i serverConfig) validateExistingSecret(instance *rhtasv1.CTlog, trillianUrl string) error {
-	secret, err := kubernetes.GetSecret(i.Client, instance.Namespace, instance.Status.ServerConfigRef.Name)
+func (i serverConfig) validateExistingSecret(ctx context.Context, instance *rhtasv1.CTlog, trillianUrl string) error {
+	secret, err := kubernetes.GetSecret(ctx, i.Client, instance.Namespace, instance.Status.ServerConfigRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return errSecretInvalid
@@ -332,7 +332,7 @@ func (i serverConfig) validateExistingSecret(instance *rhtasv1.CTlog, trillianUr
 	}
 
 	// Check if the secret was generated from the same data sources using annotations
-	expectedAnnotations := i.configMatchingAnnotations(instance, trillianUrl)
+	expectedAnnotations := i.configMatchingAnnotations(ctx, instance, trillianUrl)
 	if !equality.Semantic.DeepDerivative(expectedAnnotations, secret.GetAnnotations()) {
 		return errSecretInvalid
 	}
@@ -342,7 +342,7 @@ func (i serverConfig) validateExistingSecret(instance *rhtasv1.CTlog, trillianUr
 
 // configMatchingAnnotations generates annotations that identify the data sources
 // used to generate the server config secret.
-func (i serverConfig) configMatchingAnnotations(instance *rhtasv1.CTlog, trillianUrl string) map[string]string {
+func (i serverConfig) configMatchingAnnotations(ctx context.Context, instance *rhtasv1.CTlog, trillianUrl string) map[string]string {
 	annotations := map[string]string{
 		labels.LabelNamespace + "/trillianUrl": trillianUrl,
 	}
@@ -351,7 +351,7 @@ func (i serverConfig) configMatchingAnnotations(instance *rhtasv1.CTlog, trillia
 		annotations[labels.LabelNamespace+"/treeID"] = fmt.Sprintf("%d", *instance.Status.TreeID)
 	}
 
-	if certs, err := i.handleRootCertificates(instance); err == nil {
+	if certs, err := i.handleRootCertificates(ctx, instance); err == nil {
 		h := sha256.New()
 		for _, cert := range certs {
 			h.Write(cert)

--- a/internal/controller/ctlog/actions/server_config_test.go
+++ b/internal/controller/ctlog/actions/server_config_test.go
@@ -409,7 +409,7 @@ func TestServerConfig_Handle(t *testing.T) {
 
 					g.Expect(k8sErrors.IsNotFound(cli.Get(ctx, client.ObjectKey{Name: "config", Namespace: "default"}, &v1.Secret{}))).To(BeTrue())
 
-					secret, err := kubernetes.GetSecret(cli, "default", instance.Status.ServerConfigRef.Name)
+					secret, err := kubernetes.GetSecret(ctx, cli, "default", instance.Status.ServerConfigRef.Name)
 					g.Expect(err).ShouldNot(HaveOccurred())
 					g.Expect(secret.Data).To(HaveKey("config"))
 				},
@@ -466,14 +466,14 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.Return(),
-				verify: func(_ context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+				verify: func(ctx context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).Should(Not(BeNil()))
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(Not(Equal("config")))
 
-					_, err := kubernetes.GetSecret(cli, "default", "config")
+					_, err := kubernetes.GetSecret(ctx, cli, "default", "config")
 					g.Expect(k8sErrors.IsNotFound(err)).To(BeTrue())
 
-					secret, err := kubernetes.GetSecret(cli, "default", instance.Status.ServerConfigRef.Name)
+					secret, err := kubernetes.GetSecret(ctx, cli, "default", instance.Status.ServerConfigRef.Name)
 					g.Expect(err).ShouldNot(HaveOccurred())
 					g.Expect(secret.Data).To(HaveKey("config"))
 				},
@@ -595,7 +595,7 @@ func TestServerConfig_Update(t *testing.T) {
 	}
 	type want struct {
 		result *action.Result
-		verify func(Gomega, client.Client, *rhtasv1.CTlog)
+		verify func(context.Context, Gomega, client.Client, *rhtasv1.CTlog)
 	}
 	tests := []struct {
 		name string
@@ -634,15 +634,15 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(current.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
 
-					data, err := kubernetes.GetSecretData(cli, "default", &rhtasv1.SecretKeySelector{LocalObjectReference: *current.Status.ServerConfigRef, Key: "config"})
+					data, err := kubernetes.GetSecretData(ctx, cli, "default", &rhtasv1.SecretKeySelector{LocalObjectReference: *current.Status.ServerConfigRef, Key: "config"})
 					g.Expect(err).ShouldNot(HaveOccurred())
 					g.Expect(data).To(And(ContainSubstring("trillian-logserver.default.svc:443"), ContainSubstring("123456")))
 
-					_, err = kubernetes.GetSecret(cli, "default", "old_config")
+					_, err = kubernetes.GetSecret(ctx, cli, "default", "old_config")
 					g.Expect(err).To(WithTransform(k8sErrors.IsNotFound, BeTrue()), "old_config should be deleted")
 				},
 			},
@@ -662,7 +662,7 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).Should(Equal("existing-config"))
 
 					c := meta.FindStatusCondition(current.Status.Conditions, ConfigCondition)
@@ -686,7 +686,7 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).Should(Equal("existing-config"))
 
 					c := meta.FindStatusCondition(current.Status.Conditions, ConfigCondition)
@@ -709,12 +709,12 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(current.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
 					g.Expect(current.Status.ServerConfigRef.Name).ShouldNot(Equal("deleted-config"))
 
-					secret, err := kubernetes.GetSecret(cli, "default", current.Status.ServerConfigRef.Name)
+					secret, err := kubernetes.GetSecret(ctx, cli, "default", current.Status.ServerConfigRef.Name)
 					g.Expect(err).ShouldNot(HaveOccurred())
 					g.Expect(secret.Data).To(HaveKey("config"))
 				},
@@ -738,11 +738,11 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
 					g.Expect(current.Status.ServerConfigRef.Name).ShouldNot(Equal("old-config"))
 
-					data, err := kubernetes.GetSecretData(cli, "default", &rhtasv1.SecretKeySelector{
+					data, err := kubernetes.GetSecretData(ctx, cli, "default", &rhtasv1.SecretKeySelector{
 						LocalObjectReference: *current.Status.ServerConfigRef, Key: "config",
 					})
 					g.Expect(err).ShouldNot(HaveOccurred())
@@ -780,10 +780,10 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).ShouldNot(Equal("old-config"))
 
-					secret, err := kubernetes.GetSecret(cli, "default", current.Status.ServerConfigRef.Name)
+					secret, err := kubernetes.GetSecret(ctx, cli, "default", current.Status.ServerConfigRef.Name)
 					g.Expect(err).ShouldNot(HaveOccurred())
 					g.Expect(secret.Data).To(HaveKey("config"))
 					g.Expect(secret.Annotations).To(HaveKey("rhtas.redhat.com/rootCertificatesHash"))
@@ -814,7 +814,7 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.RequeueAfter(5 * time.Second),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					c := meta.FindStatusCondition(current.Status.Conditions, ConfigCondition)
 					g.Expect(c).ShouldNot(BeNil())
 					g.Expect(c.Status).Should(Equal(metav1.ConditionFalse))
@@ -837,16 +837,16 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 
-					data, err := kubernetes.GetSecretData(cli, "mynamespace", &rhtasv1.SecretKeySelector{
+					data, err := kubernetes.GetSecretData(ctx, cli, "mynamespace", &rhtasv1.SecretKeySelector{
 						LocalObjectReference: *current.Status.ServerConfigRef, Key: "config",
 					})
 					g.Expect(err).ShouldNot(HaveOccurred())
 					g.Expect(data).To(ContainSubstring("trillian-logserver.mynamespace.svc:8091"))
 
-					secret, err := kubernetes.GetSecret(cli, "mynamespace", current.Status.ServerConfigRef.Name)
+					secret, err := kubernetes.GetSecret(ctx, cli, "mynamespace", current.Status.ServerConfigRef.Name)
 					g.Expect(err).ShouldNot(HaveOccurred())
 					g.Expect(secret.Annotations).To(HaveKeyWithValue(
 						"rhtas.redhat.com/trillianUrl", "trillian-logserver.mynamespace.svc:8091",
@@ -883,10 +883,10 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef.Name).Should(Equal("custom_config"))
 
-					data, err := kubernetes.GetSecretData(cli, "default", &rhtasv1.SecretKeySelector{LocalObjectReference: *current.Status.ServerConfigRef, Key: "config"})
+					data, err := kubernetes.GetSecretData(ctx, cli, "default", &rhtasv1.SecretKeySelector{LocalObjectReference: *current.Status.ServerConfigRef, Key: "config"})
 					g.Expect(err).ShouldNot(HaveOccurred())
 					g.Expect(data).To(And(ContainSubstring("trillian-logserver.custom.svc:80"), ContainSubstring("9999999")))
 				},
@@ -924,7 +924,7 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Continue(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(current.Status.ServerConfigRef.Name).Should(Equal("custom_config"))
 
@@ -967,7 +967,7 @@ func TestServerConfig_Update(t *testing.T) {
 			}(),
 			want: want{
 				result: testAction.Return(),
-				verify: func(g Gomega, cli client.Client, current *rhtasv1.CTlog) {
+				verify: func(ctx context.Context, g Gomega, cli client.Client, current *rhtasv1.CTlog) {
 					g.Expect(current.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(current.Status.ServerConfigRef.Name).Should(Equal("custom_config"))
 
@@ -994,7 +994,7 @@ func TestServerConfig_Update(t *testing.T) {
 				t.Errorf("CanHandle() = %v, want %v", got, tt.want.result)
 			}
 			if tt.want.verify != nil {
-				tt.want.verify(g, c, &tt.env.instance)
+				tt.want.verify(ctx, g, c, &tt.env.instance)
 			}
 		})
 	}

--- a/internal/controller/fulcio/actions/generate_signer.go
+++ b/internal/controller/fulcio/actions/generate_signer.go
@@ -91,14 +91,14 @@ func generateData(ctx context.Context, instance *rhtasv1.Fulcio, c client.Client
 	}
 
 	if ref := instance.Spec.Certificate.PrivateKeyPasswordRef; ref != nil { //nolint:staticcheck
-		password, err := kubernetes.GetSecretData(c, instance.Namespace, ref)
+		password, err := kubernetes.GetSecretData(ctx, c, instance.Namespace, ref)
 		if err != nil {
 			return nil, err
 		}
 		config.PrivateKeyPassword = password
 	}
 	if ref := instance.Spec.Certificate.PrivateKeyRef; ref != nil {
-		key, err := kubernetes.GetSecretData(c, instance.Namespace, ref)
+		key, err := kubernetes.GetSecretData(ctx, c, instance.Namespace, ref)
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +123,7 @@ func generateData(ctx context.Context, instance *rhtasv1.Fulcio, c client.Client
 	}
 
 	if ref := instance.Spec.Certificate.CARef; ref != nil {
-		cert, err := kubernetes.GetSecretData(c, instance.Namespace, ref)
+		cert, err := kubernetes.GetSecretData(ctx, c, instance.Namespace, ref)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -173,7 +173,7 @@ func handleSignerKeys(instance *rhtasv1.TimestampAuthority, config *tsaUtils.Tsa
 
 func handleCertificateChain(ctx context.Context, instance *rhtasv1.TimestampAuthority, config *tsaUtils.TsaCertChainConfig, c client.Client) (*tsaUtils.TsaCertChainConfig, error) {
 	if ref := instance.Spec.Signer.CertificateChain.CertificateChainRef; ref != nil {
-		certificateChain, err := kubernetes.GetSecretData(c, instance.Namespace, ref)
+		certificateChain, err := kubernetes.GetSecretData(ctx, c, instance.Namespace, ref)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controller/tuf/actions/migration_job.go
+++ b/internal/controller/tuf/actions/migration_job.go
@@ -50,7 +50,7 @@ func (i migrationJobAction) CanHandle(_ context.Context, tuf *rhtasv1.Tuf) bool 
 
 func (i migrationJobAction) Handle(ctx context.Context, instance *rhtasv1.Tuf) *action.Result {
 	if instance.Spec.RootKeySecretRef != nil && instance.Spec.RootKeySecretRef.Name != "" {
-		if _, err := kubernetes.GetSecret(i.Client, instance.Namespace, instance.Spec.RootKeySecretRef.Name); err != nil {
+		if _, err := kubernetes.GetSecret(ctx, i.Client, instance.Namespace, instance.Spec.RootKeySecretRef.Name); err != nil {
 			if errors.IsNotFound(err) {
 				i.Logger.Info("Root key secret not found", "secret", instance.Spec.RootKeySecretRef.Name)
 				return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("cannot migrate TUF: root key secret %s not found: %w", instance.Spec.RootKeySecretRef.Name, err)), instance)

--- a/internal/utils/kubernetes/secret.go
+++ b/internal/utils/kubernetes/secret.go
@@ -17,10 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func GetSecret(client client.Client, namespace, secretName string) (*corev1.Secret, error) {
+func GetSecret(ctx context.Context, client client.Client, namespace, secretName string) (*corev1.Secret, error) {
 	var secret corev1.Secret
 
-	err := client.Get(context.TODO(), types.NamespacedName{
+	err := client.Get(ctx, types.NamespacedName{
 		Name:      secretName,
 		Namespace: namespace,
 	}, &secret)
@@ -31,9 +31,9 @@ func GetSecret(client client.Client, namespace, secretName string) (*corev1.Secr
 	return &secret, nil
 }
 
-func GetSecretData(client client.Client, namespace string, selector *rhtasv1.SecretKeySelector) ([]byte, error) {
+func GetSecretData(ctx context.Context, client client.Client, namespace string, selector *rhtasv1.SecretKeySelector) ([]byte, error) {
 	if selector != nil && selector.Name != "" && selector.Key != "" {
-		secret, err := GetSecret(client, namespace, selector.Name)
+		secret, err := GetSecret(ctx, client, namespace, selector.Name)
 		if err != nil {
 			return nil, fmt.Errorf("could not retrieve secret %s: %w", selector.Name, err)
 		}

--- a/test/e2e/install/key_autodiscovery_test.go
+++ b/test/e2e/install/key_autodiscovery_test.go
@@ -84,27 +84,27 @@ var _ = Describe("Securesign key autodiscovery test", Ordered, func() {
 				err              error
 			)
 			for _, k := range t.Status.Keys {
-				actual, err = kubernetes.GetSecretData(cli, namespace.Name, k.SecretRef)
+				actual, err = kubernetes.GetSecretData(ctx, cli, namespace.Name, k.SecretRef)
 				Expect(err).To(Not(HaveOccurred()))
 
 				switch k.Name {
 				case "fulcio_v1.crt.pem":
-					expected, err = kubernetes.GetSecretData(cli, namespace.Name, s.Spec.Fulcio.Certificate.CARef)
+					expected, err = kubernetes.GetSecretData(ctx, cli, namespace.Name, s.Spec.Fulcio.Certificate.CARef)
 					Expect(err).To(Not(HaveOccurred()))
 				case "rekor.pub":
 					expectedKeyRef := s.Spec.Rekor.Signer.KeyRef.DeepCopy()
 					expectedKeyRef.Key = "public"
-					expected, err = kubernetes.GetSecretData(cli, namespace.Name, expectedKeyRef)
+					expected, err = kubernetes.GetSecretData(ctx, cli, namespace.Name, expectedKeyRef)
 					Expect(err).To(Not(HaveOccurred()))
 				case "ctfe.pub":
 					expectedKeyRef := s.Spec.Ctlog.PrivateKeyRef.DeepCopy()
 					expectedKeyRef.Key = "public"
-					expected, err = kubernetes.GetSecretData(cli, namespace.Name, expectedKeyRef)
+					expected, err = kubernetes.GetSecretData(ctx, cli, namespace.Name, expectedKeyRef)
 					Expect(err).To(Not(HaveOccurred()))
 				case "tsa.certchain.pem":
 					expectedKeyRef := s.Spec.TimestampAuthority.Signer.CertificateChain.CertificateChainRef.DeepCopy()
 					expectedKeyRef.Key = "certificateChain"
-					expected, err = kubernetes.GetSecretData(cli, namespace.Name, expectedKeyRef)
+					expected, err = kubernetes.GetSecretData(ctx, cli, namespace.Name, expectedKeyRef)
 					Expect(err).To(Not(HaveOccurred()))
 				}
 				Expect(bytes.TrimSpace(actual)).To(Equal(bytes.TrimSpace(expected)))

--- a/test/e2e/lifecycle/key_rotation_test.go
+++ b/test/e2e/lifecycle/key_rotation_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Key rotation test", Ordered, func() {
 		It("Download fulcio cert", func(ctx SpecContext) {
 			f := fulcio.Get(ctx, cli, namespace.Name, s.Name)
 			Expect(f).ToNot(BeNil())
-			oldFulcioCert, err = kubernetes.GetSecretData(cli, namespace.Name, f.Status.Certificate.CARef)
+			oldFulcioCert, err = kubernetes.GetSecretData(ctx, cli, namespace.Name, f.Status.Certificate.CARef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(oldFulcioCert).ToNot(BeEmpty())
 		})
@@ -184,7 +184,7 @@ var _ = Describe("Key rotation test", Ordered, func() {
 		It("Download rekor signer", func(ctx SpecContext) {
 			r := rekor.Get(ctx, cli, namespace.Name, s.Name)
 			Expect(r).ToNot(BeNil())
-			signerSecret, err := kubernetes.GetSecret(cli, namespace.Name, r.Status.Signer.KeyRef.Name)
+			signerSecret, err := kubernetes.GetSecret(ctx, cli, namespace.Name, r.Status.Signer.KeyRef.Name)
 			Expect(err).ToNot(HaveOccurred())
 
 			oldRekorSigner = signerSecret.Data[r.Status.Signer.KeyRef.Key]
@@ -397,7 +397,7 @@ var _ = Describe("Key rotation test", Ordered, func() {
 		It("Download tsa cert", func(ctx SpecContext) {
 			t := tsa.Get(ctx, cli, namespace.Name, s.Name)
 			Expect(t).ToNot(BeNil())
-			oldTsa, err = kubernetes.GetSecretData(cli, namespace.Name, t.Status.Signer.CertificateChainRef)
+			oldTsa, err = kubernetes.GetSecretData(ctx, cli, namespace.Name, t.Status.Signer.CertificateChainRef)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(oldTsa).ToNot(BeEmpty())
 		})


### PR DESCRIPTION
## Why

`GetSecret` and `GetSecretData` hardcoded `context.TODO()` internally because their signatures never accepted a `ctx`, unlike sibling functions in the same file (`ExistsSecret`, `FindSecret`, `ListSecrets`) which all take `ctx` as their first parameter. Every caller lost cancellation/deadline propagation as a result.

## What

- `GetSecret` and `GetSecretData` now take `ctx context.Context` as their first parameter, matching the sibling convention.
- Threaded `ctx` through every production call site, adding a `ctx` parameter to internal helpers that didn't have one yet (`server_config.go`: `validateExistingSecret`, `handlePrivateKey`, `handleRootCertificates`, `configMatchingAnnotations`).
- `ctlogTrustMaterialResolver.Resolve` no longer discards its `ctx` parameter — it now passes it through to `GetSecretData`.
- Updated unit and e2e test call sites to pass their existing `ctx`/`t.Context()`.