### PR TITLE
fix: correct context handling in Ginkgo envtest suites

### DIFF
--- a/internal/controller/ctlog/ctlog_controller_test.go
+++ b/internal/controller/ctlog/ctlog_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ctlog
 
 import (
-	"context"
 	"time"
 
 	rhtasv1 "github.com/securesign/operator/api/v1"
@@ -49,8 +48,6 @@ var _ = Describe("CTlog controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -61,13 +58,13 @@ var _ = Describe("CTlog controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &rhtasv1.CTlog{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind CTlog")
 			found := &rhtasv1.CTlog{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
@@ -84,7 +81,7 @@ var _ = Describe("CTlog controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for CTlog", func() {
+		It("should successfully reconcile a custom resource for CTlog", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind CTlog")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/ctlog/ctlog_controller_test.go
+++ b/internal/controller/ctlog/ctlog_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ctlog
 
 import (
+	"context"
 	"time"
 
 	rhtasv1 "github.com/securesign/operator/api/v1"
@@ -70,9 +71,9 @@ var _ = Describe("CTlog controller", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -107,27 +108,27 @@ var _ = Describe("CTlog controller", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				found := &rhtasv1.CTlog{}
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Status conditions are initialized")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, constants.ReadyCondition, metav1.ConditionFalse)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Creating trillian service")
 			Expect(suite.Client().Create(ctx, kubernetes.CreateService(Namespace, trillian.LogserverDeploymentName, trillian.ServerPortName, trillian.ServerPort, trillian.ServerPort, labels.ForComponent(trillian.LogServerComponentName, instance.Name)))).To(Succeed())
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Creating.String()))
+			}).WithContext(ctx).Should(Equal(state.Creating.String()))
 
 			By("Creating Fulcio CR with root certificate for autodiscovery")
 			fulcioCR := &rhtasv1.Fulcio{
@@ -155,35 +156,35 @@ var _ = Describe("CTlog controller", func() {
 			})
 			Expect(suite.Client().Status().Update(ctx, fulcioCR)).To(Succeed())
 
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Creating.String()))
+			}).WithContext(ctx).Should(Equal(state.Creating.String()))
 
 			By("Key Secret is created")
 			found := &rhtasv1.CTlog{}
-			Eventually(func(g Gomega) *rhtasv1.SecretKeySelector {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.SecretKeySelector {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.PrivateKeyRef
-			}).Should(Not(BeNil()))
-			Eventually(func() error {
+			}).WithContext(ctx).Should(Not(BeNil()))
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.PrivateKeyRef.Name, Namespace: Namespace}, &corev1.Secret{})
-			}).Should(Not(HaveOccurred()))
+			}).WithContext(ctx).Should(Not(HaveOccurred()))
 
 			deployment := &appsv1.Deployment{}
 			By("Checking if Deployment was successfully created in the reconciliation")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Checking if Service was successfully created in the reconciliation")
 			service := &corev1.Service{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.ComponentName, Namespace: Namespace}, service)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(80)))
 
 			By("Move to Ready phase")
@@ -191,32 +192,32 @@ var _ = Describe("CTlog controller", func() {
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Waiting until CTlog instance is Ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Public key has been resolved into status")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.PublicKey).ShouldNot(BeEmpty())
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Checking if controller will return deployment to desired state")
 			deployment = &appsv1.Deployment{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			replicas := int32(99)
 			deployment.Spec.Replicas = &replicas
 			Expect(suite.Client().Status().Update(ctx, deployment)).Should(Succeed())
-			Eventually(func(g Gomega) int32 {
+			Eventually(func(g Gomega, ctx context.Context) int32 {
 				deployment = &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)).Should(Succeed())
 				return *deployment.Spec.Replicas
-			}).Should(Equal(int32(1)))
+			}).WithContext(ctx).Should(Equal(int32(1)))
 		})
 	})
 })

--- a/internal/controller/ctlog/ctlog_hot_update_test.go
+++ b/internal/controller/ctlog/ctlog_hot_update_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ctlog
 
 import (
+	"context"
 	_ "embed"
 	"time"
 
@@ -77,9 +78,9 @@ var _ = Describe("CTlog update test", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 3*time.Minute, time.Second).Should(Succeed())
+			}, 3*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -114,10 +115,10 @@ var _ = Describe("CTlog update test", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				found := &rhtasv1.CTlog{}
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Creating trillian service")
 			Expect(suite.Client().Create(ctx, kubernetes.CreateService(Namespace, trillian.LogserverDeploymentName, trillian.ServerPortName, trillian.ServerPort, trillian.ServerPort, labels.ForComponent(trillian.LogServerComponentName, instance.Name)))).To(Succeed())
@@ -150,29 +151,29 @@ var _ = Describe("CTlog update test", func() {
 
 			deployment := &appsv1.Deployment{}
 			By("Checking if Deployment was successfully created in the reconciliation")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Move to Ready phase")
 			// Workaround to succeed condition for Ready phase
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Waiting until CTlog instance is ReadyCondition")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Public key has been resolved from operator-generated key")
 			var originalPublicKey string
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.PublicKey).ShouldNot(BeEmpty())
 				originalPublicKey = found.Status.PublicKey
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Private key has changed")
 			key, err := utils.CreatePrivateKey()
@@ -188,7 +189,7 @@ var _ = Describe("CTlog update test", func() {
 
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)).To(Succeed())
 			found := &rhtasv1.CTlog{}
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				found.Spec.PrivateKeyRef = &rhtasv1.SecretKeySelector{
 					LocalObjectReference: rhtasv1.LocalObjectReference{
@@ -204,21 +205,21 @@ var _ = Describe("CTlog update test", func() {
 				}
 				found.Spec.PrivateKeyPasswordRef = nil //nolint:staticcheck
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("CTLog status field changed")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.PrivateKeyRef.Name
-			}).Should(Equal("key-secret"))
+			}).WithContext(ctx).Should(Equal("key-secret"))
 
 			By("CTL deployment is updated")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				updated := &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, updated)).To(Succeed())
 				return equality.Semantic.DeepDerivative(deployment.Spec.Template.Spec.Volumes, updated.Spec.Template.Spec.Volumes)
-			}).Should(BeFalse())
+			}).WithContext(ctx).Should(BeFalse())
 
 			By("Simulate deployment controller: mark updated deployment as ready")
 			deployment = &appsv1.Deployment{}
@@ -226,22 +227,22 @@ var _ = Describe("CTlog update test", func() {
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Rotated public key is flagged as drifted, not silently accepted")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, trustmaterial.TrustMaterialCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(trustmaterial.ReasonDrifted))
+			}).WithContext(ctx).Should(Equal(trustmaterial.ReasonDrifted))
 
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.PublicKey
-			}).Should(Equal(originalPublicKey))
+			}).WithContext(ctx).Should(Equal(originalPublicKey))
 
 			By("Acknowledging the drift")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				if found.Annotations == nil {
@@ -249,16 +250,16 @@ var _ = Describe("CTlog update test", func() {
 				}
 				found.Annotations[annotations.RefreshTrustMaterial] = "true"
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Public key status updated after key change")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				found := &rhtasv1.CTlog{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.PublicKey).ShouldNot(BeEmpty())
 				g.Expect(found.Status.PublicKey).ShouldNot(Equal(originalPublicKey))
 				g.Expect(found.Status.PublicKey).Should(Equal(string(key.PublicKey)))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 		})
 	})
 })

