### PR TITLE
Update operator images from release 1.4.3 builds 2026-07-22

### DIFF
--- a/config/default/images.env
+++ b/config/default/images.env
@@ -1,50 +1,50 @@
 # Trillian - Log Signer
-RELATED_IMAGE_TRILLIAN_LOG_SIGNER=registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:d2b774d9e7962500e24bb6c629ea2e62a4d46ed2a9c1dd240a7c1dbb75def3c9
+RELATED_IMAGE_TRILLIAN_LOG_SIGNER=registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:6722d0deef8b88f32f715cdc94960019ec62599837f03fedd1af9d8c2b423275
 
 # Trillian - Database
-RELATED_IMAGE_TRILLIAN_DB=registry.redhat.io/rhtas/trillian-database-rhel9@sha256:df92c04caca9fcfd76bc9cdf0e86c211fbe2f4a58e92101fddd8764aee63a107
+RELATED_IMAGE_TRILLIAN_DB=registry.redhat.io/rhtas/trillian-database-rhel9@sha256:494f3d92f6a5d3dfb3e9ffef17a09a218308e2682e1cb02726781a7f78d97cfa
 
 # Trillian - Log Server
-RELATED_IMAGE_TRILLIAN_LOG_SERVER=registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:aa8b1b40423856e4ee72bd16365f94819345b3144d9ce66a3afc634c447fca4f
+RELATED_IMAGE_TRILLIAN_LOG_SERVER=registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:46e2e5e66e6593a50dd8636b44d7f0a963c16adc5c6f1989bd74451b6f7209da
 
 # Trillian - Netcat (ose-tools)
 RELATED_IMAGE_TRILLIAN_NETCAT=registry.redhat.io/openshift4/ose-tools-rhel9@sha256:52da0e4461897bbd0d4ab6f3340e290de5d6b9a702014950b4db6b6abb4880f4
 
 # Trillian - CreateTree
-RELATED_IMAGE_CREATETREE=registry.redhat.io/rhtas/createtree-rhel9@sha256:0e90e4219ab0e8b7ee0e77108c87fea8f699f5c2bac28e8fd3f5b4ff867147f6
+RELATED_IMAGE_CREATETREE=registry.redhat.io/rhtas/createtree-rhel9@sha256:5f3f5285401966381300fd6c382f110e669ef883402034cac478b4393f27f6be
 
 # Fulcio - Server
-RELATED_IMAGE_FULCIO_SERVER=registry.redhat.io/rhtas/fulcio-rhel9@sha256:5395edc0795b38375f8d8480ac77ea26ad41aac60f89e8b68537bc4f1a6e360b
+RELATED_IMAGE_FULCIO_SERVER=registry.redhat.io/rhtas/fulcio-rhel9@sha256:e3fe2ba5e50dc26ebf7305f01d19d3b575b36e8df480594e0dbef5c26aae359c
 
 # Rekor - Server
-RELATED_IMAGE_REKOR_SERVER=registry.redhat.io/rhtas/rekor-server-rhel9@sha256:29d95400864ec7bef421fd5fb180138feed8eb5d796f2f4bd8e4178722b655f6
+RELATED_IMAGE_REKOR_SERVER=registry.redhat.io/rhtas/rekor-server-rhel9@sha256:89843e674bd2eda3d3f079e28553669e84c7cb32f96b6fe7855817c3077b27b2
 
 # Rekor - Redis
-RELATED_IMAGE_REKOR_REDIS=registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:935ab04c208b93577b864587adab23fcfc66135d84417440a86da980ea9bcd3a
+RELATED_IMAGE_REKOR_REDIS=registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:2cb14badeeb6516405265222d93fb59a61707683c625c3d056582f61054f8c3d
 
 # Rekor - Search UI
-RELATED_IMAGE_REKOR_SEARCH_UI=registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:fb0f828b264e330a74db15da96c992fc21f4ba1fbc1884b334f6eca89ddf3344
+RELATED_IMAGE_REKOR_SEARCH_UI=registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:9a66e6f53130ae8211d220d0c487c14b2f24f7fce0c99a63007ed272df3be0d6
 
 # Rekor - Backfill Redis
