### PR TITLE
Disable cluster-wide caching of Secret and ConfigMap data

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -315,6 +315,18 @@ func main() {
 			RecoverPanic: ptr.To(true),
 		},
 		Cache: cacheOpts,
+		// Secret/ConfigMap are excluded from cacheOpts.ByObject: a label/field selector on
+		// these types would return a permanent NotFound for any object outside the selector
+		// (no live fallback), breaking user-provided (BYO) secret/configmap refs. DisableFor
+		// keeps reads live instead, avoiding an unfiltered, cluster-wide cache.
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.Secret{},
+					&corev1.ConfigMap{},
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -171,7 +171,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.CTlog) *acti
 
 	configAnnotations := i.configMatchingAnnotations(ctx, instance, trillianUrl)
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		newConfig,
 		ensure.ControllerReference[*corev1.Secret](instance, i.Client),
 		ensure.Labels[*corev1.Secret](slices.Collect(maps.Keys(configLabels)), configLabels),

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -324,7 +324,7 @@ func (i serverConfig) handleRootCertificates(ctx context.Context, instance *rhta
 //   - errSecretInvalid if the secret needs recreation (not a failure)
 //   - other error for API errors - reconciliation should fail
 func (i serverConfig) validateExistingSecret(ctx context.Context, instance *rhtasv1.CTlog, trillianUrl string) error {
-	secret, err := kubernetes.GetSecret(ctx, i.Client, instance.Namespace, instance.Status.ServerConfigRef.Name)
+	secretMeta, err := kubernetes.GetSecretMetadata(ctx, i.Client, instance.Namespace, instance.Status.ServerConfigRef.Name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return errSecretInvalid
@@ -334,7 +334,7 @@ func (i serverConfig) validateExistingSecret(ctx context.Context, instance *rhta
 
 	// Check if the secret was generated from the same data sources using annotations
 	expectedAnnotations := i.configMatchingAnnotations(ctx, instance, trillianUrl)
-	if !equality.Semantic.DeepDerivative(expectedAnnotations, secret.GetAnnotations()) {
+	if !equality.Semantic.DeepDerivative(expectedAnnotations, secretMeta.GetAnnotations()) {
 		return errSecretInvalid
 	}
 

--- a/internal/controller/ctlog/actions/server_config_test.go
+++ b/internal/controller/ctlog/actions/server_config_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/onsi/gomega/gstruct"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"k8s.io/utils/ptr"
 
@@ -169,9 +170,10 @@ func TestServerConfig_Handle(t *testing.T) {
 	labels := labels.ForResource(ComponentName, DeploymentName, "ctlog", serverConfigResourceName)
 
 	type env struct {
-		spec    rhtasv1.CTlogSpec
-		status  rhtasv1.CTlogStatus
-		objects []client.Object
+		spec      rhtasv1.CTlogSpec
+		status    rhtasv1.CTlogStatus
+		objects   []client.Object
+		intercept interceptor.Funcs
 	}
 	type want struct {
 		result *action.Result
@@ -238,6 +240,52 @@ func TestServerConfig_Handle(t *testing.T) {
 							"private": privateKey,
 							"public":  publicKey,
 						},
+					},
+				},
+			},
+			want: want{
+				result: testAction.Return(),
+				verify: func(_ context.Context, g Gomega, instance *rhtasv1.CTlog, cli client.WithWatch) {
+					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
+				},
+			},
+		},
+		{
+			name: "create a new config with an uncached client rejecting empty-name Get",
+			env: env{
+				spec: rhtasv1.CTlogSpec{
+					ServerConfigRef: nil,
+					Trillian:        rhtasv1.TrillianService{Port: ptr.To(int32(80))},
+				},
+				status: rhtasv1.CTlogStatus{
+					ServerConfigRef: nil,
+					TreeID:          ptr.To(int64(123456)),
+					RootCertificates: []rhtasv1.SecretKeySelector{
+						{LocalObjectReference: rhtasv1.LocalObjectReference{Name: "secret"}, Key: "cert"},
+					},
+					PrivateKeyRef: &rhtasv1.SecretKeySelector{LocalObjectReference: rhtasv1.LocalObjectReference{Name: "secret"}, Key: "private"},
+					PublicKeyRef:  &rhtasv1.SecretKeySelector{LocalObjectReference: rhtasv1.LocalObjectReference{Name: "secret"}, Key: "public"},
+				},
+				objects: []client.Object{
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "secret",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"cert":    cert,
+							"private": privateKey,
+							"public":  publicKey,
+						},
+					},
+				},
+				intercept: interceptor.Funcs{
+					Get: func(ctx context.Context, wrapped client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*v1.Secret); ok && key.Name == "" {
+							return k8sErrors.NewBadRequest("resource name may not be empty")
+						}
+						return wrapped.Get(ctx, key, obj, opts...)
 					},
 				},
 			},
@@ -502,6 +550,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				WithObjects(instance).
 				WithStatusSubresource(instance).
 				WithObjects(tt.env.objects...).
+				WithInterceptorFuncs(tt.env.intercept).
 				Build()
 
 			a := testAction.PrepareAction(c, NewServerConfigAction())

--- a/internal/controller/fulcio/actions/server_config.go
+++ b/internal/controller/fulcio/actions/server_config.go
@@ -87,7 +87,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1.Fulcio) *act
 		},
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		newConfig,
 		ensure.ControllerReference[*v1.ConfigMap](instance, i.Client),
 		ensure.Labels[*v1.ConfigMap](slices.Collect(maps.Keys(configLabel)), configLabel),

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/generate_password.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/generate_password.go
@@ -52,7 +52,7 @@ func (i generatePasswordAction) Handle(ctx context.Context, instance *rhtasv1.Re
 			GenerateName: fmt.Sprintf("redis-password-%s", instance.Name),
 		},
 	}
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, obj,
+	if err = kubernetes.Create(ctx, i.Client, obj,
 		ensure.ControllerReference[*core.Secret](instance, i.Client),
 		ensure.Labels[*core.Secret](slices.Collect(maps.Keys(labels)), labels),
 		kubernetes.EnsureSecretData(true, map[string][]byte{"password": utils.GeneratePassword(8)}),

--- a/internal/controller/rekor/actions/server/sharding_config.go
+++ b/internal/controller/rekor/actions/server/sharding_config.go
@@ -84,7 +84,7 @@ func (i shardingConfig) Handle(ctx context.Context, instance *rhtasv1.Rekor) *ac
 		},
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		newConfig,
 		ensure.ControllerReference[*v1.ConfigMap](instance, i.Client),
 		ensure.Labels[*v1.ConfigMap](slices.Collect(maps.Keys(labels)), labels),