--- a/internal/controller/ctlog/ctlog_hot_update_test.go
+++ b/internal/controller/ctlog/ctlog_hot_update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ctlog
 
 import (
-	"context"
 	_ "embed"
 	"time"
 
@@ -57,8 +56,6 @@ var _ = Describe("CTlog update test", func() {
 			Namespace = "update"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Namespace,
@@ -68,13 +65,13 @@ var _ = Describe("CTlog update test", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &rhtasv1.CTlog{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind CTlog")
 			found := &rhtasv1.CTlog{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
@@ -91,7 +88,7 @@ var _ = Describe("CTlog update test", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for CTlog", func() {
+		It("should successfully reconcile a custom resource for CTlog", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind CTlog")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/ctlog/suite_test.go
+++ b/internal/controller/ctlog/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/fulcio/fulcio_controller_test.go
+++ b/internal/controller/fulcio/fulcio_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fulcio
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -110,9 +111,9 @@ var _ = Describe("Fulcio controller", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -169,26 +170,26 @@ var _ = Describe("Fulcio controller", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				found := &rhtasv1.Fulcio{}
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Status conditions are initialized")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, constants.ReadyCondition, metav1.ConditionFalse)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Pending phase until password key is resolved")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Pending.String()))
+			}).WithContext(ctx).Should(Equal(state.Pending.String()))
 
 			By("Creating password secret with cert password")
 			Expect(suite.Client().Create(ctx, &corev1.Secret{
@@ -205,89 +206,89 @@ var _ = Describe("Fulcio controller", func() {
 			By("Secrets are resolved")
 			certSecretName := fmt.Sprintf("fulcio-cert-config-%s", Name)
 			var certSecret *corev1.Secret
-			Eventually(func(g Gomega) *corev1.Secret {
+			Eventually(func(g Gomega, ctx context.Context) *corev1.Secret {
 				certSecret = &corev1.Secret{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: certSecretName, Namespace: Namespace}, certSecret)).To(Succeed())
 				return certSecret
-			}).Should(Not(BeNil()))
+			}).WithContext(ctx).Should(Not(BeNil()))
 
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, actions.CertCondition)
-			}).Should(BeTrue())
-			Eventually(func(g Gomega) string {
+			}).WithContext(ctx).Should(BeTrue())
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Certificate.CARef.Name
-			}).Should(Equal(certSecret.Name))
-			Eventually(func(g Gomega) string {
+			}).WithContext(ctx).Should(Equal(certSecret.Name))
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Certificate.PrivateKeyRef.Name
-			}).Should(Equal(certSecret.Name))
-			Eventually(func(g Gomega) string {
+			}).WithContext(ctx).Should(Equal(certSecret.Name))
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Certificate.PrivateKeyPasswordRef.Name
-			}).Should(Equal("password-secret"))
+			}).WithContext(ctx).Should(Equal("password-secret"))
 
 			Expect(certSecret.Data).To(And(HaveKey("private"), HaveKey("cert")))
 
 			deployment := &appsv1.Deployment{}
 			By("Checking if Deployment was successfully created in the reconciliation")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Move to Ready phase")
 			// Workaround to succeed condition for Ready phase
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Waiting until Fulcio instance is Ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Root certificate has been resolved into status")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				found := &rhtasv1.Fulcio{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.CertificateChain).Should(Equal(expectedRootCert))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Checking if Service was successfully created in the reconciliation")
 			service := &corev1.Service{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, service)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(80)))
 			Expect(service.Spec.Ports[1].Port).Should(Equal(int32(5554)))
 
 			By("Checking if Ingress was successfully created in the reconciliation")
 			ingress := &v1.Ingress{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, ingress)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			Expect(ingress.Spec.Rules[0].Host).Should(Equal("fulcio.localhost"))
 			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name).Should(Equal(service.Name))
 			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).Should(Equal(actions.ServerPortName))
 
 			By("Checking if controller will return deployment to desired state")
 			deployment = &appsv1.Deployment{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			replicas := int32(99)
 			deployment.Spec.Replicas = &replicas
 			Expect(suite.Client().Status().Update(ctx, deployment)).Should(Succeed())
-			Eventually(func(g Gomega) int32 {
+			Eventually(func(g Gomega, ctx context.Context) int32 {
 				deployment = &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)).Should(Succeed())
 				return *deployment.Spec.Replicas
-			}).Should(Equal(int32(1)))
+			}).WithContext(ctx).Should(Equal(int32(1)))
 		})
 	})
 })

--- a/internal/controller/fulcio/fulcio_controller_test.go
+++ b/internal/controller/fulcio/fulcio_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fulcio
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -58,7 +57,6 @@ var _ = Describe("Fulcio controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
 		var mockClient *http.Client
 
 		namespace := &corev1.Namespace{
@@ -71,13 +69,13 @@ var _ = Describe("Fulcio controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &rhtasv1.Fulcio{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating TrustedCA ConfigMap")
 			Expect(suite.Client().Create(ctx, &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "trusted-ca-bundle", Namespace: Namespace},
@@ -106,7 +104,7 @@ var _ = Describe("Fulcio controller", func() {
 			})
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Fulcio")
 			found := &rhtasv1.Fulcio{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
@@ -123,7 +121,7 @@ var _ = Describe("Fulcio controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Fulcio", func() {
+		It("should successfully reconcile a custom resource for Fulcio", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Fulcio")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/fulcio/fulcio_hot_update_test.go
+++ b/internal/controller/fulcio/fulcio_hot_update_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fulcio
 
 import (
+	"context"
 	_ "embed"
 	"io"
 	"net/http"
@@ -100,9 +101,9 @@ var _ = Describe("Fulcio hot update", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -148,64 +149,66 @@ var _ = Describe("Fulcio hot update", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				found := &rhtasv1.Fulcio{}
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			deployment := &appsv1.Deployment{}
 			By("Checking if Deployment was successfully created in the reconciliation")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Move to Ready phase")
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Waiting until Fulcio instance is Ready")
 			found := &rhtasv1.Fulcio{}
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Verify cert condition is resolved")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, actions.CertCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Root certificate has been resolved into status")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.CertificateChain).Should(Equal(expectedRootCert))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Config update")
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)).To(Succeed())
 
 			By("Update OIDC")
-			Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
-			found.Spec.Config.OIDCIssuers[0] = rhtasv1.OIDCIssuer{
-				IssuerURL: "fake",
-				Issuer:    "fake",
-				ClientID:  "fake",
-				Type:      "email",
-			}
-			Expect(suite.Client().Update(ctx, found)).To(Succeed())
+			Eventually(func(g Gomega, ctx context.Context) error {
+				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
+				found.Spec.Config.OIDCIssuers[0] = rhtasv1.OIDCIssuer{
+					IssuerURL: "fake",
+					Issuer:    "fake",
+					ClientID:  "fake",
+					Type:      "email",
+				}
+				return suite.Client().Update(ctx, found)
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Fulcio deployment is updated")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				updated := &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, updated)).To(Succeed())
 				return equality.Semantic.DeepDerivative(deployment.Spec.Template.Spec.Volumes, updated.Spec.Template.Spec.Volumes)
-			}).Should(BeFalse())
+			}).WithContext(ctx).Should(BeFalse())
 
 			By("Root certificate still present after config update")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.CertificateChain).Should(Equal(expectedRootCert))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Snapshot deployment state before rotating the trust bundle")
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)).To(Succeed())
@@ -226,7 +229,7 @@ var _ = Describe("Fulcio hot update", func() {
 			})
 
 			By("Triggering another spec change to force re-resolution")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				found.Spec.Config.OIDCIssuers[0] = rhtasv1.OIDCIssuer{
 					IssuerURL: "fake2",
@@ -235,14 +238,14 @@ var _ = Describe("Fulcio hot update", func() {
 					Type:      "email",
 				}
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Fulcio deployment is updated again")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				updated := &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, updated)).To(Succeed())
 				return equality.Semantic.DeepDerivative(deployment.Spec.Template.Spec.Volumes, updated.Spec.Template.Spec.Volumes)
-			}).Should(BeFalse())
+			}).WithContext(ctx).Should(BeFalse())
 
 			By("Move to Ready phase")
 			deployment = &appsv1.Deployment{}
