### PR TITLE
fix: handle KMS and Tink signers in TSA generate_signer action

### DIFF
--- a/internal/controller/tsa/actions/resolve_kms_tink_signer.go
+++ b/internal/controller/tsa/actions/resolve_kms_tink_signer.go
@@ -1,0 +1,151 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/generateSigner"
+	"github.com/securesign/operator/internal/constants"
+	tsaUtils "github.com/securesign/operator/internal/controller/tsa/utils"
+	"github.com/securesign/operator/internal/labels"
+	"github.com/securesign/operator/internal/state"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var ErrMissingKeysetRef = errors.New("missing keyset reference for Tink signer")
+
+type resolveKMSTinkSignerAction struct {
+	action.BaseAction
+}
+
+func NewResolveKMSTinkSignerAction() action.Action[*rhtasv1.TimestampAuthority] {
+	return &resolveKMSTinkSignerAction{}
+}
+
+func (a *resolveKMSTinkSignerAction) Name() string {
+	return "resolve timestamp-authority KMS/Tink signer"
+}
+
+func (a *resolveKMSTinkSignerAction) CanHandle(_ context.Context, instance *rhtasv1.TimestampAuthority) bool {
+	if tsaUtils.IsFileType(instance) {
+		return false
+	}
+
+	c := meta.FindStatusCondition(instance.GetConditions(), constants.ReadyCondition)
+	switch {
+	case c == nil:
+		return false
+	case state.FromCondition(c) < state.Pending:
+		return false
+	}
+
+	cc := meta.FindStatusCondition(instance.GetConditions(), TSASignerCondition)
+	return cc == nil || cc.Status != metav1.ConditionTrue || instance.GetGeneration() != cc.ObservedGeneration
+}
+
+func (a *resolveKMSTinkSignerAction) Handle(ctx context.Context, instance *rhtasv1.TimestampAuthority) *action.Result {
+	signer := &instance.Spec.Signer
+
+	if signer.Tink != nil {
+		if signer.Tink.KeysetRef == nil {
+			return a.Error(ctx, reconcile.TerminalError(ErrMissingKeysetRef), instance,
+				metav1.Condition{
+					Type:               TSASignerCondition,
+					Status:             metav1.ConditionFalse,
+					Reason:             state.Failure.String(),
+					Message:            ErrMissingKeysetRef.Error(),
+					ObservedGeneration: instance.GetGeneration(),
+				},
+			)
+		}
+		if err := generateSigner.RequireSecret(ctx, a.Client, instance.Namespace, signer.Tink.KeysetRef); err != nil {
+			return a.Error(ctx, fmt.Errorf("tink keyset secret: %w", err), instance,
+				metav1.Condition{
+					Type:               TSASignerCondition,
+					Status:             metav1.ConditionFalse,
+					Reason:             state.Failure.String(),
+					Message:            err.Error(),
+					ObservedGeneration: instance.GetGeneration(),
+				},
+				metav1.Condition{
+					Type:               constants.ReadyCondition,
+					Status:             metav1.ConditionFalse,
+					Reason:             state.Pending.String(),
+					Message:            err.Error(),
+					ObservedGeneration: instance.GetGeneration(),
+				},
+			)
+		}
+	}
+
+	chainRef := signer.CertificateChain.CertificateChainRef
+	if err := generateSigner.RequireSecret(ctx, a.Client, instance.Namespace, chainRef); err != nil {
+		return a.Error(ctx, fmt.Errorf("certificate chain secret: %w", err), instance,
+			metav1.Condition{
+				Type:               TSASignerCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Failure.String(),
+				Message:            err.Error(),
+				ObservedGeneration: instance.GetGeneration(),
+			},
+			metav1.Condition{
+				Type:               constants.ReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             state.Pending.String(),
+				Message:            err.Error(),
+				ObservedGeneration: instance.GetGeneration(),
+			},
+		)
+	}
+
+	if err := a.ensureCertChainLabel(ctx, instance, chainRef); err != nil {
+		a.Logger.V(1).Info("failed to apply labels to certificate chain secret", "error", err)
+	}
+
+	instance.Status.Signer = &rhtasv1.TimestampAuthoritySignerStatus{
+		CertificateChainRef: chainRef.DeepCopy(),
+	}
+
+	instance.SetCondition(metav1.Condition{
+		Type:               TSASignerCondition,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Resolved",
+		Message:            "Using existing secret",
+		ObservedGeneration: instance.GetGeneration(),
+	})
+
+	return a.ReturnOnChange(a.PersistStatus)(ctx, instance)
+}
+
+func (a *resolveKMSTinkSignerAction) ensureCertChainLabel(ctx context.Context, instance *rhtasv1.TimestampAuthority, ref *rhtasv1.SecretKeySelector) error {
+	label := labels.LabelNamespace + "/tsa.certchain.pem"
+
+	existing, err := kubernetes.ListSecrets(ctx, a.Client, instance.Namespace, label)
+	if err != nil {
+		return err
+	}
+	for _, s := range existing.Items {
+		if s.Name == ref.Name {
+			continue
+		}
+		if err := labels.Remove(ctx, &s, a.Client, label); err != nil {
+			return err
+		}
+	}
+
+	secret := &corev1.Secret{}
+	secret.Name = ref.Name
+	secret.Namespace = instance.Namespace
+	_, err = kubernetes.CreateOrUpdate(ctx, a.Client, secret,
+		ensure.Labels[*corev1.Secret]([]string{label}, map[string]string{label: tsaUtils.KeyCertificateChain}),
+	)
+	return err
+}