--- a/internal/controller/trillian/actions/db/handle_secret.go
+++ b/internal/controller/trillian/actions/db/handle_secret.go
@@ -136,7 +136,7 @@ func (i handleSecretAction) Handle(ctx context.Context, instance *rhtasv1.Trilli
 			Namespace:    instance.Namespace,
 		},
 	}
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		dbSecret,
 		ensure.Labels[*corev1.Secret](slices.Collect(maps.Keys(dbLabels)), dbLabels),
 		ensure.Annotations[*corev1.Secret](managedAnnotations, i.secretAnnotations()),

--- a/internal/controller/tsa/actions/ntpMonitoring.go
+++ b/internal/controller/tsa/actions/ntpMonitoring.go
@@ -97,7 +97,7 @@ func (i ntpMonitoringAction) Handle(ctx context.Context, instance *rhtasv1.Times
 			Namespace:    instance.Namespace,
 		},
 	}
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		configMap,
 		ensure.ControllerReference[*v1.ConfigMap](instance, i.Client),
 		ensure.Labels[*v1.ConfigMap](slices.Collect(maps.Keys(configLabel)), configLabel),

--- a/internal/controller/tuf/actions/migration_job.go
+++ b/internal/controller/tuf/actions/migration_job.go
@@ -20,7 +20,6 @@ import (
 	tlsensure "github.com/securesign/operator/internal/utils/tls/ensure"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apilabels "k8s.io/apimachinery/pkg/labels"
@@ -50,12 +49,13 @@ func (i migrationJobAction) CanHandle(_ context.Context, tuf *rhtasv1.Tuf) bool 
 
 func (i migrationJobAction) Handle(ctx context.Context, instance *rhtasv1.Tuf) *action.Result {
 	if instance.Spec.RootKeySecretRef != nil && instance.Spec.RootKeySecretRef.Name != "" {
-		if _, err := kubernetes.GetSecret(ctx, i.Client, instance.Namespace, instance.Spec.RootKeySecretRef.Name); err != nil {
-			if errors.IsNotFound(err) {
-				i.Logger.Info("Root key secret not found", "secret", instance.Spec.RootKeySecretRef.Name)
-				return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("cannot migrate TUF: root key secret %s not found: %w", instance.Spec.RootKeySecretRef.Name, err)), instance)
-			}
+		found, err := kubernetes.ExistsSecret(ctx, i.Client, instance.Namespace, instance.Spec.RootKeySecretRef.Name)
+		if err != nil {
 			return i.Error(ctx, err, instance)
+		}
+		if !found {
+			i.Logger.Info("Root key secret not found", "secret", instance.Spec.RootKeySecretRef.Name)
+			return i.Error(ctx, reconcile.TerminalError(fmt.Errorf("cannot migrate TUF: root key secret %s not found", instance.Spec.RootKeySecretRef.Name)), instance)
 		}
 	} else {
 		i.Logger.Info("root key secret not specified")

--- a/internal/utils/kubernetes/common.go
+++ b/internal/utils/kubernetes/common.go
@@ -101,6 +101,17 @@ func FindByLabelSelector(ctx context.Context, c client.Client, list client.Objec
 	return c.List(ctx, list, client.InNamespace(namespace), listOptions)
 }
 
+func Create[T client.Object](ctx context.Context, cli client.Client, obj T, fn ...func(object T) error) error {
+	var err error
+	for _, f := range fn {
+		err = errors.Join(err, f(obj))
+	}
+	if err != nil {
+		return err
+	}
+	return cli.Create(ctx, obj)
+}
+
 func CreateOrUpdate[T client.Object](ctx context.Context, cli client.Client, obj T, fn ...func(object T) error) (result controllerutil.OperationResult, err error) {
 	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return apiErrors.IsConflict(err) || apiErrors.IsAlreadyExists(err)

--- a/internal/utils/kubernetes/common_test.go
+++ b/internal/utils/kubernetes/common_test.go
@@ -2,14 +2,20 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/securesign/operator/internal/config"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func TestCalculateHostname(t *testing.T) {
@@ -131,5 +137,77 @@ func TestCalculateHostname_OpenShift_MissingIngress(t *testing.T) {
 	_, err := CalculateHostname(context.Background(), cli, "rekor-server", "test-ns")
 	if err == nil {
 		t.Fatal("expected error when cluster Ingress is missing, got nil")
+	}
+}
+
+func TestCreate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		mutateErr error
+		intercept interceptor.Funcs
+		wantErr   bool
+	}{
+		{
+			name: "applies mutate fns and creates, without probing for an existing object",
+			intercept: interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return fmt.Errorf("Get should never be called by Create")
+				},
+			},
+		},
+		{
+			name:      "mutate fn error is returned and Create is not called",
+			mutateErr: fmt.Errorf("mutate failed"),
+			intercept: interceptor.Funcs{
+				Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+					return fmt.Errorf("Create should not be called when a mutate fn fails")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "client Create error is propagated",
+			intercept: interceptor.Funcs{
+				Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+					return fmt.Errorf("api server unavailable")
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			c := testAction.FakeClientBuilder().
+				WithInterceptorFuncs(tt.intercept).
+				Build()
+
+			obj := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-secret-",
+					Namespace:    "default",
+				},
+			}
+
+			err := Create(t.Context(), c, obj,
+				func(s *corev1.Secret) error {
+					if tt.mutateErr != nil {
+						return tt.mutateErr
+					}
+					s.Labels = map[string]string{"foo": "bar"}
+					return nil
+				},
+			)
+
+			if tt.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(obj.Name).ToNot(gomega.BeEmpty())
+			g.Expect(obj.Labels).To(gomega.Equal(map[string]string{"foo": "bar"}))
+		})
 	}
 }