@@ -250,33 +253,33 @@ var _ = Describe("Fulcio hot update", func() {
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Rotated root certificate is flagged as drifted, not silently accepted")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, trustmaterial.TrustMaterialCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(trustmaterial.ReasonDrifted))
+			}).WithContext(ctx).Should(Equal(trustmaterial.ReasonDrifted))
 
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.CertificateChain
-			}).ShouldNot(Equal(rotatedRootCert))
+			}).WithContext(ctx).ShouldNot(Equal(rotatedRootCert))
 
 			By("Acknowledging the drift")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				if found.Annotations == nil {
 					found.Annotations = map[string]string{}
 				}
 				found.Annotations[annotations.RefreshTrustMaterial] = "true"
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Root certificate updated after acknowledgement")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.CertificateChain).Should(Equal(rotatedRootCert))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 		})
 	})
 })

--- a/internal/controller/fulcio/fulcio_hot_update_test.go
+++ b/internal/controller/fulcio/fulcio_hot_update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package fulcio
 
 import (
-	"context"
 	_ "embed"
 	"io"
 	"net/http"
@@ -60,8 +59,6 @@ var _ = Describe("Fulcio hot update", func() {
 			Namespace = "update"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Namespace,
@@ -71,7 +68,7 @@ var _ = Describe("Fulcio hot update", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &rhtasv1.Fulcio{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
@@ -97,7 +94,7 @@ var _ = Describe("Fulcio hot update", func() {
 			})
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Fulcio")
 			found := &rhtasv1.Fulcio{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
@@ -114,7 +111,7 @@ var _ = Describe("Fulcio hot update", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Fulcio", func() {
+		It("should successfully reconcile a custom resource for Fulcio", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Fulcio")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/fulcio/suite_test.go
+++ b/internal/controller/fulcio/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/rekor/rekor_attestation_test.go
+++ b/internal/controller/rekor/rekor_attestation_test.go
@@ -85,9 +85,9 @@ var _ = Describe("Rekor controller", func() {
 			err := suite.Client().Get(ctx, types.NamespacedName{Name: Name, Namespace: namespace.Name}, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			By("Deleting the Namespace to perform the tests")
 			_ = suite.Client().Delete(ctx, &namespace)
@@ -111,10 +111,10 @@ var _ = Describe("Rekor controller", func() {
 
 			By("Rekor server PVC created")
 			found := &rhtasv1.Rekor{}
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, client.ObjectKeyFromObject(instance), found)).Should(Succeed())
 				return found.Status.PvcName
-			}).Should(Not(BeEmpty()))
+			}).WithContext(ctx).Should(Not(BeEmpty()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.PvcName, Namespace: namespace.Name}, &corev1.PersistentVolumeClaim{})).Should(Succeed())
 
 			deployment := &appsv1.Deployment{}
@@ -162,10 +162,10 @@ var _ = Describe("Rekor controller", func() {
 
 			By("Rekor server PVC not created")
 			found := &rhtasv1.Rekor{}
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, client.ObjectKeyFromObject(instance), found)).Should(Succeed())
 				return found.Status.PvcName
-			}).Should(Not(BeEmpty()))
+			}).WithContext(ctx).Should(Not(BeEmpty()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.PvcName, Namespace: namespace.Name}, &corev1.PersistentVolumeClaim{})).Should(HaveOccurred())
 
 			deployment := &appsv1.Deployment{}
@@ -237,38 +237,38 @@ func deployAndVerify(ctx context.Context, instance *rhtasv1.Rekor) {
 	Expect(suite.Client().Create(ctx, instance)).To(Not(HaveOccurred()))
 
 	By("Checking if the custom resource was successfully created")
-	Eventually(func() error {
+	Eventually(func(ctx context.Context) error {
 		return suite.Client().Get(ctx, client.ObjectKeyFromObject(instance), &rhtasv1.Rekor{})
-	}).Should(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 
 	By("Status conditions are initialized")
-	Eventually(func(g Gomega) bool {
+	Eventually(func(g Gomega, ctx context.Context) bool {
 		found := &rhtasv1.Rekor{}
 		g.Expect(suite.Client().Get(ctx, client.ObjectKeyFromObject(instance), found)).Should(Succeed())
 		return meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, constants.ReadyCondition, metav1.ConditionFalse)
-	}).Should(BeTrue())
+	}).WithContext(ctx).Should(BeTrue())
 
 	By("Rekor signer created")
 	found := &rhtasv1.Rekor{}
-	Eventually(func(g Gomega) *rhtasv1.SecretKeySelector {
+	Eventually(func(g Gomega, ctx context.Context) *rhtasv1.SecretKeySelector {
 		g.Expect(suite.Client().Get(ctx, client.ObjectKeyFromObject(instance), found)).To(Succeed())
 		return found.Status.Signer.KeyRef
-	}).Should(Not(BeNil()))
+	}).WithContext(ctx).Should(Not(BeNil()))
 	Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.Signer.KeyRef.Name, Namespace: instance.Namespace}, &corev1.Secret{})).Should(Succeed())
 
 	By("Rekor server deployment created")
-	Eventually(func() error {
+	Eventually(func(ctx context.Context) error {
 		return suite.Client().Get(ctx, types.NamespacedName{Name: actions.ServerDeploymentName, Namespace: instance.Namespace}, &appsv1.Deployment{})
-	}).Should(Succeed())
+	}).WithContext(ctx).Should(Succeed())
 
 	By("Waiting until Rekor instance is Initialization")
-	Eventually(func(g Gomega) string {
+	Eventually(func(g Gomega, ctx context.Context) string {
 		found := &rhtasv1.Rekor{}
 		g.Expect(suite.Client().Get(ctx, client.ObjectKeyFromObject(instance), found)).Should(Succeed())
 		cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 		g.Expect(cond).ToNot(BeNil())
 		return cond.Reason
-	}).Should(Equal(state.Initialize.String()))
+	}).WithContext(ctx).Should(Equal(state.Initialize.String()))
 
 	By("Move to Ready phase")
 	// Workaround to succeed condition for Ready phase
@@ -279,11 +279,11 @@ func deployAndVerify(ctx context.Context, instance *rhtasv1.Rekor) {
 	}
 
 	By("Waiting until Rekor instance is Ready")
-	Eventually(func(g Gomega) bool {
+	Eventually(func(g Gomega, ctx context.Context) bool {
 		found := &rhtasv1.Rekor{}
 		g.Expect(suite.Client().Get(ctx, client.ObjectKeyFromObject(instance), found)).Should(Succeed())
 		return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-	}).Should(BeTrue())
+	}).WithContext(ctx).Should(BeTrue())
 }
 
 func findVolumeByName(volumes []corev1.Volume, name string) *corev1.Volume {

--- a/internal/controller/rekor/rekor_controller_test.go
+++ b/internal/controller/rekor/rekor_controller_test.go
@@ -18,7 +18,6 @@ package rekor
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"time"
@@ -57,8 +56,6 @@ var _ = Describe("Rekor controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -69,7 +66,7 @@ var _ = Describe("Rekor controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &rhtasv1.Rekor{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
@@ -93,7 +90,7 @@ var _ = Describe("Rekor controller", func() {
 			})
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Rekor")
 			found := &rhtasv1.Rekor{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
@@ -110,7 +107,7 @@ var _ = Describe("Rekor controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Rekor", func() {
+		It("should successfully reconcile a custom resource for Rekor", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Rekor")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/rekor/rekor_controller_test.go
+++ b/internal/controller/rekor/rekor_controller_test.go
@@ -18,6 +18,7 @@ package rekor
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"time"
@@ -96,9 +97,9 @@ var _ = Describe("Rekor controller", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -142,76 +143,76 @@ var _ = Describe("Rekor controller", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				found := &rhtasv1.Rekor{}
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Status conditions are initialized")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, constants.ReadyCondition, metav1.ConditionFalse)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Rekor signer created")
 			found := &rhtasv1.Rekor{}
-			Eventually(func(g Gomega) *rhtasv1.SecretKeySelector {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.SecretKeySelector {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).To(Succeed())
 				return found.Status.Signer.KeyRef
-			}).Should(Not(BeNil()))
+			}).WithContext(ctx).Should(Not(BeNil()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.Signer.KeyRef.Name, Namespace: Namespace}, &corev1.Secret{})).Should(Succeed())
 
 			By("Rekor server PVC created")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.PvcName
-			}).Should(Not(BeEmpty()))
+			}).WithContext(ctx).Should(Not(BeEmpty()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.PvcName, Namespace: Namespace}, &corev1.PersistentVolumeClaim{})).Should(Succeed())
 
 			By("Rekor server SVC created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.ServerDeploymentName, Namespace: Namespace}, &corev1.Service{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Rekor server deployment created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.ServerDeploymentName, Namespace: Namespace}, &appsv1.Deployment{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Redis Deployment created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.RedisDeploymentName, Namespace: Namespace}, &appsv1.Deployment{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Redis svc created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.RedisDeploymentName, Namespace: Namespace}, &corev1.Service{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("UI Deployment created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.SearchUiDeploymentName, Namespace: Namespace}, &appsv1.Deployment{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("UI svc created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.SearchUiDeploymentName, Namespace: Namespace}, &corev1.Service{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Backfill Redis Cronjob Created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.BackfillRedisCronJobName, Namespace: Namespace}, &batchv1.CronJob{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Waiting until Rekor instance is Initialization")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Initialize.String()))
