### PR TITLE
fix: trillian logsigner actions use wrong condition type

### DIFF
--- a/internal/controller/trillian/actions/logserver/deployment.go
+++ b/internal/controller/trillian/actions/logserver/deployment.go
@@ -77,10 +77,11 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1.Trillian) *a
 
 	if result != controllerutil.OperationResultNone {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    actions.ServerCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  state.Creating.String(),
-			Message: "Deployment created",
+			Type:               actions.ServerCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             state.Creating.String(),
+			Message:            "Deployment created",
+			ObservedGeneration: instance.Generation,
 		})
 		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {

--- a/internal/controller/trillian/actions/logserver/service.go
+++ b/internal/controller/trillian/actions/logserver/service.go
@@ -95,10 +95,11 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1.Trill
 
 	if result != controllerutil.OperationResultNone {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    actions.ServerCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  state.Creating.String(),
-			Message: "Service created",
+			Type:               actions.ServerCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             state.Creating.String(),
+			Message:            "Service created",
+			ObservedGeneration: instance.Generation,
 		})
 		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {

--- a/internal/controller/trillian/actions/logsigner/deployment.go
+++ b/internal/controller/trillian/actions/logsigner/deployment.go
@@ -78,10 +78,11 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1.Trillian) *a
 
 	if result != controllerutil.OperationResultNone {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    actions.SignerCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  state.Creating.String(),
-			Message: "Deployment created",
+			Type:               actions.SignerCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             state.Creating.String(),
+			Message:            "Deployment created",
+			ObservedGeneration: instance.Generation,
 		})
 		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {

--- a/internal/controller/trillian/actions/logsigner/monitoring.go
+++ b/internal/controller/trillian/actions/logsigner/monitoring.go
@@ -21,7 +21,7 @@ func (logsignerMonitoringConfig) TLS(i *rhtasv1.Trillian) rhtasv1.TLS {
 func NewCreateMonitorAction() action.Action[*rhtasv1.Trillian] {
 	return monitoring.NewAction(
 		actions.LogSignerComponentName, actions.LogSignerMonitoringName, actions.LogSignerComponentName,
-		actions.ServerCondition,
+		actions.SignerCondition,
 		logsignerMonitoringConfig{},
 	)
 }

--- a/internal/controller/trillian/actions/logsigner/service.go
+++ b/internal/controller/trillian/actions/logsigner/service.go
@@ -86,10 +86,11 @@ func (i createServiceAction) Handle(ctx context.Context, instance *rhtasv1.Trill
 
 	if result != controllerutil.OperationResultNone {
 		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
-			Type:    actions.ServerCondition,
-			Status:  metav1.ConditionFalse,
-			Reason:  state.Creating.String(),
-			Message: "Service created",
+			Type:               actions.SignerCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             state.Creating.String(),
+			Message:            "Service created",
+			ObservedGeneration: instance.Generation,
 		})
 		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
 	} else {


### PR DESCRIPTION
## Summary

Two pre-existing bugs in the Trillian logsigner controller actions that prevent the SecureSign stack from reliably reaching Ready state:

- **Wrong condition type:** `logsigner/service.go` and `logsigner/monitoring.go` use `actions.ServerCondition` ("LogServerAvailable") instead of `actions.SignerCondition` ("LogSignerAvailable"). When the logsigner service is created, it overwrites the logserver's condition to "Creating", causing `LogServerAvailable` to oscillate between Creating and Ready.

- **Missing ObservedGeneration:** All four deployment/service actions in logserver and logsigner set conditions without `ObservedGeneration`, inconsistent with the rollout check actions.

The combined effect blocks the dependency chain: Trillian never reaches Ready → CTLog can't complete → TUF can't resolve keys → SecureSign stays stuck.

### Files changed
| File | Change |
|------|--------|
| `logsigner/service.go` | `ServerCondition` → `SignerCondition` + add `ObservedGeneration` |
| `logsigner/monitoring.go` | `ServerCondition` → `SignerCondition` |
| `logsigner/deployment.go` | Add `ObservedGeneration` |
| `logserver/deployment.go` | Add `ObservedGeneration` |
| `logserver/service.go` | Add `ObservedGeneration` |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/controller/trillian/...` passes
- [ ] Deploy SecureSign CR — all conditions reach Ready without oscillation
- [ ] Verify Trillian LogServerAvailable and LogSignerAvailable both stabilize at Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)