### PR TITLE
Update operator images from release builds 2026-07-30

### DIFF
--- a/config/default/images.env
+++ b/config/default/images.env
@@ -1,50 +1,50 @@
 # Trillian - Log Signer
-RELATED_IMAGE_TRILLIAN_LOG_SIGNER=registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:0a95cb8267a110b63b69593ec498ea33c7a2bb03dd541222ff3f966a4dfbcbbd
+RELATED_IMAGE_TRILLIAN_LOG_SIGNER=registry.redhat.io/rhtas/trillian-logsigner-rhel9@sha256:e9d5ddcfdebb4c728bbdc5b305216d372d6d880dd7c85fadb6df7bed6b47a8d2
 
 # Trillian - Database
-RELATED_IMAGE_TRILLIAN_DB=registry.redhat.io/rhtas/trillian-database-rhel9@sha256:437ce01cae0d9edd0623e24dffe6df52b9fffd03a356fe5e07018c74f587ab67
+RELATED_IMAGE_TRILLIAN_DB=registry.redhat.io/rhtas/trillian-database-rhel9@sha256:fa963e4b0f7c6ee46d84f9a5e5e31445d659db80e08a90e0927646bc24c1e53b
 
 # Trillian - Log Server
-RELATED_IMAGE_TRILLIAN_LOG_SERVER=registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:08d2c4cc9c03a7a3341c228adf7865f71a57daba43e78e8a1a72ca9f39c2370e
+RELATED_IMAGE_TRILLIAN_LOG_SERVER=registry.redhat.io/rhtas/trillian-logserver-rhel9@sha256:e3a8872b1ffd7282ec1133fcc7826682fb77c09e3d44cc2394bf9113dcb1e34c
 
 # Trillian - Netcat (ose-tools)
 RELATED_IMAGE_TRILLIAN_NETCAT=registry.redhat.io/openshift4/ose-tools-rhel9@sha256:f9c033d1f8f867ac0d9e683a84281187bcaa33d8198911b1780bbcd571688235
 
 # Trillian - CreateTree
-RELATED_IMAGE_CREATETREE=registry.redhat.io/rhtas/createtree-rhel9@sha256:0d0b8323ed753f83956ea3498d1bbf29ea0d0423e14e3dc3e1963c5b616012e9
+RELATED_IMAGE_CREATETREE=registry.redhat.io/rhtas/createtree-rhel9@sha256:be9734d8982ba67b2ec1b7b69199b5aded23bfc7c9d9f3eda47f3f0ccd110ab8
 
 # Fulcio - Server
-RELATED_IMAGE_FULCIO_SERVER=registry.redhat.io/rhtas/fulcio-rhel9@sha256:1f61255fe0c6fb21df53446daba1d5bec587c78f39b9d97c83701e0cb3cc538c
+RELATED_IMAGE_FULCIO_SERVER=registry.redhat.io/rhtas/fulcio-rhel9@sha256:0996775ede985a6b2b1ada6045c1ab4d60d16977d7087326ee14988e28be87e6
 
 # Rekor - Server
-RELATED_IMAGE_REKOR_SERVER=registry.redhat.io/rhtas/rekor-server-rhel9@sha256:ac59364f7baefa6ee9dfc5bcafe3d6d65adf50e753d59622e37607e2b878f36b
+RELATED_IMAGE_REKOR_SERVER=registry.redhat.io/rhtas/rekor-server-rhel9@sha256:b0264e38a58995d26b27042c23c023a410c9632f472c56db85db5a5fef96bb85
 
 # Rekor - Redis
-RELATED_IMAGE_REKOR_REDIS=registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:12cf9d1cd3cbd3d1cdc7157f83630cc118f61b4922a49457028d07ae50d7f1ce
+RELATED_IMAGE_REKOR_REDIS=registry.redhat.io/rhtas/trillian-redis-rhel9@sha256:f56e3c3845c4d37ec8b47f6dc00dec4186cba95b66ae88c99b4969eea3eb56e1
 
 # Rekor - Search UI
-RELATED_IMAGE_REKOR_SEARCH_UI=registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:9a22038a93528e82148cad57784b13ccb1ed52de9f47d9b52cac94b105fc569e
+RELATED_IMAGE_REKOR_SEARCH_UI=registry.redhat.io/rhtas/rekor-search-ui-rhel9@sha256:ac76a66ffeffbccea272181936686f4160f190f5575c8b27357a1b8e4f5640b7
 
 # Rekor - Backfill Redis