+			}).WithContext(ctx).Should(Equal(state.Initialize.String()))
 
 			By("Move to Ready phase")
 			// Workaround to succeed condition for Ready phase
@@ -222,32 +223,32 @@ var _ = Describe("Rekor controller", func() {
 			}
 
 			By("Public key status has been resolved")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).To(Succeed())
 				g.Expect(found.Status.PublicKey).Should(Equal(testPubKeyPEM))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Waiting until Rekor instance is Ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Checking if controller will return deployment to desired state")
 			deployment := &appsv1.Deployment{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.ServerDeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			replicas := int32(99)
 			deployment.Spec.Replicas = &replicas
 			Expect(suite.Client().Status().Update(ctx, deployment)).Should(Succeed())
-			Eventually(func(g Gomega) int32 {
+			Eventually(func(g Gomega, ctx context.Context) int32 {
 				deployment = &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.ServerDeploymentName, Namespace: Namespace}, deployment)).Should(Succeed())
 				return *deployment.Spec.Replicas
-			}).Should(Equal(int32(1)))
+			}).WithContext(ctx).Should(Equal(int32(1)))
 		})
 	})
 })

--- a/internal/controller/rekor/rekor_hot_update_test.go
+++ b/internal/controller/rekor/rekor_hot_update_test.go
@@ -18,7 +18,6 @@ package rekor
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"time"
@@ -58,8 +57,6 @@ var _ = Describe("Rekor hot update test", func() {
 			Namespace = "update"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Namespace,
@@ -69,7 +66,7 @@ var _ = Describe("Rekor hot update test", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		instance := &rhtasv1.Rekor{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
@@ -93,7 +90,7 @@ var _ = Describe("Rekor hot update test", func() {
 			})
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Rekor")
 			found := &rhtasv1.Rekor{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
@@ -110,7 +107,7 @@ var _ = Describe("Rekor hot update test", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Rekor", func() {
+		It("should successfully reconcile a custom resource for Rekor", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Rekor")
 			err := suite.Client().Get(ctx, typeNamespaceName, instance)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/rekor/rekor_hot_update_test.go
+++ b/internal/controller/rekor/rekor_hot_update_test.go
@@ -18,6 +18,7 @@ package rekor
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"time"
@@ -96,9 +97,9 @@ var _ = Describe("Rekor hot update test", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -140,28 +141,28 @@ var _ = Describe("Rekor hot update test", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				found := &rhtasv1.Rekor{}
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Rekor signer created")
 			found := &rhtasv1.Rekor{}
-			Eventually(func(g Gomega) *rhtasv1.SecretKeySelector {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.SecretKeySelector {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).To(Succeed())
 				return found.Status.Signer.KeyRef
-			}).Should(Not(BeNil()))
+			}).WithContext(ctx).Should(Not(BeNil()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.Signer.KeyRef.Name, Namespace: Namespace}, &corev1.Secret{})).Should(Succeed())
 
 			By("Waiting until Rekor instance is Initialization")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
 				return cond.Reason
-			}).Should(Equal(state.Initialize.String()))
+			}).WithContext(ctx).Should(Equal(state.Initialize.String()))
 
 			By("Move to Ready phase")
 			deployments := &appsv1.DeploymentList{}
@@ -172,25 +173,25 @@ var _ = Describe("Rekor hot update test", func() {
 			// Workaround to succeed condition for Ready phase
 
 			By("Public key status resolved")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.PublicKey).Should(Equal(testPubKeyPEM))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Waiting until Rekor instance is Ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Save the Deployment configuration")
 			deployment := &appsv1.Deployment{}
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.ServerDeploymentName, Namespace: Namespace}, deployment)).Should(Succeed())
 
 			By("Patch the signer key")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				found.Spec.Signer.KeyRef = &rhtasv1.SecretKeySelector{
@@ -200,7 +201,7 @@ var _ = Describe("Rekor hot update test", func() {
 					Key: "private",
 				}
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Move to CreatingPhase by creating trillian service")
 			Expect(suite.Client().Create(ctx, &corev1.Secret{
@@ -228,11 +229,11 @@ var _ = Describe("Rekor hot update test", func() {
 			})
 
 			By("Rekor deployment is updated")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				updated := &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.ServerDeploymentName, Namespace: Namespace}, updated)).To(Succeed())
 				return equality.Semantic.DeepDerivative(deployment.Spec.Template.Spec.Volumes, updated.Spec.Template.Spec.Volumes)
-			}).Should(BeFalse())
+			}).WithContext(ctx).Should(BeFalse())
 
 			By("Move to Ready phase")
 			deployments = &appsv1.DeploymentList{}
