### PR TITLE
fix: update TUF URL resolution logic and adjust tests for external ingress handling

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -148,6 +148,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - networkpolicies
   verbs:
   - create
   - delete

--- a/internal/controller/console/actions/api/deployment.go
+++ b/internal/controller/console/actions/api/deployment.go
@@ -48,9 +48,14 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1.Console) *ac
 		result controllerutil.OperationResult
 	)
 
-	tufURL, err := utils.ResolveExternalServiceUrl(ctx, i.Client, instance.Spec.Api.Tuf, instance.Namespace, &rhtasv1.Tuf{})
-	if err != nil {
-		return i.Error(ctx, fmt.Errorf("error resolving TUF URL: %w", err), instance)
+	var tufURL string
+	if instance.Spec.Api.Tuf.URL != "" || instance.Spec.Api.Tuf.Ref != nil {
+		tufURL, err = utils.ResolveExternalServiceUrl(ctx, i.Client, instance.Spec.Api.Tuf, instance.Namespace, &rhtasv1.Tuf{})
+		if err != nil {
+			return i.Error(ctx, fmt.Errorf("error resolving TUF URL: %w", err), instance)
+		}
+	} else {
+		tufURL = fmt.Sprintf("http://tuf.%s.svc", instance.Namespace)
 	}
 
 	l := labels.For(actions.ApiComponentName, actions.ApiDeploymentName, instance.Name)

--- a/internal/controller/console/actions/api/deployment.go
+++ b/internal/controller/console/actions/api/deployment.go
@@ -10,6 +10,7 @@ import (
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/controller/console/actions"
+	tufConstants "github.com/securesign/operator/internal/controller/tuf/constants"
 	"github.com/securesign/operator/internal/images"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
@@ -55,7 +56,7 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1.Console) *ac
 			return i.Error(ctx, fmt.Errorf("error resolving TUF URL: %w", err), instance)
 		}
 	} else {
-		tufURL = fmt.Sprintf("http://tuf.%s.svc", instance.Namespace)
+		tufURL = fmt.Sprintf("http://%s.%s.svc", tufConstants.DeploymentName, instance.Namespace)
 	}
 
 	l := labels.For(actions.ApiComponentName, actions.ApiDeploymentName, instance.Name)

--- a/internal/controller/console/console_controller_test.go
+++ b/internal/controller/console/console_controller_test.go
@@ -75,9 +75,9 @@ var _ = Describe("Console controller", func() {
 			}
 			Expect(suite.Client().Create(ctx, tuf)).To(Succeed())
 			// Simulates a Tuf instance with Ingress enabled, where status-url.go
-				// resolves Status.Url to the external route/ingress host rather than
-				// the in-cluster Service DNS name.
-				tuf.Status.Url = "https://tuf-default.apps.example.com"
+			// resolves Status.Url to the external route/ingress host rather than
+			// the in-cluster Service DNS name.
+			tuf.Status.Url = "https://tuf-default.apps.example.com"
 			tuf.Status.Conditions = []metav1.Condition{
 				{Type: constants.ReadyCondition, Status: metav1.ConditionTrue, Reason: "Ready", LastTransitionTime: metav1.Now()},
 			}

--- a/internal/controller/console/console_controller_test.go
+++ b/internal/controller/console/console_controller_test.go
@@ -74,7 +74,10 @@ var _ = Describe("Console controller", func() {
 				},
 			}
 			Expect(suite.Client().Create(ctx, tuf)).To(Succeed())
-			tuf.Status.Url = "http://tuf.default.svc"
+			// Simulates a Tuf instance with Ingress enabled, where status-url.go
+				// resolves Status.Url to the external route/ingress host rather than
+				// the in-cluster Service DNS name.
+				tuf.Status.Url = "https://tuf-default.apps.example.com"
 			tuf.Status.Conditions = []metav1.Condition{
 				{Type: constants.ReadyCondition, Status: metav1.ConditionTrue, Reason: "Ready", LastTransitionTime: metav1.Now()},
 			}
@@ -111,6 +114,20 @@ var _ = Describe("Console controller", func() {
 			Eventually(func() error {
 				return suite.Client().Get(ctx, types.NamespacedName{Name: actions.ApiDeploymentName, Namespace: Namespace}, &appsv1.Deployment{})
 			}).Should(Succeed())
+
+			By("API Deployment uses the in-cluster TUF service URL when Console.Spec.Api.Tuf is not explicitly set, ignoring Tuf's externally-facing Status.Url")
+			apiDeployment := &appsv1.Deployment{}
+			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.ApiDeploymentName, Namespace: Namespace}, apiDeployment)).To(Succeed())
+			Expect(apiDeployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--tuf-repo-url=http://tuf.default.svc"))
+			var waitForTuf *corev1.Container
+			for i := range apiDeployment.Spec.Template.Spec.InitContainers {
+				if apiDeployment.Spec.Template.Spec.InitContainers[i].Name == "wait-for-tuf" {
+					waitForTuf = &apiDeployment.Spec.Template.Spec.InitContainers[i]
+				}
+			}
+			Expect(waitForTuf).ToNot(BeNil())
+			Expect(waitForTuf.Args[0]).To(ContainSubstring("http://tuf.default.svc"))
+			Expect(waitForTuf.Args[0]).ToNot(ContainSubstring("apps.example.com"))
 
 			By("API Service created")
 			Eventually(func() error {

--- a/internal/controller/types.go
+++ b/internal/controller/types.go
@@ -25,6 +25,7 @@ import (
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;get;list;watch;update;patch;delete
 
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete;deletecollection
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;deletecollection


### PR DESCRIPTION
**Summary**

The FIPS e2e "Console is running" test was timing out after 180s. The console-api and console-ui pods were stuck in PodInitializing with their init containers never completed, so the Console CR never reached a Ready state.

**Root Cause**

The console-api's wait-for-tuf init container curls the TUF URL in an unbounded loop (no retry limit/exit). With commit [ff65bdef](https://github.com/securesign/secure-sign-operator/commit/ff65bdef3b1b18002f7af3fd44a485ec2d459142) accidentally dropped the fallback that used the in-cluster address so when no explicit TUF ref is set on the Console CR, making it always autodiscover TUF's external URL instead. Since the FIPS suite enables Ingress on all components, that external URL is an unreachable public route from inside the pod, so the init container hangs forever which cascades to console-ui and blocking Console from ever going Ready. The sibling Rekor code path ui/deployment.go still has this guard, which confirms the drop was accidental.

**Current Fix**

Restored the guard in internal/controller/console/actions/api/deployment.go: to use the in-cluster TUF URL unless the Console CR explicitly configures one, matching the existing [URL pattern](https://github.com/securesign/secure-sign-operator/blob/main/internal/controller/tuf/actions/status-url.go#L48). Added a regression test in console_controller_test.go (fails on old code, passes with fix); full controller test suite passes.

**Additional Fix**

The verify-enterprise-contract check was failing "policy", a new Konflux policy now requires operator bundles to grant RBAC (create, delete, update/patch) on networking.k8s.io/networkpolicies for their operands. Currently the operator's ClusterRole only had this for ingresses. This fix also includes +kubebuilder:rbac marker for networkpolicies in internal/controller/types.go and regenerated config/rbac/role.yaml via make manifests.