--- a/internal/controller/tsa/actions/resolve_kms_tink_signer_test.go
+++ b/internal/controller/tsa/actions/resolve_kms_tink_signer_test.go
@@ -1,0 +1,166 @@
+package actions
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	generateSigner "github.com/securesign/operator/internal/action/generateSigner"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestKMSTinkSigner_KMSWithCertChainRef(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+	instance := tsaInstance()
+	instance.Spec.Signer = rhtasv1.TimestampAuthoritySigner{
+		CertificateChain: rhtasv1.CertificateChain{
+			CertificateChainRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "kms-cert-secret"},
+				Key:                  "certificateChain",
+			},
+		},
+		Kms: &rhtasv1.KMS{
+			KeyResource: "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1",
+		},
+	}
+
+	certSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "kms-cert-secret", Namespace: "default"},
+		Data:       map[string][]byte{"certificateChain": []byte("cert-chain-data")},
+	}
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance, certSecret).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewResolveKMSTinkSignerAction())
+	g.Expect(a.CanHandle(ctx, instance)).To(BeTrue())
+
+	result := a.Handle(ctx, instance)
+	g.Expect(result).To(Equal(testAction.Return()))
+	g.Expect(instance.Status.Signer).NotTo(BeNil())
+	g.Expect(instance.Status.Signer.CertificateChainRef).NotTo(BeNil())
+	g.Expect(instance.Status.Signer.CertificateChainRef.Name).To(Equal("kms-cert-secret"))
+	g.Expect(instance.Status.Signer.FileSigner).To(BeNil())
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, TSASignerCondition)).To(BeTrue())
+}
+
+func TestKMSTinkSigner_TinkWithCertChainRef(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+	instance := tsaInstance()
+	instance.Spec.Signer = rhtasv1.TimestampAuthoritySigner{
+		CertificateChain: rhtasv1.CertificateChain{
+			CertificateChainRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "tink-cert-secret"},
+				Key:                  "certificateChain",
+			},
+		},
+		Tink: &rhtasv1.Tink{
+			KeysetRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "tink-keyset-secret"},
+				Key:                  "keySet",
+			},
+		},
+	}
+
+	certSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tink-cert-secret", Namespace: "default"},
+		Data:       map[string][]byte{"certificateChain": []byte("cert-chain-data")},
+	}
+	keysetSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "tink-keyset-secret", Namespace: "default"},
+		Data:       map[string][]byte{"keySet": []byte("keyset-data")},
+	}
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance, certSecret, keysetSecret).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewResolveKMSTinkSignerAction())
+	g.Expect(a.CanHandle(ctx, instance)).To(BeTrue())
+
+	result := a.Handle(ctx, instance)
+	g.Expect(result).To(Equal(testAction.Return()))
+	g.Expect(instance.Status.Signer).NotTo(BeNil())
+	g.Expect(instance.Status.Signer.CertificateChainRef).NotTo(BeNil())
+	g.Expect(instance.Status.Signer.CertificateChainRef.Name).To(Equal("tink-cert-secret"))
+	g.Expect(instance.Status.Signer.FileSigner).To(BeNil())
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, TSASignerCondition)).To(BeTrue())
+}
+
+func TestKMSTinkSigner_TinkWithoutKeysetRef(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+	instance := tsaInstance()
+	instance.Spec.Signer = rhtasv1.TimestampAuthoritySigner{
+		CertificateChain: rhtasv1.CertificateChain{
+			CertificateChainRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "tink-cert-secret"},
+				Key:                  "certificateChain",
+			},
+		},
+		Tink: &rhtasv1.Tink{},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewResolveKMSTinkSignerAction())
+	g.Expect(a.CanHandle(ctx, instance)).To(BeTrue())
+
+	result := a.Handle(ctx, instance)
+	g.Expect(result.Err).To(HaveOccurred())
+	g.Expect(errors.Is(result.Err, reconcile.TerminalError(result.Err))).To(BeTrue())
+	g.Expect(result.Err.Error()).To(ContainSubstring("missing keyset reference"))
+
+	cond := meta.FindStatusCondition(instance.Status.Conditions, TSASignerCondition)
+	g.Expect(cond).NotTo(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+}
+
+func TestKMSTinkSigner_FileTypeDisabled(t *testing.T) {
+	g := NewWithT(t)
+	instance := tsaInstance()
+
+	c := testAction.FakeClientBuilder().Build()
+	a := testAction.PrepareAction(c, NewResolveKMSTinkSignerAction())
+	g.Expect(a.CanHandle(t.Context(), instance)).To(BeFalse())
+}
+
+func TestKMSTinkSigner_MissingCertChainSecret(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+	instance := tsaInstance()
+	instance.Spec.Signer = rhtasv1.TimestampAuthoritySigner{
+		CertificateChain: rhtasv1.CertificateChain{
+			CertificateChainRef: &rhtasv1.SecretKeySelector{
+				LocalObjectReference: rhtasv1.LocalObjectReference{Name: "missing-secret"},
+				Key:                  "certificateChain",
+			},
+		},
+		Kms: &rhtasv1.KMS{
+			KeyResource: "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key/cryptoKeyVersions/1",
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewResolveKMSTinkSignerAction())
+	result := a.Handle(ctx, instance)
+
+	g.Expect(result).NotTo(BeNil())
+	g.Expect(result.Err).To(HaveOccurred())
+	g.Expect(errors.Is(result.Err, generateSigner.ErrSecretNotFound)).To(BeTrue())
+}

--- a/internal/controller/tsa/timestampauthority_controller.go
+++ b/internal/controller/tsa/timestampauthority_controller.go
@@ -103,6 +103,7 @@ func (r *timestampAuthorityReconciler) Reconcile(ctx context.Context, req ctrl.R
 		transitions.NewEnsureConditionsAction[*rhtasv1.TimestampAuthority](conditionSupplier),
 		actions.NewFIPSValidationAction(),
 		actions.NewGenerateSignerAction(),
+		actions.NewResolveKMSTinkSignerAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1.TimestampAuthority](),
 		actions.NewRBACAction(),
 		actions.NewNtpMonitoringAction(),


### PR DESCRIPTION
## Summary
- Fix nil pointer panic when deploying TSA with KMS or Tink signer
- The `isEnabled` callback was returning false for KMS/Tink, skipping
  status population that the deployment action depends on
- Add `resolveRef` handling for KMS/Tink that validates
  CertificateChainRef and Tink KeysetRef secrets before marking the
  signer as resolved
- Add `TerminalError` guard for Tink configured without KeysetRef
- Regression from generic signer refactor (6764d473)