### PR TITLE
feat: add tufcli ConsoleCLIDownload manifest

### DIFF
--- a/config/manifests/consoleclidownloads/kustomization.yaml
+++ b/config/manifests/consoleclidownloads/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - createtree.yaml
 - updatetree.yaml
 - tuftool.yaml
+- tufcli.yaml

--- a/config/manifests/consoleclidownloads/tufcli.yaml
+++ b/config/manifests/consoleclidownloads/tufcli.yaml
@@ -1,0 +1,24 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  name: tufcli
+  labels:
+    app.kubernetes.io/part-of: trusted-artifact-signer
+spec:
+  displayName: "tufcli - Command Line Interface (CLI)"
+  description: "tufcli is a Go command-line utility for generating and signing TUF repositories."
+  links:
+    - text: "Download tufcli for Linux x86_64"
+      href: "https://developers.redhat.com/content-gateway/file/RHTAS/__VERSION__/tufcli_linux_amd64.tar.gz"
+    - text: "Download tufcli for Linux arm64"
+      href: "https://developers.redhat.com/content-gateway/file/RHTAS/__VERSION__/tufcli_linux_arm64.tar.gz"
+    - text: "Download tufcli for Linux ppc64le"
+      href: "https://developers.redhat.com/content-gateway/file/RHTAS/__VERSION__/tufcli_linux_ppc64le.tar.gz"
+    - text: "Download tufcli for Linux s390x"
+      href: "https://developers.redhat.com/content-gateway/file/RHTAS/__VERSION__/tufcli_linux_s390x.tar.gz"
+    - text: "Download tufcli for Mac x86_64"
+      href: "https://developers.redhat.com/content-gateway/file/RHTAS/__VERSION__/tufcli_darwin_amd64.tar.gz"
+    - text: "Download tufcli for Mac arm64"
+      href: "https://developers.redhat.com/content-gateway/file/RHTAS/__VERSION__/tufcli_darwin_arm64.tar.gz"
+    - text: "Download tufcli for Windows x86_64"
+      href: "https://developers.redhat.com/content-gateway/file/RHTAS/__VERSION__/tufcli_windows_amd64.tar.gz"


### PR DESCRIPTION
## Summary

- Add static `ConsoleCLIDownload` manifest for `tufcli` CLI with all 7 platform variants
- Add `tufcli` entry to `cli_server_test.go` downloadable artifacts table
- Add `tufcli.yaml` to consoleclidownloads kustomization resources

## Note

The `cli_server_test.go` entry requires the client-server image to include tufcli binaries. This is available from [securesign/cosign#828](https://github.com/securesign/cosign/pull/828) which is merged to main. The `images.env` digest will need updating to a client-server build that includes tufcli for the E2E test to pass.