--- a/internal/utils/kubernetes/secret.go
+++ b/internal/utils/kubernetes/secret.go
@@ -67,6 +67,18 @@ func ExistsSecret(ctx context.Context, c client.Client, namespace, name string) 
 	return true, nil
 }
 
+// GetSecretMetadata fetches a Secret's ObjectMeta only (no secret data), using
+// a metadata-only GET. Use this instead of GetSecret when only metadata
+// (e.g. annotations, labels) is needed.
+func GetSecretMetadata(ctx context.Context, c client.Client, namespace, name string) (*metav1.PartialObjectMetadata, error) {
+	obj := &metav1.PartialObjectMetadata{}
+	obj.SetGroupVersionKind(secretGVK)
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
 func FindSecret(ctx context.Context, c client.Client, namespace string, label string) (*metav1.PartialObjectMetadata, error) {
 	list, err := ListSecrets(ctx, c, namespace, label)
 	if err != nil {

--- a/internal/utils/kubernetes/secret_test.go
+++ b/internal/utils/kubernetes/secret_test.go
@@ -67,6 +67,63 @@ func TestExistsSecret(t *testing.T) {
 	}
 }
 
+func TestGetSecretMetadata(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		objects   []client.Object
+		intercept interceptor.Funcs
+		wantAnn   map[string]string
+		wantErr   bool
+	}{
+		{
+			name: "secret exists",
+			objects: []client.Object{
+				&v1.Secret{
+					ObjectMeta: v2.ObjectMeta{
+						Name:        "my-secret",
+						Namespace:   "default",
+						Annotations: map[string]string{"foo": "bar"},
+					},
+					Data: map[string][]byte{"key": []byte("should-not-be-needed")},
+				},
+			},
+			wantAnn: map[string]string{"foo": "bar"},
+		},
+		{
+			name:    "secret not found",
+			wantErr: true,
+		},
+		{
+			name: "transient API error",
+			intercept: interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return fmt.Errorf("api server unavailable")
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			c := testAction.FakeClientBuilder().
+				WithObjects(tt.objects...).
+				WithInterceptorFuncs(tt.intercept).
+				Build()
+
+			meta, err := GetSecretMetadata(t.Context(), c, "default", "my-secret")
+			if tt.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(meta.GetAnnotations()).To(gomega.Equal(tt.wantAnn))
+		})
+	}
+}
+
 func TestEnsureSecret(t *testing.T) {
 	t.Parallel()
 	data := map[string][]byte{"test": []byte("data")}


### PR DESCRIPTION
## Why

The manager's cached client (`mgr.GetClient()`) caches reads by default via controller-runtime's informer cache. `cmd/main.go` already restricts this cache for high-cardinality types the operator exclusively owns (Deployment, ReplicaSet, StatefulSet, Pod, Service, Ingress, CronJob, Job), but `Secret` and `ConfigMap` were missing from that list.

Because of that, the first typed `Get`/`List` against either type starts an unfiltered, cluster-wide informer that lists and watches every Secret/ConfigMap in every namespace the operator's RBAC allows (a cluster-scoped `ClusterRole`/`ClusterRoleBinding` with no `resourceNames`), retaining full object data in the shared cache for the life of the operator process.

- For `Secret`, this means decrypted key material for objects the operator was never asked to read can sit resident in memory indefinitely.
- For `ConfigMap`, the payloads aren't sensitive, but ConfigMaps are typically far more numerous cluster-wide than Secrets, reintroducing the same class of OOM risk that the existing `ByObject` restriction already addresses for the other types.

A label-filtered `ByObject` entry (mirroring the existing Deployment/Pod/Service pattern) isn't viable for these two types: this operator's CRDs support user-provided ("bring your own") Secret/ConfigMap refs — signer keys, TLS certs, CA refs, `TrustedCA` bundles — that are never labeled by the operator. A `Get()` on an object outside a `ByObject` selector returns a permanent `NotFound` with no live fallback, which would permanently break resolution of those user-provided refs.

## What

- Add `Client.Cache.DisableFor` for `corev1.Secret` and `corev1.ConfigMap` to the manager's `ctrl.Options`, so reads for these types go straight to the API server instead of the shared informer cache.
- Use the existing metadata-only `ExistsSecret` helper for the TUF migration job's root-key existence check, which previously used the full content-capable `GetSecret` but only needed to know whether the secret exists.
- Add a `GetSecretMetadata` helper (metadata-only `GET`, alongside the existing `ExistsSecret`/`FindSecret`/`ListSecrets`) and use it for CTlog's `validateExistingSecret`, which only ever reads the existing config secret's annotations and never its data.