### PR TITLE
docs: add v1 Securesign sample demonstrating imagePullSecrets

### DIFF
--- a/config/samples/rhtas_v1_securesign.yaml
+++ b/config/samples/rhtas_v1_securesign.yaml
@@ -1,0 +1,108 @@
+# Securesign sample on the v1 API (the CRD storage version).
+#
+# This mirrors rhtas_v1alpha1_securesign.yaml but uses apiVersion rhtas.redhat.com/v1
+# and additionally demonstrates per-component `imagePullSecrets`, which is only
+# available on the v1 API. Follow docs/kubernetes.md ("Image Registry") to create
+# the referenced `redhat-registry` pull secret before applying this CR, e.g.:
+#
+#   kubectl create secret docker-registry redhat-registry \
+#     --docker-server=registry.redhat.io \
+#     --docker-username=<your-username-or-sa-name> \
+#     --docker-password=<your-password-or-token> \
+#     -n <tas-namespace>
+#
+# Replace the placeholder Fulcio OIDC issuer URLs with a reachable issuer before use.
+apiVersion: rhtas.redhat.com/v1
+kind: Securesign
+metadata:
+  labels:
+    app.kubernetes.io/name: securesign-sample
+    app.kubernetes.io/instance: securesign-sample
+    app.kubernetes.io/part-of: trusted-artifact-signer
+  name: securesign-sample
+spec:
+  rekor:
+    imagePullSecrets:
+      - name: redhat-registry
+    ingress:
+      enabled: true
+    monitoring:
+      metrics:
+        enabled: true
+  trillian:
+    imagePullSecrets:
+      - name: redhat-registry
+    database:
+      create: true
+    monitoring:
+      metrics:
+        enabled: true
+  fulcio:
+    imagePullSecrets:
+      - name: redhat-registry
+    ingress:
+      enabled: true
+    config:
+      oidcIssuers:
+        - clientID: "trusted-artifact-signer"
+          issuerURL: "https://your-oidc-issuer-url"
+          issuer: "https://your-oidc-issuer-url"
+          type: "email"
+    signer:
+      certificateChain:
+        organizationName: Red Hat
+        organizationEmail: jdoe@redhat.com
+        commonName: fulcio.hostname
+    monitoring:
+      metrics:
+        enabled: true
+  tuf:
+    imagePullSecrets:
+      - name: redhat-registry
+    ingress:
+      enabled: true
+    keys:
+      - name: rekor.pub
+      - name: ctfe.pub
+      - name: fulcio_v1.crt.pem
+      - name: tsa.certchain.pem
+    rootKeySecretRef:
+      name: tuf-root-keys
+    pvc:
+      accessModes:
+        - ReadWriteOnce
+      retain: true
+      size: 100Mi
+  ctlog:
+    imagePullSecrets:
+      - name: redhat-registry
+    # signer is required on the v1 API; leave it empty to let the operator
+    # auto-generate and manage the CTlog signing key.
+    signer: {}
+    monitoring:
+      metrics:
+        enabled: true
+  tsa:
+    imagePullSecrets:
+      - name: redhat-registry
+    ingress:
+      enabled: true
+    monitoring:
+      metrics:
+        enabled: true
+    ntpMonitoring:
+      enabled: true
+    signer:
+      certificateChain:
+        rootCA:
+          organizationName: Red Hat
+          organizationEmail: jdoe@redhat.com
+          commonName: tsa.hostname-root
+        intermediateCA:
+          - organizationName: Red Hat
+            organizationEmail: jdoe@redhat.com
+            commonName: tsa.hostname-intermediate
+        leafCA:
+          organizationName: Red Hat
+          organizationEmail: jdoe@redhat.com
+          commonName: tsa.hostname-leaf

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -218,8 +218,14 @@ After the operator is running, create a namespace and apply a Securesign CR conf
 
 ```sh
 kubectl create ns securesign
-kubectl apply --server-side -n securesign -f config/samples/rhtas_v1alpha1_securesign.yaml
+kubectl apply --server-side -n securesign -f config/samples/rhtas_v1_securesign.yaml
 ```
+
+The `rhtas_v1_securesign.yaml` sample uses the `v1` API (the CRD storage version) and
+demonstrates the per-component `imagePullSecrets` described in
+[Image Registry](#image-registry). A `v1alpha1` variant
+(`config/samples/rhtas_v1alpha1_securesign.yaml`) is also provided for backward
+compatibility, but it cannot express `imagePullSecrets`.
 
 See `config/samples/` for example CR configurations with OIDC providers and external access.
 


### PR DESCRIPTION
This pull request adds a sample `Securesign` Custom Resource (CR) for the `v1` API and updates the vanilla-Kubernetes install docs to use it, demonstrating the per-component `imagePullSecrets` field that is only available on `v1`.

## Changes

- **New v1 sample CR:** added `config/samples/rhtas_v1_securesign.yaml`, a `rhtas.redhat.com/v1` sample mirroring `rhtas_v1alpha1_securesign.yaml`, with `imagePullSecrets` configured on every component.
- **docs/kubernetes.md:** the EKS install walkthrough now applies `rhtas_v1_securesign.yaml` instead of the `v1alpha1` sample, with a note explaining the `v1` sample demonstrates `imagePullSecrets` and that the `v1alpha1` sample remains available for backward compatibility (it cannot express `imagePullSecrets`).

## Validation

The initial version of the sample had two fields that don't exist on the `v1` API and would fail CRD validation:
- `fulcio.certificate` → corrected to `fulcio.signer.certificateChain` (`FulcioSpec.Signer` is required in `v1`).
- `ctlog.signer` was missing (`CTlogSpec.Signer` is required in `v1` but doesn't exist in `v1alpha1`, so it's easy to miss when mirroring the old sample).

Both were caught and fixed, then verified with a real `kubectl apply --server-side --dry-run=server` against the `v1` CRD, which now succeeds with no validation errors.

Assisted-by: Co-pilot(Claude Sonnet 5)