-RELATED_IMAGE_BACKFILL_REDIS=registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:9bbed4541cf2305ec915c39b51c1103524e68841d98178c61bf841fd5ccc504b
+RELATED_IMAGE_BACKFILL_REDIS=registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:08c58b49b9f9d9b0df907ff1650f16dff7906aa5058cc676201903574bfd3494
 
 # TUF - Server
-RELATED_IMAGE_TUF=registry.redhat.io/rhtas/tuffer-rhel9@sha256:3dbd01bd144a94c7662f646bcd98220a65d218391dc4b1be282c6618d8eb2b1c
+RELATED_IMAGE_TUF=registry.redhat.io/rhtas/tuffer-rhel9@sha256:499fc42e5b7544fd3464472e9f7204f34b2e19ce8edf28e7554d1ccb2b08c35e
 
 # CTlog - Server
-RELATED_IMAGE_CTLOG=registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:37cc3179946c699bb78e775a3d514bf92873424559d9cebf35e0a5812256f5b7
+RELATED_IMAGE_CTLOG=registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:6f51e40f3378ebe16783aa37ccffa1716130f4be84fa5bcdf5a158a25837e354
 
 # HTTP Server (httpd)
 RELATED_IMAGE_HTTP_SERVER=registry.redhat.io/ubi9/httpd-24@sha256:66b14ae828342819823fe01bc93117b54ce3999eaee8bc608de0be7459abc65b
 
 # Timestamp Authority - Server
-RELATED_IMAGE_TIMESTAMP_AUTHORITY=registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:b71b536a4f70e70df2ec9ee03d373a76e5b505de3513c46bcdcb799b1103685b
+RELATED_IMAGE_TIMESTAMP_AUTHORITY=registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:cd6ad40172b5e995177297c078537aeb28d3d5b73a4e70c255f6842837b32acd
 
 # Client Server - CLI tools
-RELATED_IMAGE_CLIENT_SERVER=registry.redhat.io/rhtas/client-server-rhel9@sha256:93df5643ae68ef896371d1278e323f153c906c7049ce0f6ba72fa927e16e272b
+RELATED_IMAGE_CLIENT_SERVER=registry.redhat.io/rhtas/client-server-rhel9@sha256:cc0d213d9846cf15d5078240cf7d5d0a4996aa0b7e356d90207094e044e90f40
 
 # Rekor - Monitor
-RELATED_IMAGE_REKOR_MONITOR=registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:a40a4a303b4d5755f62103dfc55c773c4e63f6955334a52435f493d81265c13b
+RELATED_IMAGE_REKOR_MONITOR=registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:2a9c3702485e26932884dd61c52942999ee3fe0634d2f89ada25207075d0b5a4
 
 # CTlog - Monitor
-RELATED_IMAGE_CTLOG_MONITOR=registry.redhat.io/rhtas/ctlog-monitor-rhel9@sha256:8c51a84b03c365fd9e3858471efd3fc6a92107544a845ea2a6df315263c1eb6d
+RELATED_IMAGE_CTLOG_MONITOR=registry.redhat.io/rhtas/ctlog-monitor-rhel9@sha256:109fd35c6171799cbe2f86aa5cc62e22fe919f5993bb054150da0a6deec3bfa3


### PR DESCRIPTION
Updates images.env with digests from 1.4.3 release builds.

Source snapshots:
- tas-components-v1-4-20260722-114647-212
- tas-tools-v1-4-20260722-103132-000
- tough-v1-4-20260722-094822-000
- create-tree-v1-4-20260722-112446-000
- rekor-monitor-v1-4-20260722-114839-306
- cli-stacks-v1-4-20260722-114322-000
- client-server-v1-4-20260722-121852-000

15 components updated, 2 unchanged (ose-tools, httpd).