### PR TITLE
fix: enable autodiscovery and use correct service URLs in console controller

### DIFF
--- a/internal/controller/console/actions/api/deployment.go
+++ b/internal/controller/console/actions/api/deployment.go
@@ -10,7 +10,6 @@ import (
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/controller/console/actions"
-	tufConstants "github.com/securesign/operator/internal/controller/tuf/constants"
 	"github.com/securesign/operator/internal/images"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/state"
@@ -49,14 +48,9 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1.Console) *ac
 		result controllerutil.OperationResult
 	)
 
-	var tufURL string
-	if instance.Spec.Api.Tuf.URL != "" || instance.Spec.Api.Tuf.Ref != nil {
-		tufURL, err = utils.ResolveExternalServiceUrl(ctx, i.Client, instance.Spec.Api.Tuf, instance.Namespace, &rhtasv1.Tuf{})
-		if err != nil {
-			return i.Error(ctx, fmt.Errorf("error resolving TUF URL: %w", err), instance)
-		}
-	} else {
-		tufURL = fmt.Sprintf("http://%s.%s.svc", tufConstants.DeploymentName, instance.Namespace)
+	tufURL, err := utils.ResolveInternalServiceUrl(ctx, i.Client, instance.Spec.Api.Tuf, instance.Namespace, &rhtasv1.Tuf{})
+	if err != nil {
+		return i.Error(ctx, fmt.Errorf("error resolving TUF URL: %w", err), instance)
 	}
 
 	l := labels.For(actions.ApiComponentName, actions.ApiDeploymentName, instance.Name)

--- a/internal/controller/console/actions/ui/deployment.go
+++ b/internal/controller/console/actions/ui/deployment.go
@@ -47,12 +47,9 @@ func (i deployAction) Handle(ctx context.Context, instance *rhtasv1.Console) *ac
 		result controllerutil.OperationResult
 	)
 
-	var rekorURL string
-	if instance.Spec.UI.Rekor.URL != "" || instance.Spec.UI.Rekor.Ref != nil {
-		rekorURL, err = utils.ResolveExternalServiceUrl(ctx, i.Client, instance.Spec.UI.Rekor, instance.Namespace, &rhtasv1.Rekor{})
-		if err != nil {
-			return i.Error(ctx, fmt.Errorf("error resolving Rekor URL: %w", err), instance)
-		}
+	rekorURL, err := utils.ResolveExternalServiceUrl(ctx, i.Client, instance.Spec.UI.Rekor, instance.Namespace, &rhtasv1.Rekor{})
+	if err != nil {
+		return i.Error(ctx, fmt.Errorf("error resolving Rekor URL: %w", err), instance)
 	}
 
 	l := labels.For(actions.UIComponentName, actions.UIDeploymentName, instance.Name)

--- a/internal/controller/console/console_controller_test.go
+++ b/internal/controller/console/console_controller_test.go
@@ -83,6 +83,20 @@ var _ = Describe("Console controller", func() {
 			}
 			Expect(suite.Client().Status().Update(ctx, tuf)).To(Succeed())
 
+			By("creating the Rekor resource for autodiscovery")
+			rekor := &rhtasv1.Rekor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      Name,
+					Namespace: Namespace,
+				},
+			}
+			Expect(suite.Client().Create(ctx, rekor)).To(Succeed())
+			rekor.Status.Url = "https://rekor-default.apps.example.com"
+			rekor.Status.Conditions = []metav1.Condition{
+				{Type: constants.ReadyCondition, Status: metav1.ConditionTrue, Reason: "Ready", LastTransitionTime: metav1.Now()},
+			}
+			Expect(suite.Client().Status().Update(ctx, rekor)).To(Succeed())
+
 			By("creating the custom resource for the Kind Console")
 			err := suite.Client().Get(ctx, typeNamespaceName, console)
 			if err != nil && errors.IsNotFound(err) {
@@ -118,7 +132,7 @@ var _ = Describe("Console controller", func() {
 			By("API Deployment uses the in-cluster TUF service URL when Console.Spec.Api.Tuf is not explicitly set, ignoring Tuf's externally-facing Status.Url")
 			apiDeployment := &appsv1.Deployment{}
 			Expect(suite.Client().Get(ctx, types.NamespacedName{Name: actions.ApiDeploymentName, Namespace: Namespace}, apiDeployment)).To(Succeed())
-			Expect(apiDeployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--tuf-repo-url=http://tuf.default.svc"))
+			Expect(apiDeployment.Spec.Template.Spec.Containers[0].Args).To(ContainElement("--tuf-repo-url=http://tuf.default.svc:80"))
 			var waitForTuf *corev1.Container
 			for i := range apiDeployment.Spec.Template.Spec.InitContainers {
 				if apiDeployment.Spec.Template.Spec.InitContainers[i].Name == "wait-for-tuf" {

--- a/internal/controller/tuf/serviceresolver/resolver.go
+++ b/internal/controller/tuf/serviceresolver/resolver.go
@@ -11,6 +11,6 @@ import (
 func init() {
 	serviceresolver.Register(
 		func(obj *rhtasv1.Tuf) (string, error) {
-			return fmt.Sprintf("http://%s.%s.svc:%d", constants.DeploymentName, obj.Namespace, constants.Port), nil
+			return fmt.Sprintf("http://%s.%s.svc:%d", constants.DeploymentName, obj.Namespace, obj.Spec.Port), nil
 		})
 }


### PR DESCRIPTION
Summary

- Console API (api/deployment.go): Replace guarded ResolveExternalServiceUrl + hardcoded fallback with ResolveInternalServiceUrl. The TUF URL is used by the init container and --tuf-repo-url (pod-to-pod), so it must be an in-cluster address. The guard also prevented autodiscovery when neither URL nor Ref was set.
- Console UI (ui/deployment.go): Remove the guard around ResolveExternalServiceUrl so autodiscovery kicks in when neither URL nor Ref is set. The external URL is correct here since NEXT_PUBLIC_REKOR_DEFAULT_DOMAIN is consumed by the browser (An internal URL like `http://rekor-server.trusted-artifact-signer.svc` would be unreachable from the browser + console ui requires rekor url protocol to be https).
- TUF service resolver (tuf/serviceresolver/resolver.go): Use obj.Spec.Port (the Kubernetes Service port, default 80) instead of constants.Port (the container target port, 8080). The previous value produced an unreachable URL (tuf.<ns>.svc:8080) since the Service exposes port 80.