@@ -242,32 +243,32 @@ var _ = Describe("Rekor hot update test", func() {
 			}
 
 			By("Secret key is resolved")
-			Eventually(func(g Gomega) *rhtasv1.SecretKeySelector {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.SecretKeySelector {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Signer.KeyRef
-			}).Should(Not(BeNil()))
-			Eventually(func(g Gomega) string {
+			}).WithContext(ctx).Should(Not(BeNil()))
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Signer.KeyRef.Name
-			}).Should(Equal("key-secret"))
+			}).WithContext(ctx).Should(Equal("key-secret"))
 
 			By("Rotated public key is flagged as drifted, not silently accepted")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, trustmaterial.TrustMaterialCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(trustmaterial.ReasonDrifted))
+			}).WithContext(ctx).Should(Equal(trustmaterial.ReasonDrifted))
 
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.PublicKey
-			}).ShouldNot(Equal(rotatedPubKeyPEM))
+			}).WithContext(ctx).ShouldNot(Equal(rotatedPubKeyPEM))
 
 			By("Acknowledging the drift")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				if found.Annotations == nil {
@@ -275,14 +276,14 @@ var _ = Describe("Rekor hot update test", func() {
 				}
 				found.Annotations[annotations.RefreshTrustMaterial] = "true"
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Public key status updated after acknowledgement")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				found := &rhtasv1.Rekor{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.PublicKey).Should(Equal(rotatedPubKeyPEM))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 		})
 	})

--- a/internal/controller/rekor/suite_test.go
+++ b/internal/controller/rekor/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/testonly/suite.go
+++ b/internal/controller/testonly/suite.go
@@ -62,7 +62,7 @@ func ControllerSuite(supplier controller.Constructor) controllerSuite {
 }
 
 func (t *controllerSuite) BeforeSuite() {
-	t.ctx, t.cancel = context.WithCancel(context.TODO())
+	t.ctx, t.cancel = context.WithCancel(context.Background())
 
 	By("bootstrapping test environment")
 	t.testEnv = &envtest.Environment{
@@ -127,7 +127,7 @@ func (t *controllerSuite) BeforeSuite() {
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
-		elog := logf.FromContext(context.TODO()).WithName("Event")
+		elog := logf.FromContext(context.Background()).WithName("Event")
 		for msg := range recorder.Events {
 			elog.Info(msg)
 		}

--- a/internal/controller/trillian/suite_test.go
+++ b/internal/controller/trillian/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/trillian/trillian_controller_test.go
+++ b/internal/controller/trillian/trillian_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package trillian
 
 import (
+	"context"
 	"time"
 
 	"github.com/securesign/operator/internal/constants"
@@ -68,9 +69,9 @@ var _ = Describe("Trillian controller", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -105,67 +106,67 @@ var _ = Describe("Trillian controller", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				found := &rhtasv1.Trillian{}
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Status conditions are initialized")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Trillian{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, constants.ReadyCondition, metav1.ConditionFalse)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 			found := &rhtasv1.Trillian{}
 
 			By("Database secret created")
-			Eventually(func(g Gomega) *rhtasv1.LocalObjectReference {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.LocalObjectReference {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Db.DatabaseSecretRef
-			}).Should(Not(BeNil()))
+			}).WithContext(ctx).Should(Not(BeNil()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.Db.DatabaseSecretRef.Name, Namespace: Namespace}, &corev1.Secret{})).Should(Succeed())
 
 			By("Database PVC created")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Db.PvcName
-			}).Should(Not(BeEmpty()))
+			}).WithContext(ctx).Should(Not(BeEmpty()))
 
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.Db.PvcName, Namespace: Namespace}, &corev1.PersistentVolumeClaim{})).Should(Succeed())
 
 			By("Database SVC created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: "trillian-mysql", Namespace: Namespace}, &corev1.Service{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Database Deployment created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DbDeploymentName, Namespace: Namespace}, &appsv1.Deployment{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("LogServer Deployment created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.LogserverDeploymentName, Namespace: Namespace}, &appsv1.Deployment{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("LogServerSvc Deployment created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.LogserverDeploymentName, Namespace: Namespace}, &corev1.Service{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("LogSigner Deployment created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.LogsignerDeploymentName, Namespace: Namespace}, &appsv1.Deployment{})
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Waiting until Trillian instance is Initialization")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Trillian{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Initialize.String()))
+			}).WithContext(ctx).Should(Equal(state.Initialize.String()))
 
 			By("Move to Ready phase")
 			// Workaround to succeed condition for Ready phase
@@ -176,25 +177,25 @@ var _ = Describe("Trillian controller", func() {
 			}
 
 			By("Waiting until Trillian instance is Ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Trillian{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Checking if controller will return deployment to desired state")
 			deployment := &appsv1.Deployment{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.LogserverDeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			replicas := int32(99)
 			deployment.Spec.Replicas = &replicas
 			Expect(suite.Client().Status().Update(ctx, deployment)).Should(Succeed())
-			Eventually(func(g Gomega) int32 {
+			Eventually(func(g Gomega, ctx context.Context) int32 {
 				deployment = &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.LogserverDeploymentName, Namespace: Namespace}, deployment)).Should(Succeed())
 				return *deployment.Spec.Replicas
-			}).Should(Equal(int32(1)))
+			}).WithContext(ctx).Should(Equal(int32(1)))
 		})
 	})
 })