-RELATED_IMAGE_BACKFILL_REDIS=registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:564bcd4b65abb4971f7d9dee41ef9ebc72d3477f9e57b55d0a0c292b063d4035
+RELATED_IMAGE_BACKFILL_REDIS=registry.redhat.io/rhtas/rekor-backfill-redis-rhel9@sha256:414b330788915c554e162ad87da9dcb62b0bc44f50ea4fb9586c1a1b61d6e47e
 
 # TUF - Server
-RELATED_IMAGE_TUF=registry.redhat.io/rhtas/tuffer-rhel9@sha256:57a4aebf9c54b0747fdea757ce268987314ecd8b284d1a91d4317faa55623b6e
+RELATED_IMAGE_TUF=registry.redhat.io/rhtas/tuffer-rhel9@sha256:7e5f420f6a469525e6a3bff9fff41a1c646aca0bb0429a2c6edc7f398409b757
 
 # CTlog - Server
-RELATED_IMAGE_CTLOG=registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:a00cc819616803193674883d789b9a3c9a477904fc9881241b7411c64fedc164
+RELATED_IMAGE_CTLOG=registry.redhat.io/rhtas/certificate-transparency-rhel9@sha256:5a07b75ddd1a925c85b22cba4eac9317370e5fc9ca01d79e7a6414246171bb90
 
 # HTTP Server (httpd)
 RELATED_IMAGE_HTTP_SERVER=registry.redhat.io/ubi9/httpd-24@sha256:e65107714c48505af8070c750d45827295e0b16e9924992864c5a5dad7beb4d2
 
 # Timestamp Authority - Server
-RELATED_IMAGE_TIMESTAMP_AUTHORITY=registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:a4c58969cca61ab3ebfa62ed56a41e740b706533431cc003d135614477fb47c2
+RELATED_IMAGE_TIMESTAMP_AUTHORITY=registry.redhat.io/rhtas/timestamp-authority-rhel9@sha256:0c392cea88e98bed79228bedd39e5f046945277147c44cec1f15d2f756e84da3
 
 # Client Server - CLI tools
-RELATED_IMAGE_CLIENT_SERVER=registry.redhat.io/rhtas/client-server-rhel9@sha256:99b6d8677d7d49d5130ce315bbcc6912fe750e0ad96f6c77bdaf2696ebe35668
+RELATED_IMAGE_CLIENT_SERVER=registry.redhat.io/rhtas/client-server-rhel9@sha256:3d08a27f79bda1f19369786723cb8d1e130c3d46cbb8a7f44e30571d5a213240
 
 # Rekor - Monitor
-RELATED_IMAGE_REKOR_MONITOR=registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:865475757d942578bf0561d8ab7b1a0dc45197b0417682c77775fbe7471774f4
+RELATED_IMAGE_REKOR_MONITOR=registry.redhat.io/rhtas/rekor-monitor-rhel9@sha256:e96b0b3146b63f4710ebfb3ed4a4edd9278b15852aa3130881e8332965bf00a3
 
 # CTlog - Monitor
-RELATED_IMAGE_CTLOG_MONITOR=registry.redhat.io/rhtas/ctlog-monitor-rhel9@sha256:e459bfc1a3fa6aa7e5d2f0f3ec8abeaa17aed09bed1d9b41220f2cc2b3cc1bd8
+RELATED_IMAGE_CTLOG_MONITOR=registry.redhat.io/rhtas/ctlog-monitor-rhel9@sha256:30ada665ab85885aab04afce71b8e0403c14d1b7e5c94bffcbde39d09eb2863d


### PR DESCRIPTION
## Summary
This PR updates operator component images in `config/default/images.env` with the latest 1.4.3 release builds.

### Source snapshots
- Wave 1: `tas-components-v1-4-20260730-062129-000`, `rekor-monitor-v1-4-20260730-061538-000`, `create-tree-v1-4-20260730-062515-000`, `tough-v1-4-20260730-063816-000`
- Wave 2: `client-server-v1-4-20260730-074512-000`

### Updated (15 components)
Trillian (logsigner, database, logserver), createtree, fulcio-server, rekor-server, redis, rekor-search-ui, backfill-redis, tuffer, certificate-transparency-go, timestamp-authority, client-server, rekor-monitor, ctlog-monitor