### PR TITLE
feat: implement user specification tracking for pod resources and reconcile logic

### DIFF
--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -147,6 +147,22 @@ const (
 	// trust material change and accept the newly observed value.
 	RefreshTrustMaterial = "rhtas.redhat.com/refresh-trust-material"
 
+	// LastUserSpecApplied tracks the names of user-specified resources (volumes,
+	// volume mounts, annotations, labels) applied during the last reconcile.
+	// The value is a JSON-encoded object used to detect removals on the next reconcile.
+	//
+	// We use an annotation-based diff approach instead of Server-Side Apply (SSA)
+	// because SSA field ownership tracks at the field level, not the semantic
+	// "user-specified resource" level. When the operator and user both touch
+	// PodSpec.Volumes, SSA cannot distinguish operator-managed volumes from
+	// user-specified ones — conflicts arise on shared slice fields, and removing
+	// a single user volume requires the operator to re-apply the entire field,
+	// which risks clobbering operator-managed entries. This annotation sidesteps
+	// SSA ownership entirely: it records which named resources the user specified,
+	// so the next reconcile can compute the diff and remove stale items without
+	// affecting operator-managed resources in the same slice.
+	LastUserSpecApplied = "rhtas.redhat.com/last-user-spec-applied"
+
 	TLS = "service.beta.openshift.io/serving-cert-secret-name"
 )
 

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -147,9 +147,17 @@ const (
 	// trust material change and accept the newly observed value.
 	RefreshTrustMaterial = "rhtas.redhat.com/refresh-trust-material"
 
-	// LastUserSpecApplied tracks the names of user-specified resources (volumes,
-	// volume mounts, annotations, labels) applied during the last reconcile.
-	// The value is a JSON-encoded object used to detect removals on the next reconcile.
+	// LastUserSpecApplied tracks, per concern, the names of user-specified
+	// resources applied during the last reconcile, so the next reconcile can
+	// detect removals. The value is a JSON object keyed by concern name, e.g.:
+	//
+	//	{"podExtensions": {"volumes": ["a"], "volumeMounts": ["a"]}}
+	//
+	// Each concern (e.g. "podExtensions") owns exactly one top-level key and
+	// only ever reads/writes it via ensure.ReadNamespacedState /
+	// ensure.WriteNamespacedState — this lets multiple independent ensure
+	// functions share this one annotation on the same object without
+	// overwriting each other's tracked state.
 	//
 	// We use an annotation-based diff approach instead of Server-Side Apply (SSA)
 	// because SSA field ownership tracks at the field level, not the semantic

--- a/internal/utils/kubernetes/ensure/deployment/deployment.go
+++ b/internal/utils/kubernetes/ensure/deployment/deployment.go
@@ -55,13 +55,19 @@ func PodRequirements(requirements rhtasv1.PodRequirements, containerName string)
 }
 
 // PodExtensions applies user-defined init containers, volumes, and volume mounts
-// to a Deployment. It is a standalone ensure function so callers can compose it
-// independently from signer-specific logic.
+// to a Deployment. It reads the previous state from the tracking annotation,
+// removes stale resources, upserts desired ones, and writes the current state back.
 func PodExtensions(ext rhtasv1.PodExtensions, containerName string) func(*v1.Deployment) error {
 	return func(dp *v1.Deployment) error {
+		prev := ensure.ReadLastApplied(dp)
 		template := &dp.Spec.Template
-		container := kubernetes.FindContainerByNameOrCreate(&template.Spec, containerName)
-		ensure.ReconcileUserPodResources(&template.Spec, container, ext)
+		current, err := ensure.ReconcileUserPodResources(&template.Spec, containerName, ext, prev)
+		if err != nil {
+			return err
+		}
+		current.Annotations = prev.Annotations
+		current.Labels = prev.Labels
+		ensure.WriteLastApplied(dp, current)
 		return nil
 	}
 }

--- a/internal/utils/kubernetes/ensure/deployment/deployment.go
+++ b/internal/utils/kubernetes/ensure/deployment/deployment.go
@@ -65,8 +65,6 @@ func PodExtensions(ext rhtasv1.PodExtensions, containerName string) func(*v1.Dep
 		if err != nil {
 			return err
 		}
-		current.Annotations = prev.Annotations
-		current.Labels = prev.Labels
 		ensure.WriteLastApplied(dp, current)
 		return nil
 	}

--- a/internal/utils/kubernetes/ensure/deployment/deployment_test.go
+++ b/internal/utils/kubernetes/ensure/deployment/deployment_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onsi/gomega"
 	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/annotations"
 	testAction "github.com/securesign/operator/internal/testing/action"
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"github.com/securesign/operator/internal/utils/tls"
@@ -265,4 +266,41 @@ func TestPodRequirements(t *testing.T) {
 			tt.verify(g, dp)
 		})
 	}
+}
+
+func TestPodExtensions_PreservesOtherAnnotationConcerns(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	dp := &v1.Deployment{
+		ObjectMeta: v2.ObjectMeta{
+			Annotations: map[string]string{
+				annotations.LastUserSpecApplied: `{"auth":{"volumes":["auth-vol"]}}`,
+			},
+		},
+		Spec: v1.DeploymentSpec{
+			Template: core.PodTemplateSpec{
+				Spec: core.PodSpec{
+					Containers: []core.Container{{Name: "app"}},
+				},
+			},
+		},
+	}
+
+	fn := PodExtensions(rhtasv1.PodExtensions{
+		Volumes: []rhtasv1.AdditionalVolume{
+			{Name: "custom-config", AdditionalVolumeSource: rhtasv1.AdditionalVolumeSource{
+				ConfigMap: &core.ConfigMapVolumeSource{LocalObjectReference: core.LocalObjectReference{Name: "my-cm"}},
+			}},
+		},
+	}, "app")
+	g.Expect(fn(dp)).To(gomega.Succeed())
+
+	g.Expect(dp.Spec.Template.Spec.Volumes).To(gomega.HaveLen(1))
+	g.Expect(dp.Spec.Template.Spec.Volumes[0].Name).To(gomega.Equal("custom-config"))
+
+	g.Expect(dp.GetAnnotations()).To(gomega.HaveKeyWithValue(
+		annotations.LastUserSpecApplied,
+		`{"auth":{"volumes":["auth-vol"]},"podExtensions":{"volumes":["custom-config"]}}`,
+	))
 }