--- a/internal/controller/trillian/trillian_controller_test.go
+++ b/internal/controller/trillian/trillian_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package trillian
 
 import (
-	"context"
 	"time"
 
 	"github.com/securesign/operator/internal/constants"
@@ -47,8 +46,6 @@ var _ = Describe("Trillian controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -59,13 +56,13 @@ var _ = Describe("Trillian controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: Name, Namespace: Namespace}
 		trillian := &rhtasv1.Trillian{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Trillian")
 			found := &rhtasv1.Trillian{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
@@ -82,7 +79,7 @@ var _ = Describe("Trillian controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Trillian", func() {
+		It("should successfully reconcile a custom resource for Trillian", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Trillian")
 			err := suite.Client().Get(ctx, typeNamespaceName, trillian)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/tsa/suite_test.go
+++ b/internal/controller/tsa/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/tsa/timestampauthority_controller_test.go
+++ b/internal/controller/tsa/timestampauthority_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tsa
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -95,9 +96,9 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -157,93 +158,93 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Status conditions are initialized")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, constants.ReadyCondition, metav1.ConditionFalse)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Tsa signer should be resolved")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, actions.TSASignerCondition, metav1.ConditionTrue)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Certificate chain secret should be created")
-			Eventually(func(g Gomega) *rhtasv1.SecretKeySelector {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.SecretKeySelector {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Signer.CertificateChainRef
-			}).Should(Not(BeNil()))
+			}).WithContext(ctx).Should(Not(BeNil()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.Signer.CertificateChainRef.Name, Namespace: Namespace}, &corev1.Secret{})).Should(Succeed())
 
 			By("File Signer secret should be created")
-			Eventually(func(g Gomega) *rhtasv1.SecretKeySelector {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.SecretKeySelector {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Signer.FileSigner.PrivateKeyRef
-			}).Should(Not(BeNil()))
+			}).WithContext(ctx).Should(Not(BeNil()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.Signer.FileSigner.PrivateKeyRef.Name, Namespace: Namespace}, &corev1.Secret{})).Should(Succeed())
 
 			By("Should be in a creating phase")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Creating.String()))
+			}).WithContext(ctx).Should(Equal(state.Creating.String()))
 
 			By("NTP monitoring should be resolved")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Initialize.String()))
+			}).WithContext(ctx).Should(Equal(state.Initialize.String()))
 
 			By("NTP monitoring config should be created")
-			Eventually(func(g Gomega) *rhtasv1.LocalObjectReference {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.LocalObjectReference {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.NtpConfigRef
-			}).Should(Not(BeNil()))
+			}).WithContext(ctx).Should(Not(BeNil()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.NtpConfigRef.Name, Namespace: Namespace}, &corev1.ConfigMap{})).Should(Succeed())
 
 			By("Timestamp Authority service is created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, service)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(3000)))
 
 			By("Checking if Ingress was successfully created in the reconciliation")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, ingress)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			Expect(ingress.Spec.Rules[0].Host).Should(Equal("tsa.localhost"))
 			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name).Should(Equal(service.Name))
 			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).Should(Equal(actions.ServerPortName))
 
 			By("Timestamp Authority deployment is created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Move to Ready phase")
 			// Workaround to succeed condition for Ready phase
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Waiting until Timestamp Authority instance is Ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Certificate chain has been resolved into status")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.CertificateChain).Should(Equal(testCertChainPEM))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 		})
 	})

--- a/internal/controller/tsa/timestampauthority_controller_test.go
+++ b/internal/controller/tsa/timestampauthority_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tsa
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -55,8 +54,6 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			Namespace = "default"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -71,7 +68,7 @@ var _ = Describe("TimestampAuthority Controller", func() {
 		service := &corev1.Service{}
 		ingress := &v1.Ingress{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
@@ -93,7 +90,7 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			})
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Timestamp Authority")
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
@@ -109,7 +106,7 @@ var _ = Describe("TimestampAuthority Controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for the Timestamp Authority", func() {
+		It("should successfully reconcile a custom resource for the Timestamp Authority", func(ctx SpecContext) {
 			By("creating the custom resource for the Timestamp Authority")
 			err := suite.Client().Get(ctx, typeNamespaceName, timestampAuthority)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/tsa/tsa_hot_update_test.go
+++ b/internal/controller/tsa/tsa_hot_update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 import (
-	"context"
 	_ "embed"
 	"io"
 	"net/http"
@@ -62,8 +61,6 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			Namespace = "update"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: Namespace,
@@ -74,7 +71,7 @@ var _ = Describe("Timestamp Authority hot update", func() {
 		timestampAuthority := &rhtasv1.TimestampAuthority{}
 		found := &rhtasv1.TimestampAuthority{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
@@ -96,7 +93,7 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			})
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Timestamp Authority")
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
@@ -112,7 +109,7 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for the Timestamp Authority", func() {
+		It("should successfully reconcile a custom resource for the Timestamp Authority", func(ctx SpecContext) {
 			By("creating the custom resource for the Timestamp Authority")
 			err := suite.Client().Get(ctx, typeNamespaceName, timestampAuthority)
 			if err != nil && errors.IsNotFound(err) {

--- a/internal/controller/tsa/tsa_hot_update_test.go
+++ b/internal/controller/tsa/tsa_hot_update_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 */
 
 import (
+	"context"
 	_ "embed"
 	"io"
 	"net/http"
@@ -98,9 +99,9 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -161,33 +162,33 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			deployment := &appsv1.Deployment{}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Checking if Deployment was successfully created in the reconciliation")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Move to Ready phase")
 			// Workaround to succeed condition for Ready phase
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Waiting until Timestamp Authority is Ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Certificate chain has been resolved into status")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.CertificateChain).Should(Equal(testCertChainPEM))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Cert and Key rotation")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				found.Spec.Signer.CertificateChain = rhtasv1.CertificateChain{
 					CertificateChainRef: &rhtasv1.SecretKeySelector{
@@ -213,35 +214,35 @@ var _ = Describe("Timestamp Authority hot update", func() {
 					},
 				}
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Creating new certificate chain and signer keys")
 			secret := tsa.CreateSecrets(Namespace, "tsa-test-secret", true)
 			Expect(suite.Client().Create(ctx, secret)).NotTo(HaveOccurred())
 
 			By("Status field changed for cert chain")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Signer.CertificateChainRef.Name
-			}).Should(Equal("tsa-test-secret"))
+			}).WithContext(ctx).Should(Equal("tsa-test-secret"))
 
 			By("Status field changed for signer key")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.Signer.FileSigner.PasswordRef.Name
-			}).Should(Equal("tsa-test-secret"))
+			}).WithContext(ctx).Should(Equal("tsa-test-secret"))
 
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, actions.TSASignerCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Timestamp Authority deployment is updated")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				updated := &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, updated)).To(Succeed())
 				return equality.Semantic.DeepDerivative(deployment.Spec.Template.Spec.Volumes, updated.Spec.Template.Spec.Volumes)
-			}).Should(BeFalse())
+			}).WithContext(ctx).Should(BeFalse())
 
 			By("Move to Ready phase")
 			deployment = &appsv1.Deployment{}
