### PR TITLE
fix(e2e): migrate test image registry from ttl.sh to quay

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,6 +219,14 @@ jobs:
           registry: registry.redhat.io
           auth_file_path: /tmp/config.json
 
+      - name: Log in to quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+          auth_file_path: /tmp/config.json
+
       - name: Install Cluster
         uses: ./.github/actions/kind-cluster
         with:
@@ -255,6 +263,8 @@ jobs:
 
       - name: Run tests
         run: make test-e2e
+        env:
+          DOCKER_CONFIG: /tmp
 
       - name: Archive test artifacts
         uses: actions/upload-artifact@v4
@@ -304,6 +314,14 @@ jobs:
           registry: registry.redhat.io
           auth_file_path: /tmp/config.json
 
+      - name: Log in to quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+          auth_file_path: /tmp/config.json
+
       - name: Install Cluster
         uses: ./.github/actions/kind-cluster
         with:
@@ -323,7 +341,7 @@ jobs:
           podman save ${{ env.IMG }} -o operator-oci.tar
           podman save ${{ env.BUNDLE_IMG }} -o operator-bundle-oci.tar
           podman save ${{ env.CATALOG_IMG }} -o operator-fbc-oci.tar
-          
+
           kind load image-archive operator-oci.tar
           kind load image-archive operator-bundle-oci.tar
           kind load image-archive operator-fbc-oci.tar
@@ -343,6 +361,7 @@ jobs:
           TEST_TARGET_CATALOG: ${{ env.CATALOG_IMG }}
           TEST_UPGRADE_CHANNEL: stable-v1.3
           OPENSHIFT: false
+          DOCKER_CONFIG: /tmp
         run: go test -p 1 ./test/e2e/... -tags=upgrade -timeout 20m
 
       - name: Archive test artifacts
@@ -386,6 +405,14 @@ jobs:
           registry: registry.redhat.io
           auth_file_path: /tmp/config.json
 
+      - name: Log in to quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+          auth_file_path: /tmp/config.json
+
       - name: Install Cluster
         uses: ./.github/actions/kind-cluster
         with:
@@ -423,6 +450,8 @@ jobs:
         run: go install github.com/sigstore/cosign/v2/cmd/cosign@v2.4.0
 
       - name: Run tests
+        env:
+          DOCKER_CONFIG: /tmp
         run: |
           make generate && go test -p 1 ./test/e2e/... -tags=ha -timeout 20m
 
@@ -561,6 +590,14 @@ jobs:
           registry: registry.redhat.io
           auth_file_path: /tmp/config.json
 
+      - name: Log in to quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: quay.io
+          auth_file_path: /tmp/config.json
+
       - name: Install Cluster
         id: kind
         uses: ./.github/actions/kind-cluster
@@ -605,6 +642,8 @@ jobs:
           kubectl wait --for=condition=Ready securesign/securesign-sample --timeout=10m -n ${{ env.TEST_NAMESPACE }}
 
       - name: Run tests
+        env:
+          DOCKER_CONFIG: /tmp
         run: |
           export OIDC_ISSUER_URL="http://${{ steps.kind.outputs.oidc_host }}/realms/trusted-artifact-signer"
           export FULCIO_URL=$(kubectl get fulcio -o jsonpath='{.items[0].status.url}' -n ${{ env.TEST_NAMESPACE }})

--- a/test/e2e/support/common.go
+++ b/test/e2e/support/common.go
@@ -22,7 +22,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/yaml"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	containerv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/uuid"
@@ -90,13 +93,28 @@ func PrepareImage(ctx context.Context) string {
 		panic(err.Error())
 	}
 
-	targetImageName := fmt.Sprintf("ttl.sh/%s:15m", uuid.New().String())
-	ref, err := name.ParseReference(targetImageName)
+	image, err = mutate.Config(image, containerv1.Config{
+		Labels: map[string]string{
+			"quay.expires-after": "1h",
+			"run-id":             uuid.New().String(),
+		},
+	})
 	if err != nil {
 		panic(err.Error())
 	}
 
-	pusher, err := remote.NewPusher()
+	digest, err := image.Digest()
+	if err != nil {
+		panic(err.Error())
+	}
+
+	imageRef := fmt.Sprintf("quay.io/securesign/e2e-tests@%s", digest.String())
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	pusher, err := remote.NewPusher(remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -105,7 +123,36 @@ func PrepareImage(ctx context.Context) string {
 	if err != nil {
 		panic(err.Error())
 	}
-	return targetImageName
+	return imageRef
+}
+
+func CreateRegistryAuthSecret(ctx context.Context, cli client.Client, namespace, secretName string) error {
+	dockerConfigDir := os.Getenv("DOCKER_CONFIG")
+	if dockerConfigDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home dir: %w", err)
+		}
+		dockerConfigDir = filepath.Join(home, ".docker")
+	}
+	configPath := filepath.Join(dockerConfigDir, "config.json")
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read docker config at %s: %w", configPath, err)
+	}
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Type: v1.SecretTypeDockerConfigJson,
+		Data: map[string][]byte{
+			v1.DockerConfigJsonKey: data,
+		},
+	}
+	return cli.Create(ctx, secret)
 }
 
 func EnvOrDefault(env string, def string) string {


### PR DESCRIPTION
Push e2e test images to the e2e-tests quay repo with unique tags per test run. For Konflux cluster runs, the quay secret is stored on-cluster and referenced in pipelines. For GitHub Actions, the secret is ingested from the repo secrets in workflows.