--- a/internal/utils/kubernetes/ensure/pod_spec.go
+++ b/internal/utils/kubernetes/ensure/pod_spec.go
@@ -70,22 +70,41 @@ func ensureContainerSecurityContext(container *core.Container) {
 }
 
 // ReconcileUserPodResources applies user-defined init containers, volumes, and
-// volume mounts to a PodSpec and main container. This is the shared entry point
-// called by both Fulcio and CTLog deployment actions to avoid duplication.
-func ReconcileUserPodResources(podSpec *core.PodSpec, container *core.Container, ext v1.PodExtensions) {
+// volume mounts to a PodSpec. It uses the previous UserSpecState to remove
+// volumes and volume mounts that are no longer desired via EnsureWithCleanup.
+// Returns the current state so the caller can persist it via WriteLastApplied.
+func ReconcileUserPodResources(podSpec *core.PodSpec, containerName string, ext v1.PodExtensions, prev UserSpecState) (UserSpecState, error) {
 	ReconcileInitContainers(podSpec, ext.InitContainers)
 
-	for i := range ext.Volumes {
-		coreVol := ext.Volumes[i].ToVolume()
-		v := kubernetes.FindVolumeByNameOrCreate(podSpec, coreVol.Name)
-		v.VolumeSource = coreVol.VolumeSource
+	if err := EnsureWithCleanup(podSpec, Toggleable[*core.PodSpec]{
+		Ensure:  upsertUserResources(containerName, ext),
+		Managed: StaleResources(prev, ext, containerName),
+	}); err != nil {
+		return UserSpecState{}, err
 	}
 
-	for _, vm := range ext.VolumeMounts {
-		m := kubernetes.FindVolumeMountByNameOrCreate(container, vm.Name)
-		name := m.Name
-		*m = vm
-		m.Name = name
+	return UserSpecState{
+		Volumes:      Names(ext.Volumes, func(v v1.AdditionalVolume) string { return v.Name }),
+		VolumeMounts: Names(ext.VolumeMounts, func(vm core.VolumeMount) string { return vm.Name }),
+	}, nil
+}
+
+func upsertUserResources(containerName string, ext v1.PodExtensions) func(*core.PodSpec) error {
+	return func(spec *core.PodSpec) error {
+		for i := range ext.Volumes {
+			coreVol := ext.Volumes[i].ToVolume()
+			v := kubernetes.FindVolumeByNameOrCreate(spec, coreVol.Name)
+			v.VolumeSource = coreVol.VolumeSource
+		}
+
+		container := kubernetes.FindContainerByNameOrCreate(spec, containerName)
+		for _, vm := range ext.VolumeMounts {
+			m := kubernetes.FindVolumeMountByNameOrCreate(container, vm.Name)
+			name := m.Name
+			*m = vm
+			m.Name = name
+		}
+		return nil
 	}
 }
 

--- a/internal/utils/kubernetes/ensure/pod_spec_test.go
+++ b/internal/utils/kubernetes/ensure/pod_spec_test.go
@@ -188,6 +188,131 @@ func ptrBool(b bool) *bool {
 	return &b
 }
 
+func TestReconcileUserPodResources(t *testing.T) {
+	findContainer := func(spec *core.PodSpec, name string) *core.Container {
+		for i := range spec.Containers {
+			if spec.Containers[i].Name == name {
+				return &spec.Containers[i]
+			}
+		}
+		return nil
+	}
+
+	tests := []struct {
+		name    string
+		podSpec core.PodSpec
+		ext     rhtasv1.PodExtensions
+		prev    UserSpecState
+		verify  func(Gomega, *core.PodSpec, UserSpecState)
+	}{
+		{
+			name:    "adds volumes and mounts from empty state",
+			podSpec: core.PodSpec{Containers: []core.Container{{Name: "app"}}},
+			ext: rhtasv1.PodExtensions{
+				Volumes: []rhtasv1.AdditionalVolume{
+					{Name: "custom-config", AdditionalVolumeSource: rhtasv1.AdditionalVolumeSource{
+						ConfigMap: &core.ConfigMapVolumeSource{LocalObjectReference: core.LocalObjectReference{Name: "my-cm"}},
+					}},
+				},
+				VolumeMounts: []core.VolumeMount{
+					{Name: "custom-config", MountPath: "/etc/custom"},
+				},
+			},
+			prev: UserSpecState{},
+			verify: func(g Gomega, spec *core.PodSpec, current UserSpecState) {
+				g.Expect(spec.Volumes).To(HaveLen(1))
+				g.Expect(spec.Volumes[0].Name).To(Equal("custom-config"))
+				g.Expect(spec.Volumes[0].ConfigMap.Name).To(Equal("my-cm"))
+				c := findContainer(spec, "app")
+				g.Expect(c.VolumeMounts).To(HaveLen(1))
+				g.Expect(c.VolumeMounts[0].MountPath).To(Equal("/etc/custom"))
+				g.Expect(current.Volumes).To(ConsistOf("custom-config"))
+				g.Expect(current.VolumeMounts).To(ConsistOf("custom-config"))
+			},
+		},
+		{
+			name: "removes stale volumes and mounts",
+			podSpec: core.PodSpec{
+				Containers: []core.Container{{
+					Name: "app",
+					VolumeMounts: []core.VolumeMount{
+						{Name: "stale-vol", MountPath: "/old"},
+						{Name: "operator-vol", MountPath: "/op"},
+					},
+				}},
+				Volumes: []core.Volume{
+					{Name: "stale-vol", VolumeSource: core.VolumeSource{EmptyDir: &core.EmptyDirVolumeSource{}}},
+					{Name: "operator-vol", VolumeSource: core.VolumeSource{EmptyDir: &core.EmptyDirVolumeSource{}}},
+				},
+			},
+			ext:  rhtasv1.PodExtensions{},
+			prev: UserSpecState{Volumes: []string{"stale-vol"}, VolumeMounts: []string{"stale-vol"}},
+			verify: func(g Gomega, spec *core.PodSpec, current UserSpecState) {
+				g.Expect(spec.Volumes).To(HaveLen(1))
+				g.Expect(spec.Volumes[0].Name).To(Equal("operator-vol"))
+				c := findContainer(spec, "app")
+				g.Expect(c.VolumeMounts).To(HaveLen(1))
+				g.Expect(c.VolumeMounts[0].Name).To(Equal("operator-vol"))
+				g.Expect(current.Volumes).To(BeEmpty())
+				g.Expect(current.VolumeMounts).To(BeEmpty())
+			},
+		},
+		{
+			name: "does not remove volumes not in previous state",
+			podSpec: core.PodSpec{
+				Containers: []core.Container{{
+					Name:         "app",
+					VolumeMounts: []core.VolumeMount{{Name: "operator-managed", MountPath: "/op"}},
+				}},
+				Volumes: []core.Volume{
+					{Name: "operator-managed", VolumeSource: core.VolumeSource{EmptyDir: &core.EmptyDirVolumeSource{}}},
+				},
+			},
+			ext:  rhtasv1.PodExtensions{},
+			prev: UserSpecState{},
+			verify: func(g Gomega, spec *core.PodSpec, current UserSpecState) {
+				g.Expect(spec.Volumes).To(HaveLen(1))
+				g.Expect(spec.Volumes[0].Name).To(Equal("operator-managed"))
+				c := findContainer(spec, "app")
+				g.Expect(c.VolumeMounts).To(HaveLen(1))
+			},
+		},
+		{
+			name: "updates existing volume source",
+			podSpec: core.PodSpec{
+				Containers: []core.Container{{Name: "app"}},
+				Volumes: []core.Volume{
+					{Name: "cfg", VolumeSource: core.VolumeSource{
+						ConfigMap: &core.ConfigMapVolumeSource{LocalObjectReference: core.LocalObjectReference{Name: "old-cm"}},
+					}},
+				},
+			},
+			ext: rhtasv1.PodExtensions{
+				Volumes: []rhtasv1.AdditionalVolume{
+					{Name: "cfg", AdditionalVolumeSource: rhtasv1.AdditionalVolumeSource{
+						ConfigMap: &core.ConfigMapVolumeSource{LocalObjectReference: core.LocalObjectReference{Name: "new-cm"}},
+					}},
+				},
+			},
+			prev: UserSpecState{Volumes: []string{"cfg"}},
+			verify: func(g Gomega, spec *core.PodSpec, current UserSpecState) {
+				g.Expect(spec.Volumes).To(HaveLen(1))
+				g.Expect(spec.Volumes[0].ConfigMap.Name).To(Equal("new-cm"))
+				g.Expect(current.Volumes).To(ConsistOf("cfg"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			current, err := ReconcileUserPodResources(&tt.podSpec, "app", tt.ext, tt.prev)
+			g.Expect(err).ToNot(HaveOccurred())
+			tt.verify(g, &tt.podSpec, current)
+		})
+	}
+}
+
 func TestReconcileInitContainers(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/utils/kubernetes/ensure/toggleable.go
+++ b/internal/utils/kubernetes/ensure/toggleable.go
@@ -29,6 +29,17 @@ func OptionalToggle[T any](condition bool, t Toggleable[T]) func(T) error {
 	}
 }
 
+// EnsureWithCleanup applies t.Ensure to the target and then removes items
+// declared in t.Managed. Unlike OptionalToggle, it always runs both steps.
+// Use it when Managed represents stale items to remove after upserting desired state.
+func EnsureWithCleanup[T any](target T, t Toggleable[T]) error {
+	if err := t.Ensure(target); err != nil {
+		return err
+	}
+	removeManaged(target, t.Managed)
+	return nil
+}
+
 // removeManaged removes items declared in managed from the live object.
 // It uses reflect to match items by Name across all nested slices (Volumes,
 // Containers, VolumeMounts, Env, Ports, etc.) regardless of resource type.

--- a/internal/utils/kubernetes/ensure/user_spec_tracking.go
+++ b/internal/utils/kubernetes/ensure/user_spec_tracking.go
@@ -2,7 +2,6 @@ package ensure
 
 import (
 	"encoding/json"
-	"slices"
 	"sort"
 
 	v1 "github.com/securesign/operator/api/v1"
@@ -11,79 +10,89 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// UserSpecState tracks the names of user-specified resources that were applied
-// during the last reconcile. Stored as JSON in the LastUserSpecApplied annotation.
+// podExtensionsConcern is this file's key within the namespaced
+// LastUserSpecApplied annotation. See ReadNamespacedState.
+const podExtensionsConcern = "podExtensions"
+
+// UserSpecState tracks the names of user-specified volumes and volume mounts
+// that were applied during the last reconcile. Stored under the
+// "podExtensions" key of the LastUserSpecApplied annotation.
 type UserSpecState struct {
 	Volumes      []string `json:"volumes,omitempty"`
 	VolumeMounts []string `json:"volumeMounts,omitempty"`
-	Annotations  []string `json:"annotations,omitempty"`
-	Labels       []string `json:"labels,omitempty"`
 }
 
-// Equal reports whether two UserSpecState values are identical.
-func (s UserSpecState) Equal(other UserSpecState) bool {
-	return slices.Equal(s.Volumes, other.Volumes) &&
-		slices.Equal(s.VolumeMounts, other.VolumeMounts) &&
-		slices.Equal(s.Annotations, other.Annotations) &&
-		slices.Equal(s.Labels, other.Labels)
-}
-
-// ReadLastApplied reads and parses the tracking annotation from the object.
-// Returns an empty state if the annotation is absent or malformed.
-func ReadLastApplied(obj client.Object) UserSpecState {
+// ReadNamespacedState reads the LastUserSpecApplied annotation, which stores
+// a JSON object keyed by concern name (e.g. "podExtensions", "auth"), and
+// unmarshals the payload for the given concern into dst. dst is left
+// untouched if the annotation is absent, malformed, or has no entry for
+// concern.
+//
+// Namespacing by concern lets multiple independent ensure functions share
+// one annotation without overwriting each other's tracked state: each
+// concern only ever reads and writes its own key.
+func ReadNamespacedState(obj client.Object, concern string, dst any) {
 	raw := obj.GetAnnotations()[annotations.LastUserSpecApplied]
 	if raw == "" {
-		return UserSpecState{}
+		return
 	}
-	var state UserSpecState
-	_ = json.Unmarshal([]byte(raw), &state)
-	return state
+	var all map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &all); err != nil {
+		return
+	}
+	payload, ok := all[concern]
+	if !ok {
+		return
+	}
+	_ = json.Unmarshal(payload, dst)
 }
 
-// WriteLastApplied serializes the current state into the tracking annotation.
-// If the state is empty, the annotation is removed.
-func WriteLastApplied(obj client.Object, state UserSpecState) {
+// WriteNamespacedState marshals src and stores it under concern in the
+// LastUserSpecApplied annotation, re-reading the existing annotation first
+// so other concerns' keys are preserved. If src marshals to an empty JSON
+// object ("{}"), the concern's key is removed instead of stored. If no
+// concerns remain, the annotation itself is removed.
+func WriteNamespacedState(obj client.Object, concern string, src any) {
 	anns := obj.GetAnnotations()
 	if anns == nil {
 		anns = make(map[string]string)
 	}
 
-	if state.Equal(UserSpecState{}) {
+	all := map[string]json.RawMessage{}
+	if raw, ok := anns[annotations.LastUserSpecApplied]; ok && raw != "" {
+		_ = json.Unmarshal([]byte(raw), &all)
+	}
+
+	data, _ := json.Marshal(src)
+	if string(data) == "{}" {
+		delete(all, concern)
+	} else {
+		all[concern] = data
+	}
+
+	if len(all) == 0 {
 		delete(anns, annotations.LastUserSpecApplied)
 	} else {
-		data, _ := json.Marshal(state)
-		anns[annotations.LastUserSpecApplied] = string(data)
+		merged, _ := json.Marshal(all)
+		anns[annotations.LastUserSpecApplied] = string(merged)
 	}
 	obj.SetAnnotations(anns)
 }
 
-// ManagedKeys returns the union of previous and desired key sets.
-// Pass the result to ensure.Annotations or ensure.Labels so that keys removed
-// from the desired set are still in the managed list and get deleted.
-func ManagedKeys(previous, desired []string) []string {
-	seen := make(map[string]struct{}, len(previous)+len(desired))
-	for _, k := range previous {
-		seen[k] = struct{}{}
-	}
-	for _, k := range desired {
-		seen[k] = struct{}{}
-	}
-	keys := make([]string, 0, len(seen))
-	for k := range seen {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
+// ReadLastApplied reads and parses the podExtensions tracking state from the
+// object's LastUserSpecApplied annotation. Returns an empty state if absent
+// or malformed.
+func ReadLastApplied(obj client.Object) UserSpecState {
+	var state UserSpecState
+	ReadNamespacedState(obj, podExtensionsConcern, &state)
+	return state
 }
 
-// KeySet extracts the keys from a map and returns them sorted.
-func KeySet(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
+// WriteLastApplied serializes state under the podExtensions key of the
+// LastUserSpecApplied annotation, preserving any other concern's data
+// already stored under other keys in the same annotation.
+func WriteLastApplied(obj client.Object, state UserSpecState) {
+	WriteNamespacedState(obj, podExtensionsConcern, state)
 }
 
 // Names extracts names from a slice of items with a Name field via a getter function.

--- a/internal/utils/kubernetes/ensure/user_spec_tracking.go
+++ b/internal/utils/kubernetes/ensure/user_spec_tracking.go
@@ -1,0 +1,137 @@
+package ensure
+
+import (
+	"encoding/json"
+	"slices"
+	"sort"
+
+	v1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/annotations"
+	core "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// UserSpecState tracks the names of user-specified resources that were applied
+// during the last reconcile. Stored as JSON in the LastUserSpecApplied annotation.
+type UserSpecState struct {
+	Volumes      []string `json:"volumes,omitempty"`
+	VolumeMounts []string `json:"volumeMounts,omitempty"`
+	Annotations  []string `json:"annotations,omitempty"`
+	Labels       []string `json:"labels,omitempty"`
+}
+
+// Equal reports whether two UserSpecState values are identical.
+func (s UserSpecState) Equal(other UserSpecState) bool {
+	return slices.Equal(s.Volumes, other.Volumes) &&
+		slices.Equal(s.VolumeMounts, other.VolumeMounts) &&
+		slices.Equal(s.Annotations, other.Annotations) &&
+		slices.Equal(s.Labels, other.Labels)
+}
+
+// ReadLastApplied reads and parses the tracking annotation from the object.
+// Returns an empty state if the annotation is absent or malformed.
+func ReadLastApplied(obj client.Object) UserSpecState {
+	raw := obj.GetAnnotations()[annotations.LastUserSpecApplied]
+	if raw == "" {
+		return UserSpecState{}
+	}
+	var state UserSpecState
+	_ = json.Unmarshal([]byte(raw), &state)
+	return state
+}
+
+// WriteLastApplied serializes the current state into the tracking annotation.
+// If the state is empty, the annotation is removed.
+func WriteLastApplied(obj client.Object, state UserSpecState) {
+	anns := obj.GetAnnotations()
+	if anns == nil {
+		anns = make(map[string]string)
+	}
+
+	if state.Equal(UserSpecState{}) {
+		delete(anns, annotations.LastUserSpecApplied)
+	} else {
+		data, _ := json.Marshal(state)
+		anns[annotations.LastUserSpecApplied] = string(data)
+	}
+	obj.SetAnnotations(anns)
+}
+
+// ManagedKeys returns the union of previous and desired key sets.
+// Pass the result to ensure.Annotations or ensure.Labels so that keys removed
+// from the desired set are still in the managed list and get deleted.
+func ManagedKeys(previous, desired []string) []string {
+	seen := make(map[string]struct{}, len(previous)+len(desired))
+	for _, k := range previous {
+		seen[k] = struct{}{}
+	}
+	for _, k := range desired {
+		seen[k] = struct{}{}
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// KeySet extracts the keys from a map and returns them sorted.
+func KeySet(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Names extracts names from a slice of items with a Name field via a getter function.
+func Names[T any](items []T, name func(T) string) []string {
+	names := make([]string, 0, len(items))
+	for _, item := range items {
+		names = append(names, name(item))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// StaleResources builds a partial PodSpec containing volumes and volume mounts
+// that were tracked in prev but are absent from the current extensions. The
+// result is intended as the Managed field for EnsureWithCleanup so that
+// removeManaged cleans up stale items via reflect-based name matching.
+func StaleResources(prev UserSpecState, ext v1.PodExtensions, containerName string) *core.PodSpec {
+	currentVols := nameSet(ext.Volumes, func(v v1.AdditionalVolume) string { return v.Name })
+	currentMounts := nameSet(ext.VolumeMounts, func(vm core.VolumeMount) string { return vm.Name })
+
+	spec := &core.PodSpec{}
+
+	for _, name := range prev.Volumes {
+		if _, ok := currentVols[name]; !ok {
+			spec.Volumes = append(spec.Volumes, core.Volume{Name: name})
+		}
+	}
+
+	var staleMounts []core.VolumeMount
+	for _, name := range prev.VolumeMounts {
+		if _, ok := currentMounts[name]; !ok {
+			staleMounts = append(staleMounts, core.VolumeMount{Name: name})
+		}
+	}
+	if len(staleMounts) > 0 {
+		spec.Containers = []core.Container{{
+			Name:         containerName,
+			VolumeMounts: staleMounts,
+		}}
+	}
+
+	return spec
+}
+
+func nameSet[T any](items []T, name func(T) string) map[string]struct{} {
+	set := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		set[name(item)] = struct{}{}
+	}
+	return set
+}

--- a/internal/utils/kubernetes/ensure/user_spec_tracking_test.go
+++ b/internal/utils/kubernetes/ensure/user_spec_tracking_test.go
@@ -10,6 +10,103 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestReadNamespacedState(t *testing.T) {
+	tests := []struct {
+		name    string
+		ann     map[string]string
+		concern string
+		expect  UserSpecState
+	}{
+		{
+			name:    "no annotation leaves dst zero value",
+			ann:     nil,
+			concern: "podExtensions",
+			expect:  UserSpecState{},
+		},
+		{
+			name:    "concern present is parsed",
+			ann:     map[string]string{annotations.LastUserSpecApplied: `{"podExtensions":{"volumes":["a"]}}`},
+			concern: "podExtensions",
+			expect:  UserSpecState{Volumes: []string{"a"}},
+		},
+		{
+			name:    "other concern's key is ignored",
+			ann:     map[string]string{annotations.LastUserSpecApplied: `{"auth":{"volumes":["ignore-me"]}}`},
+			concern: "podExtensions",
+			expect:  UserSpecState{},
+		},
+		{
+			name:    "malformed annotation leaves dst zero value",
+			ann:     map[string]string{annotations.LastUserSpecApplied: `not json`},
+			concern: "podExtensions",
+			expect:  UserSpecState{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: tt.ann}}
+			var got UserSpecState
+			ReadNamespacedState(svc, tt.concern, &got)
+			g.Expect(got).To(Equal(tt.expect))
+		})
+	}
+}
+
+func TestWriteNamespacedState(t *testing.T) {
+	t.Run("writes concern under its own key", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{}}
+		WriteNamespacedState(svc, "podExtensions", UserSpecState{Volumes: []string{"a"}})
+		g.Expect(svc.GetAnnotations()).To(HaveKeyWithValue(annotations.LastUserSpecApplied, `{"podExtensions":{"volumes":["a"]}}`))
+	})
+
+	t.Run("preserves another concern's key already present", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotations.LastUserSpecApplied: `{"auth":{"volumes":["auth-vol"]}}`,
+			},
+		}}
+		WriteNamespacedState(svc, "podExtensions", UserSpecState{Volumes: []string{"a"}})
+
+		var auth UserSpecState
+		ReadNamespacedState(svc, "auth", &auth)
+		g.Expect(auth).To(Equal(UserSpecState{Volumes: []string{"auth-vol"}}))
+
+		var podExt UserSpecState
+		ReadNamespacedState(svc, "podExtensions", &podExt)
+		g.Expect(podExt).To(Equal(UserSpecState{Volumes: []string{"a"}}))
+	})
+
+	t.Run("removing this concern's data preserves another concern's key", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotations.LastUserSpecApplied: `{"auth":{"volumes":["auth-vol"]},"podExtensions":{"volumes":["old"]}}`,
+			},
+		}}
+		WriteNamespacedState(svc, "podExtensions", UserSpecState{})
+
+		g.Expect(svc.GetAnnotations()[annotations.LastUserSpecApplied]).To(Equal(`{"auth":{"volumes":["auth-vol"]}}`))
+	})
+
+	t.Run("removing the last concern removes the whole annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotations.LastUserSpecApplied: `{"podExtensions":{"volumes":["old"]}}`,
+				"other-annotation":              "keep",
+			},
+		}}
+		WriteNamespacedState(svc, "podExtensions", UserSpecState{})
+
+		g.Expect(svc.GetAnnotations()).ToNot(HaveKey(annotations.LastUserSpecApplied))
+		g.Expect(svc.GetAnnotations()).To(HaveKeyWithValue("other-annotation", "keep"))
+	})
+}
+
 func TestReadLastApplied(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -29,7 +126,7 @@ func TestReadLastApplied(t *testing.T) {
 		{
 			name: "valid JSON is parsed",
 			ann: map[string]string{
-				annotations.LastUserSpecApplied: `{"volumes":["vol-a","vol-b"],"volumeMounts":["vol-a"]}`,
+				annotations.LastUserSpecApplied: `{"podExtensions":{"volumes":["vol-a","vol-b"],"volumeMounts":["vol-a"]}}`,
 			},
 			expect: UserSpecState{
 				Volumes:      []string{"vol-a", "vol-b"},
@@ -42,14 +139,11 @@ func TestReadLastApplied(t *testing.T) {
 			expect: UserSpecState{},
 		},
 		{
-			name: "annotations and labels are parsed",
+			name: "another concern's data does not leak into podExtensions state",
 			ann: map[string]string{
-				annotations.LastUserSpecApplied: `{"annotations":["k1"],"labels":["l1","l2"]}`,
+				annotations.LastUserSpecApplied: `{"auth":{"volumes":["auth-vol"]}}`,
 			},
-			expect: UserSpecState{
-				Annotations: []string{"k1"},
-				Labels:      []string{"l1", "l2"},
-			},
+			expect: UserSpecState{},
 		},
 	}
 
@@ -64,27 +158,28 @@ func TestReadLastApplied(t *testing.T) {
 }
 
 func TestWriteLastApplied(t *testing.T) {
-	t.Run("writes state to annotation", func(t *testing.T) {
+	t.Run("writes state under the podExtensions key", func(t *testing.T) {
 		g := NewWithT(t)
 		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{}}
 		state := UserSpecState{Volumes: []string{"vol-a"}, VolumeMounts: []string{"vol-a"}}
 		WriteLastApplied(svc, state)
-		g.Expect(svc.GetAnnotations()).To(HaveKey(annotations.LastUserSpecApplied))
+		g.Expect(svc.GetAnnotations()).To(HaveKeyWithValue(annotations.LastUserSpecApplied,
+			`{"podExtensions":{"volumes":["vol-a"],"volumeMounts":["vol-a"]}}`))
 
 		roundtrip := ReadLastApplied(svc)
 		g.Expect(roundtrip).To(Equal(state))
 	})
 
-	t.Run("empty state removes annotation", func(t *testing.T) {
+	t.Run("empty state removes only the podExtensions key", func(t *testing.T) {
 		g := NewWithT(t)
 		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				annotations.LastUserSpecApplied: `{"volumes":["old"]}`,
+				annotations.LastUserSpecApplied: `{"auth":{"volumes":["auth-vol"]},"podExtensions":{"volumes":["old"]}}`,
 				"other-annotation":              "keep",
 			},
 		}}
 		WriteLastApplied(svc, UserSpecState{})
-		g.Expect(svc.GetAnnotations()).ToNot(HaveKey(annotations.LastUserSpecApplied))
+		g.Expect(svc.GetAnnotations()).To(HaveKeyWithValue(annotations.LastUserSpecApplied, `{"auth":{"volumes":["auth-vol"]}}`))
 		g.Expect(svc.GetAnnotations()).To(HaveKeyWithValue("other-annotation", "keep"))
 	})
 
@@ -93,98 +188,10 @@ func TestWriteLastApplied(t *testing.T) {
 		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{"existing": "value"},
 		}}
-		WriteLastApplied(svc, UserSpecState{Labels: []string{"l1"}})
+		WriteLastApplied(svc, UserSpecState{Volumes: []string{"a"}})
 		g.Expect(svc.GetAnnotations()).To(HaveKeyWithValue("existing", "value"))
 		g.Expect(svc.GetAnnotations()).To(HaveKey(annotations.LastUserSpecApplied))
 	})
-}
-
-func TestManagedKeys(t *testing.T) {
-	tests := []struct {
-		name     string
-		previous []string
-		desired  []string
-		expect   []string
-	}{
-		{
-			name:     "union of previous and desired",
-			previous: []string{"a", "b"},
-			desired:  []string{"b", "c"},
-			expect:   []string{"a", "b", "c"},
-		},
-		{
-			name:     "empty previous",
-			previous: nil,
-			desired:  []string{"a"},
-			expect:   []string{"a"},
-		},
-		{
-			name:     "empty desired includes previous for cleanup",
-			previous: []string{"a", "b"},
-			desired:  nil,
-			expect:   []string{"a", "b"},
-		},
-		{
-			name:     "both empty",
-			previous: nil,
-			desired:  nil,
-			expect:   []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			got := ManagedKeys(tt.previous, tt.desired)
-			g.Expect(got).To(Equal(tt.expect))
-		})
-	}
-}
-
-func TestKeySet(t *testing.T) {
-	g := NewWithT(t)
-	g.Expect(KeySet(map[string]string{"b": "2", "a": "1"})).To(Equal([]string{"a", "b"}))
-	g.Expect(KeySet(nil)).To(Equal([]string{}))
-}
-
-func TestUserSpecState_Equal(t *testing.T) {
-	tests := []struct {
-		name  string
-		a, b  UserSpecState
-		equal bool
-	}{
-		{
-			name:  "both empty",
-			a:     UserSpecState{},
-			b:     UserSpecState{},
-			equal: true,
-		},
-		{
-			name:  "same volumes",
-			a:     UserSpecState{Volumes: []string{"a", "b"}},
-			b:     UserSpecState{Volumes: []string{"a", "b"}},
-			equal: true,
-		},
-		{
-			name:  "different volumes",
-			a:     UserSpecState{Volumes: []string{"a"}},
-			b:     UserSpecState{Volumes: []string{"b"}},
-			equal: false,
-		},
-		{
-			name:  "nil and empty slice are equal",
-			a:     UserSpecState{Volumes: nil},
-			b:     UserSpecState{Volumes: []string{}},
-			equal: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			g := NewWithT(t)
-			g.Expect(tt.a.Equal(tt.b)).To(Equal(tt.equal))
-		})
-	}
 }
 
 func TestStaleResources(t *testing.T) {

--- a/internal/utils/kubernetes/ensure/user_spec_tracking_test.go
+++ b/internal/utils/kubernetes/ensure/user_spec_tracking_test.go
@@ -1,0 +1,252 @@
+package ensure
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/annotations"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestReadLastApplied(t *testing.T) {
+	tests := []struct {
+		name   string
+		ann    map[string]string
+		expect UserSpecState
+	}{
+		{
+			name:   "no annotation returns empty state",
+			ann:    nil,
+			expect: UserSpecState{},
+		},
+		{
+			name:   "empty string returns empty state",
+			ann:    map[string]string{annotations.LastUserSpecApplied: ""},
+			expect: UserSpecState{},
+		},
+		{
+			name: "valid JSON is parsed",
+			ann: map[string]string{
+				annotations.LastUserSpecApplied: `{"volumes":["vol-a","vol-b"],"volumeMounts":["vol-a"]}`,
+			},
+			expect: UserSpecState{
+				Volumes:      []string{"vol-a", "vol-b"},
+				VolumeMounts: []string{"vol-a"},
+			},
+		},
+		{
+			name:   "malformed JSON returns empty state",
+			ann:    map[string]string{annotations.LastUserSpecApplied: `not json`},
+			expect: UserSpecState{},
+		},
+		{
+			name: "annotations and labels are parsed",
+			ann: map[string]string{
+				annotations.LastUserSpecApplied: `{"annotations":["k1"],"labels":["l1","l2"]}`,
+			},
+			expect: UserSpecState{
+				Annotations: []string{"k1"},
+				Labels:      []string{"l1", "l2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Annotations: tt.ann}}
+			got := ReadLastApplied(svc)
+			g.Expect(got).To(Equal(tt.expect))
+		})
+	}
+}
+
+func TestWriteLastApplied(t *testing.T) {
+	t.Run("writes state to annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{}}
+		state := UserSpecState{Volumes: []string{"vol-a"}, VolumeMounts: []string{"vol-a"}}
+		WriteLastApplied(svc, state)
+		g.Expect(svc.GetAnnotations()).To(HaveKey(annotations.LastUserSpecApplied))
+
+		roundtrip := ReadLastApplied(svc)
+		g.Expect(roundtrip).To(Equal(state))
+	})
+
+	t.Run("empty state removes annotation", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotations.LastUserSpecApplied: `{"volumes":["old"]}`,
+				"other-annotation":              "keep",
+			},
+		}}
+		WriteLastApplied(svc, UserSpecState{})
+		g.Expect(svc.GetAnnotations()).ToNot(HaveKey(annotations.LastUserSpecApplied))
+		g.Expect(svc.GetAnnotations()).To(HaveKeyWithValue("other-annotation", "keep"))
+	})
+
+	t.Run("preserves existing annotations", func(t *testing.T) {
+		g := NewWithT(t)
+		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{"existing": "value"},
+		}}
+		WriteLastApplied(svc, UserSpecState{Labels: []string{"l1"}})
+		g.Expect(svc.GetAnnotations()).To(HaveKeyWithValue("existing", "value"))
+		g.Expect(svc.GetAnnotations()).To(HaveKey(annotations.LastUserSpecApplied))
+	})
+}
+
+func TestManagedKeys(t *testing.T) {
+	tests := []struct {
+		name     string
+		previous []string
+		desired  []string
+		expect   []string
+	}{
+		{
+			name:     "union of previous and desired",
+			previous: []string{"a", "b"},
+			desired:  []string{"b", "c"},
+			expect:   []string{"a", "b", "c"},
+		},
+		{
+			name:     "empty previous",
+			previous: nil,
+			desired:  []string{"a"},
+			expect:   []string{"a"},
+		},
+		{
+			name:     "empty desired includes previous for cleanup",
+			previous: []string{"a", "b"},
+			desired:  nil,
+			expect:   []string{"a", "b"},
+		},
+		{
+			name:     "both empty",
+			previous: nil,
+			desired:  nil,
+			expect:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := ManagedKeys(tt.previous, tt.desired)
+			g.Expect(got).To(Equal(tt.expect))
+		})
+	}
+}
+
+func TestKeySet(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(KeySet(map[string]string{"b": "2", "a": "1"})).To(Equal([]string{"a", "b"}))
+	g.Expect(KeySet(nil)).To(Equal([]string{}))
+}
+
+func TestUserSpecState_Equal(t *testing.T) {
+	tests := []struct {
+		name  string
+		a, b  UserSpecState
+		equal bool
+	}{
+		{
+			name:  "both empty",
+			a:     UserSpecState{},
+			b:     UserSpecState{},
+			equal: true,
+		},
+		{
+			name:  "same volumes",
+			a:     UserSpecState{Volumes: []string{"a", "b"}},
+			b:     UserSpecState{Volumes: []string{"a", "b"}},
+			equal: true,
+		},
+		{
+			name:  "different volumes",
+			a:     UserSpecState{Volumes: []string{"a"}},
+			b:     UserSpecState{Volumes: []string{"b"}},
+			equal: false,
+		},
+		{
+			name:  "nil and empty slice are equal",
+			a:     UserSpecState{Volumes: nil},
+			b:     UserSpecState{Volumes: []string{}},
+			equal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(tt.a.Equal(tt.b)).To(Equal(tt.equal))
+		})
+	}
+}
+
+func TestStaleResources(t *testing.T) {
+	tests := []struct {
+		name          string
+		prev          UserSpecState
+		ext           rhtasv1.PodExtensions
+		containerName string
+		verify        func(Gomega, *v1.PodSpec)
+	}{
+		{
+			name:          "stale volumes and mounts are included",
+			prev:          UserSpecState{Volumes: []string{"a", "b"}, VolumeMounts: []string{"a", "b"}},
+			ext:           rhtasv1.PodExtensions{Volumes: []rhtasv1.AdditionalVolume{{Name: "b"}}, VolumeMounts: []v1.VolumeMount{{Name: "b"}}},
+			containerName: "app",
+			verify: func(g Gomega, spec *v1.PodSpec) {
+				g.Expect(spec.Volumes).To(HaveLen(1))
+				g.Expect(spec.Volumes[0].Name).To(Equal("a"))
+				g.Expect(spec.Containers).To(HaveLen(1))
+				g.Expect(spec.Containers[0].Name).To(Equal("app"))
+				g.Expect(spec.Containers[0].VolumeMounts).To(HaveLen(1))
+				g.Expect(spec.Containers[0].VolumeMounts[0].Name).To(Equal("a"))
+			},
+		},
+		{
+			name:          "no stale items returns empty spec",
+			prev:          UserSpecState{Volumes: []string{"a"}, VolumeMounts: []string{"a"}},
+			ext:           rhtasv1.PodExtensions{Volumes: []rhtasv1.AdditionalVolume{{Name: "a"}}, VolumeMounts: []v1.VolumeMount{{Name: "a"}}},
+			containerName: "app",
+			verify: func(g Gomega, spec *v1.PodSpec) {
+				g.Expect(spec.Volumes).To(BeEmpty())
+				g.Expect(spec.Containers).To(BeEmpty())
+			},
+		},
+		{
+			name:          "empty prev returns empty spec",
+			prev:          UserSpecState{},
+			ext:           rhtasv1.PodExtensions{Volumes: []rhtasv1.AdditionalVolume{{Name: "a"}}},
+			containerName: "app",
+			verify: func(g Gomega, spec *v1.PodSpec) {
+				g.Expect(spec.Volumes).To(BeEmpty())
+				g.Expect(spec.Containers).To(BeEmpty())
+			},
+		},
+		{
+			name:          "stale volumes only, no mounts",
+			prev:          UserSpecState{Volumes: []string{"old"}},
+			ext:           rhtasv1.PodExtensions{},
+			containerName: "app",
+			verify: func(g Gomega, spec *v1.PodSpec) {
+				g.Expect(spec.Volumes).To(HaveLen(1))
+				g.Expect(spec.Volumes[0].Name).To(Equal("old"))
+				g.Expect(spec.Containers).To(BeEmpty())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			got := StaleResources(tt.prev, tt.ext, tt.containerName)
+			tt.verify(g, got)
+		})
+	}
+}