@@ -252,36 +253,36 @@ var _ = Describe("Timestamp Authority hot update", func() {
 
 			By("NTP Monitoring update")
 			By("NTP monitoring config should be created")
-			Eventually(func(g Gomega) *rhtasv1.LocalObjectReference {
+			Eventually(func(g Gomega, ctx context.Context) *rhtasv1.LocalObjectReference {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.NtpConfigRef
-			}).Should(Not(BeNil()))
+			}).WithContext(ctx).Should(Not(BeNil()))
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: found.Status.NtpConfigRef.Name, Namespace: Namespace}, &corev1.ConfigMap{})).Should(Succeed())
 
 			By("Update NTP Config")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				err := suite.Client().Get(ctx, typeNamespaceName, found)
 				if err != nil {
 					return err
 				}
 				found.Spec.NTPMonitoring.Config.NumServers = 2
 				return suite.Client().Update(ctx, found)
-			}).WithTimeout(1 * time.Second).Should(Succeed())
+			}).WithContext(ctx).WithTimeout(1 * time.Second).Should(Succeed())
 
 			By("NTP monitoring should be resolved")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Initialize.String()))
+			}).WithContext(ctx).Should(Equal(state.Initialize.String()))
 
 			By("Timestamp Authority deployment is updated")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				updated := &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, updated)).To(Succeed())
 				return equality.Semantic.DeepDerivative(deployment.Spec.Template.Spec.Volumes, updated.Spec.Template.Spec.Volumes)
-			}).Should(BeFalse())
+			}).WithContext(ctx).Should(BeFalse())
 
 			By("Move to Ready phase")
 			deployment = &appsv1.Deployment{}
@@ -289,10 +290,10 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Certificate chain still present after rotation")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.CertificateChain).Should(Equal(testCertChainPEM))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Trust material rotated on the live service")
 			rotatedMockClient := &http.Client{}
@@ -308,18 +309,18 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			})
 
 			By("Triggering another spec change to force re-resolution")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				found.Spec.NTPMonitoring.Config.NumServers = 3
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Timestamp Authority deployment is updated again")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				updated := &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.DeploymentName, Namespace: Namespace}, updated)).To(Succeed())
 				return equality.Semantic.DeepDerivative(deployment.Spec.Template.Spec.Volumes, updated.Spec.Template.Spec.Volumes)
-			}).Should(BeFalse())
+			}).WithContext(ctx).Should(BeFalse())
 
 			By("Move to Ready phase")
 			deployment = &appsv1.Deployment{}
@@ -327,33 +328,33 @@ var _ = Describe("Timestamp Authority hot update", func() {
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Rotated certificate chain is flagged as drifted, not silently accepted")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, trustmaterial.TrustMaterialCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(trustmaterial.ReasonDrifted))
+			}).WithContext(ctx).Should(Equal(trustmaterial.ReasonDrifted))
 
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.CertificateChain
-			}).ShouldNot(Equal(rotatedCertChainPEM))
+			}).WithContext(ctx).ShouldNot(Equal(rotatedCertChainPEM))
 
 			By("Acknowledging the drift")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				if found.Annotations == nil {
 					found.Annotations = map[string]string{}
 				}
 				found.Annotations[annotations.RefreshTrustMaterial] = "true"
 				return suite.Client().Update(ctx, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Certificate chain updated after acknowledgement")
-			Eventually(func(g Gomega) {
+			Eventually(func(g Gomega, ctx context.Context) {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				g.Expect(found.Status.CertificateChain).Should(Equal(rotatedCertChainPEM))
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 		})
 	})
 })

--- a/internal/controller/tuf/suite_test.go
+++ b/internal/controller/tuf/suite_test.go
@@ -42,5 +42,6 @@ func TestController(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	SetDefaultEventuallyTimeout(2 * time.Minute)
+	EnforceDefaultTimeoutsWhenUsingContexts()
 	RunSpecs(t, "Controller Suite")
 }

--- a/internal/controller/tuf/tuf_controller_test.go
+++ b/internal/controller/tuf/tuf_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tuf
 
 import (
+	"context"
 	_ "embed"
 	"reflect"
 	"strconv"
@@ -79,9 +80,9 @@ var _ = Describe("TUF controller", func() {
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
 			Expect(err).To(Not(HaveOccurred()))
 
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Delete(ctx, found)
-			}, 2*time.Minute, time.Second).Should(Succeed())
+			}, 2*time.Minute, time.Second).WithContext(ctx).Should(Succeed())
 
 			// TODO(user): Attention if you improve this code by adding other context test you MUST
 			// be aware of the current delete namespace limitations.
@@ -137,26 +138,26 @@ var _ = Describe("TUF controller", func() {
 			}
 
 			By("Checking if the custom resource was successfully created")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				found := &rhtasv1.Tuf{}
 				return suite.Client().Get(ctx, typeNamespaceName, found)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Status conditions are initialized")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Tuf{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionPresentAndEqual(found.Status.Conditions, constants.ReadyCondition, metav1.ConditionFalse)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Pending phase until ctlog public key is resolved")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Tuf{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Pending.String()))
+			}).WithContext(ctx).Should(Equal(state.Pending.String()))
 
 			By("Creating component CRs for autodiscovery and service URL resolution")
 			ctlogCR := &rhtasv1.CTlog{
@@ -178,15 +179,15 @@ var _ = Describe("TUF controller", func() {
 
 			By("Waiting until Tuf init job is created")
 			found := &rhtasv1.Tuf{}
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return found.Status.PvcName
-			}).ShouldNot(BeEmpty())
+			}).WithContext(ctx).ShouldNot(BeEmpty())
 
-			Eventually(func(g Gomega) *metav1.Condition {
+			Eventually(func(g Gomega, ctx context.Context) *metav1.Condition {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.FindStatusCondition(found.Status.Conditions, tufConstants.RepositoryCondition)
-			}).Should(
+			}).WithContext(ctx).Should(
 				And(
 					WithTransform(func(condition *metav1.Condition) string {
 						return condition.Reason
@@ -230,10 +231,10 @@ var _ = Describe("TUF controller", func() {
 				Expect(suite.Client().Create(ctx, component)).To(Succeed())
 			}
 
-			Eventually(func(g Gomega) *metav1.Condition {
+			Eventually(func(g Gomega, ctx context.Context) *metav1.Condition {
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.FindStatusCondition(found.Status.Conditions, tufConstants.RepositoryCondition)
-			}).Should(
+			}).WithContext(ctx).Should(
 				And(
 					WithTransform(func(condition *metav1.Condition) string {
 						return condition.Reason
@@ -255,12 +256,12 @@ var _ = Describe("TUF controller", func() {
 			}
 
 			initJobList := &batchv1.JobList{}
-			Eventually(func() []batchv1.Job {
+			Eventually(func(ctx context.Context) []batchv1.Job {
 				jobLabels := labels.ForResource(tufConstants.ComponentName, tufConstants.InitJobName, TufName, found.Status.PvcName)
 				selector := apilabels.SelectorFromSet(jobLabels)
 				Expect(kubernetes.FindByLabelSelector(ctx, suite.Client(), initJobList, TufNamespace, selector.String())).To(Succeed())
 				return initJobList.Items
-			}).Should(HaveLen(1))
+			}).WithContext(ctx).Should(HaveLen(1))
 
 			By("Move to Job to completed")
 			// Workaround to succeed condition for Ready phase
@@ -276,56 +277,56 @@ var _ = Describe("TUF controller", func() {
 			Expect(suite.Client().Status().Update(ctx, initJob)).Should(Succeed())
 
 			By("Repository condition gets ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Tuf{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, tufConstants.RepositoryCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Waiting until Tuf instance is Initialization")
-			Eventually(func(g Gomega) string {
+			Eventually(func(g Gomega, ctx context.Context) string {
 				found := &rhtasv1.Tuf{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				cond := meta.FindStatusCondition(found.Status.Conditions, constants.ReadyCondition)
 				g.Expect(cond).ToNot(BeNil())
 				return cond.Reason
-			}).Should(Equal(state.Initialize.String()))
+			}).WithContext(ctx).Should(Equal(state.Initialize.String()))
 
 			deployment := &appsv1.Deployment{}
 			By("Checking if Deployment was successfully created in the reconciliation")
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: tufConstants.DeploymentName, Namespace: TufNamespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Move to Ready phase")
 			// Workaround to succeed condition for Ready phase
 			Expect(k8sTest.SetDeploymentToReady(ctx, suite.Client(), deployment)).To(Succeed())
 
 			By("Waiting until Tuf instance is Ready")
-			Eventually(func(g Gomega) bool {
+			Eventually(func(g Gomega, ctx context.Context) bool {
 				found := &rhtasv1.Tuf{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				return meta.IsStatusConditionTrue(found.Status.Conditions, constants.ReadyCondition)
-			}).Should(BeTrue())
+			}).WithContext(ctx).Should(BeTrue())
 
 			By("Checking if Service was successfully created in the reconciliation")
 			service := &corev1.Service{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: tufConstants.DeploymentName, Namespace: TufNamespace}, service)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(8181)))
 
 			By("Checking if Ingress was successfully created in the reconciliation")
 			ingress := &v1.Ingress{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: tufConstants.DeploymentName, Namespace: TufNamespace}, ingress)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			Expect(ingress.Spec.Rules[0].Host).Should(Equal("tuf.localhost"))
 			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Name).Should(Equal(service.Name))
 			Expect(ingress.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Name).Should(Equal(tufConstants.PortName))
 
 			By("Checking the latest Status Condition added to the Tuf instance")
-			Eventually(func(g Gomega) error {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				found := &rhtasv1.Tuf{}
 				g.Expect(suite.Client().Get(ctx, typeNamespaceName, found)).Should(Succeed())
 				rekorCondition := meta.FindStatusCondition(found.Status.Conditions, "rekor.pub")
@@ -337,21 +338,21 @@ var _ = Describe("TUF controller", func() {
 				g.Expect(ctlogCondition.Status).Should(Equal(metav1.ConditionTrue))
 				g.Expect(ctlogCondition.Reason).Should(Equal(state.Ready.String()))
 				return nil
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 
 			By("Checking if controller will return deployment to desired state")
 			deployment = &appsv1.Deployment{}
-			Eventually(func() error {
+			Eventually(func(ctx context.Context) error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: tufConstants.DeploymentName, Namespace: TufNamespace}, deployment)
-			}).Should(Succeed())
+			}).WithContext(ctx).Should(Succeed())
 			replicas := int32(99)
 			deployment.Spec.Replicas = &replicas
 			Expect(suite.Client().Status().Update(ctx, deployment)).Should(Succeed())
-			Eventually(func(g Gomega) int32 {
+			Eventually(func(g Gomega, ctx context.Context) int32 {
 				deployment = &appsv1.Deployment{}
 				g.Expect(suite.Client().Get(ctx, types.NamespacedName{Name: tufConstants.DeploymentName, Namespace: TufNamespace}, deployment)).Should(Succeed())
 				return *deployment.Spec.Replicas
-			}).Should(Equal(int32(1)))
+			}).WithContext(ctx).Should(Equal(int32(1)))
 		})
 	})
 })

--- a/internal/controller/tuf/tuf_controller_test.go
+++ b/internal/controller/tuf/tuf_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tuf
 
 import (
-	"context"
 	_ "embed"
 	"reflect"
 	"strconv"
@@ -59,8 +58,6 @@ var _ = Describe("TUF controller", func() {
 			TufNamespace = "controller"
 		)
 
-		ctx := context.Background()
-
 		namespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: TufNamespace,
@@ -70,13 +67,13 @@ var _ = Describe("TUF controller", func() {
 		typeNamespaceName := types.NamespacedName{Name: TufName, Namespace: TufNamespace}
 		tuf := &rhtasv1.Tuf{}
 
-		BeforeEach(func() {
+		BeforeEach(func(ctx SpecContext) {
 			By("Creating the Namespace to perform the tests")
 			err := suite.Client().Create(ctx, namespace)
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("removing the custom resource for the Kind Tuf")
 			found := &rhtasv1.Tuf{}
 			err := suite.Client().Get(ctx, typeNamespaceName, found)
@@ -93,7 +90,7 @@ var _ = Describe("TUF controller", func() {
 			_ = suite.Client().Delete(ctx, namespace)
 		})
 
-		It("should successfully reconcile a custom resource for Tuf", func() {
+		It("should successfully reconcile a custom resource for Tuf", func(ctx SpecContext) {
 			By("creating the custom resource for the Kind Tuf")
 			err := suite.Client().Get(ctx, typeNamespaceName, tuf)
 			if err != nil && errors.IsNotFound(err) {


### PR DESCRIPTION
## Why

The controller envtest suites (ctlog, fulcio, rekor, trillian, tsa, tuf) shared a single `ctx := context.Background()` across every `BeforeEach`/`AfterEach`/`It` in a spec, never enforced `EnforceDefaultTimeoutsWhenUsingContexts()`, and their `Eventually` calls weren't actually context-aware — `.WithContext(ctx)` only injects a context into a polled function when that function's own signature declares a `context.Context` parameter, so a closure that merely captures an outer `ctx` variable never receives it from Gomega. One of the hot-update tests also had an unretried spec update that raced the controller's own reconcile loop.

## What

- Added `EnforceDefaultTimeoutsWhenUsingContexts()` to the controller `suite_test.go` files.
- Converted `BeforeEach`/`AfterEach`/`It` closures in the controller and hot-update test files to accept `ctx SpecContext` instead of sharing one `ctx := context.Background()` declared at the `Describe`/`Context` level.
- Replaced `context.TODO()` with `context.Background()` in `internal/controller/testonly/suite.go`'s `BeforeSuite`/`AfterSuite` helper, shared by the controller packages.
- Chained `.WithContext(ctx)` onto every `Eventually` call in the converted suites, and gave each polled closure a real `ctx context.Context` parameter (ordered after `g Gomega` where both are needed) so Gomega actually injects the context into the closure body.
- Retried the OIDC spec update in the Fulcio hot-update test on conflict instead of a single unretried Get-then-Update.