### PR DESCRIPTION
### Summary
Adds stale resource cleanup for user-specified volumes and volume mounts during reconciliation, this is PR is working in conjuction with #2229 

### Problem
The LastUserSpecApplied annotation added in this PR stores one just one flat JSON payload for PodExtensions tracking not parts like TLS cert volumes, TrustedCA volumes, env vars. This would use an incompatible flat schema under the same key which wouldn't work together, as whichever reconciles second on a given
object silently clobbers the other's tracked state, since both implementations self-heal on unmarshal failure by resetting to empty.

  ### Review feedback/ What Changed
- Add ensure.ReadNamespacedState / ensure.WriteNamespacedState: generic,
  exported helpers that read/write one concern's key, doing a proper
  read-merge-write so other concerns' data is never touched. Future
  tracking needs (e.g. Auth) can reuse these instead of re-solving the
  same problem.
- Scope UserSpecState/ReadLastApplied/WriteLastApplied to the
  "podExtensions" key via the new helpers.
- Remove UserSpecState.Annotations/.Labels and their Equal method, plus
  ManagedKeys/KeySet with dead scaffolding with no production caller.
- Update the LastUserSpecApplied doc comment to describe the namespaced
  schema.
- Add TestPodExtensions_PreservesOtherAnnotationConcerns, an end-to-end
  test proving a PodExtensions reconcile leaves another concern's
  annotation data intact.
