### PR TITLE
feat: add ingress support to CTlog

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ env:
   CATALOG_IMG: ghcr.io/securesign/secure-sign-operator-fbc:dev-${{ github.sha }}
   NEW_OLM_CHANNEL: rhtas-operator.v1.5.0
   OCP_VERSION: ${{ vars.OLM_INDEX_VERSION }}
-  INGRESS_HOST_TEMPLATE: '%[1]s.%[2]s.127.0.0.1.nip.io'
   TARGET_PLATFORM: kubernetes
   CLI_CGW_VERSION: "1.4.2"
 
@@ -270,7 +269,8 @@ jobs:
 
       - name: Configure Ingress hostname template
         run: |
-          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
+          NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="%[1]s.%[2]s.${NODE_IP}.nip.io"
           kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
 
       - name: Wait for conversion webhook readiness
@@ -472,7 +472,8 @@ jobs:
 
       - name: Configure Ingress hostname template
         run: |
-          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
+          NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="%[1]s.%[2]s.${NODE_IP}.nip.io"
           kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
 
       - name: Wait for conversion webhook readiness
@@ -671,7 +672,8 @@ jobs:
 
       - name: Configure Ingress hostname template
         run: |
-          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
+          NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="%[1]s.%[2]s.${NODE_IP}.nip.io"
           kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
 
       - name: Wait for conversion webhook readiness
@@ -829,7 +831,8 @@ jobs:
 
       - name: Configure Ingress hostname template
         run: |
-          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="${INGRESS_HOST_TEMPLATE}"
+          NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+          kubectl set env deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator INGRESS_HOST_TEMPLATE="%[1]s.%[2]s.${NODE_IP}.nip.io"
           kubectl rollout status deployment/rhtas-operator-controller-manager -n openshift-rhtas-operator --timeout=120s
 
       - name: Wait for conversion webhook readiness

--- a/api/v1/ctlog_defaults.go
+++ b/api/v1/ctlog_defaults.go
@@ -6,6 +6,7 @@ func (s *CTlogSpec) SetDefaults() {
 	s.PodRequirements.SetDefaults()
 	s.PodExtensions.SetDefaults()
 	s.Monitoring.SetDefaults()
+	s.Ingress.SetDefaults()
 	s.Signer.SetDefaults()
 	setDefault(&s.Prefix, "trusted-artifact-signer")
 	setDefault(&s.MaxCertChainSize, ptr.To(int64(153600)))

--- a/api/v1/ctlog_types.go
+++ b/api/v1/ctlog_types.go
@@ -41,6 +41,9 @@ type CTlogSpec struct {
 	// +listType=atomic
 	RootCertificates []SecretKeySelector `json:"rootCertificates,omitempty"`
 
+	// Define whether you want to export service or not
+	Ingress Ingress `json:"ingress,omitempty"`
+
 	//Enable Service monitors for ctlog
 	Monitoring MonitoringWithTLogConfig `json:"monitoring,omitempty"`
 

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -297,6 +297,7 @@ func (in *CTlogSpec) DeepCopyInto(out *CTlogSpec) {
 		*out = make([]SecretKeySelector, len(*in))
 		copy(*out, *in)
 	}
+	in.Ingress.DeepCopyInto(&out.Ingress)
 	in.Monitoring.DeepCopyInto(&out.Monitoring)
 	in.Trillian.DeepCopyInto(&out.Trillian)
 	if in.ServerConfigRef != nil {

--- a/api/v1alpha1/ctlog_conversion.go
+++ b/api/v1alpha1/ctlog_conversion.go
@@ -114,6 +114,7 @@ func (src *CTlog) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	dst.Spec.PodExtensions = restored.Spec.PodExtensions
 	dst.Spec.Auth = restored.Spec.Auth
+	dst.Spec.Ingress = restored.Spec.Ingress
 	return nil
 }
 

--- a/api/v1alpha1/securesign_conversion.go
+++ b/api/v1alpha1/securesign_conversion.go
@@ -89,6 +89,7 @@ func (src *Securesign) ConvertTo(dstRaw conversion.Hub) error {
 	}
 	dst.Spec.Ctlog.PodExtensions = restored.Spec.Ctlog.PodExtensions
 	dst.Spec.Ctlog.Auth = restored.Spec.Ctlog.Auth
+	dst.Spec.Ctlog.Ingress = restored.Spec.Ctlog.Ingress
 	dst.Spec.Rekor.ImagePullSecrets = restored.Spec.Rekor.ImagePullSecrets
 	dst.Spec.Rekor.Monitoring.ServiceMonitor = restored.Spec.Rekor.Monitoring.ServiceMonitor
 	dst.Spec.Rekor.PodExtensions = restored.Spec.Rekor.PodExtensions

--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1000,6 +1000,7 @@ func autoConvert_v1_CTlogSpec_To_v1alpha1_CTlogSpec(in *v1.CTlogSpec, out *CTlog
 	out.TreeID = (*int64)(unsafe.Pointer(in.TreeID))
 	// WARNING: in.Signer requires manual conversion: does not exist in peer-type
 	out.RootCertificates = *(*[]SecretKeySelector)(unsafe.Pointer(&in.RootCertificates))
+	// WARNING: in.Ingress requires manual conversion: does not exist in peer-type
 	if err := Convert_v1_MonitoringWithTLogConfig_To_v1alpha1_MonitoringWithTLogConfig(&in.Monitoring, &out.Monitoring, s); err != nil {
 		return err
 	}

--- a/config/crd/bases/rhtas.redhat.com_ctlogs.yaml
+++ b/config/crd/bases/rhtas.redhat.com_ctlogs.yaml
@@ -1170,6 +1170,30 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              ingress:
+                description: Define whether you want to export service or not
+                properties:
+                  enabled:
+                    description: |-
+                      If set to true, the Operator will create a Kubernetes Ingress resource.
+                      On OpenShift, the platform automatically derives a Route from this Ingress, using "edge" TLS termination by default.
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: Feature cannot be disabled
+                      rule: (self || !oldSelf)
+                  host:
+                    description: Set hostname for your Ingress.
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Set labels applied to the created Ingress, e.g. for
+                      ingress-controller/route selection when sharding ingress traffic.
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Labels can't be modified
+                      rule: (oldSelf.size() == 0 || self == oldSelf)
+                type: object
               initContainers:
                 description: InitContainers to run before the main server container.
                 items:

--- a/config/crd/bases/rhtas.redhat.com_securesigns.yaml
+++ b/config/crd/bases/rhtas.redhat.com_securesigns.yaml
@@ -1192,6 +1192,31 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     type: array
+                  ingress:
+                    description: Define whether you want to export service or not
+                    properties:
+                      enabled:
+                        description: |-
+                          If set to true, the Operator will create a Kubernetes Ingress resource.
+                          On OpenShift, the platform automatically derives a Route from this Ingress, using "edge" TLS termination by default.
+                        type: boolean
+                        x-kubernetes-validations:
+                        - message: Feature cannot be disabled
+                          rule: (self || !oldSelf)
+                      host:
+                        description: Set hostname for your Ingress.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Set labels applied to the created Ingress, e.g.
+                          for ingress-controller/route selection when sharding ingress
+                          traffic.
+                        type: object
+                        x-kubernetes-validations:
+                        - message: Labels can't be modified
+                          rule: (oldSelf.size() == 0 || self == oldSelf)
+                    type: object
                   initContainers:
                     description: InitContainers to run before the main server container.
                     items:

--- a/internal/controller/ctlog/actions/ingress.go
+++ b/internal/controller/ctlog/actions/ingress.go
@@ -1,0 +1,86 @@
+package actions
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/constants"
+	ctlogutils "github.com/securesign/operator/internal/controller/ctlog/utils"
+	"github.com/securesign/operator/internal/labels"
+	"github.com/securesign/operator/internal/state"
+	"github.com/securesign/operator/internal/utils"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	"github.com/securesign/operator/internal/utils/kubernetes/ensure"
+	v1 "k8s.io/api/core/v1"
+	v2 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func NewIngressAction() action.Action[*rhtasv1.CTlog] {
+	return &ingressAction{}
+}
+
+type ingressAction struct {
+	action.BaseAction
+}
+
+func (i ingressAction) Name() string {
+	return "ingress"
+}
+
+func (i ingressAction) CanHandle(_ context.Context, instance *rhtasv1.CTlog) bool {
+	return utils.IsEnabled(instance.Spec.Ingress.Enabled) && state.FromInstance(instance, constants.ReadyCondition) >= state.Creating
+}
+
+func (i ingressAction) Handle(ctx context.Context, instance *rhtasv1.CTlog) *action.Result {
+	var (
+		result controllerutil.OperationResult
+		err    error
+	)
+	ok := types.NamespacedName{Name: DeploymentName, Namespace: instance.Namespace}
+	labels := labels.For(ComponentName, DeploymentName, instance.Name)
+
+	svc := &v1.Service{}
+	if err := i.Client.Get(ctx, ok, svc); err != nil {
+		return i.Error(ctx, fmt.Errorf("could not find service for ingress: %w", err), instance)
+	}
+
+	tlsEnsure := kubernetes.EnsureIngressTLS()
+	if ctlogutils.TlsEnabled(instance) {
+		// edge termination decrypts at the router and forwards plaintext to the
+		// backend; CTlog's pod can terminate real TLS itself, so that combination
+		// needs reencrypt instead.
+		tlsEnsure = kubernetes.EnsureIngressTermination("reencrypt")
+	}
+
+	if result, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+		&v2.Ingress{
+			ObjectMeta: metav1.ObjectMeta{Name: svc.Name, Namespace: svc.Namespace},
+		},
+		kubernetes.EnsureIngressSpec(ctx, i.Client, *svc, instance.Spec.Ingress, ServerPortName),
+		ensure.Optional(kubernetes.IsOpenShift(), tlsEnsure),
+		// add ingress labels
+		ensure.Labels[*v2.Ingress](slices.Collect(maps.Keys(instance.Spec.Ingress.Labels)), instance.Spec.Ingress.Labels),
+		// add common labels
+		ensure.Labels[*v2.Ingress](slices.Collect(maps.Keys(labels)), labels),
+		ensure.ControllerReference[*v2.Ingress](instance, i.Client),
+	); err != nil {
+		return i.Error(ctx, fmt.Errorf("could not create ingress object: %w", err), instance)
+	}
+
+	if result != controllerutil.OperationResultNone {
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{Type: constants.ReadyCondition,
+			Status: metav1.ConditionFalse, Reason: state.Creating.String(), Message: "Ingress created",
+			ObservedGeneration: instance.Generation})
+		return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+	} else {
+		return i.Continue()
+	}
+}

--- a/internal/controller/ctlog/actions/ingress_test.go
+++ b/internal/controller/ctlog/actions/ingress_test.go
@@ -1,0 +1,62 @@
+package actions
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/securesign/operator/internal/state"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestIngress_CanHandle(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	tests := []struct {
+		name           string
+		conditions     []metav1.Condition
+		externalAccess bool
+		expected       bool
+	}{
+		{
+			name:           "ingress is enabled and ctlog is ready",
+			conditions:     []metav1.Condition{{Type: constants.ReadyCondition, Status: metav1.ConditionTrue, Reason: state.Ready.String()}},
+			externalAccess: true,
+			expected:       true,
+		},
+		{
+			name:           "ingress is enabled and ctlog is not ready",
+			conditions:     []metav1.Condition{{Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Pending.String()}},
+			externalAccess: true,
+			expected:       false,
+		},
+		{
+			name:           "ingress is disabled",
+			conditions:     []metav1.Condition{{Type: constants.ReadyCondition, Status: metav1.ConditionTrue, Reason: state.Ready.String()}},
+			externalAccess: false,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			instance := rhtasv1.CTlog{
+				Spec: rhtasv1.CTlogSpec{
+					Ingress: rhtasv1.Ingress{
+						Enabled: ptr.To(tt.externalAccess),
+					},
+				},
+				Status: rhtasv1.CTlogStatus{
+					Conditions: tt.conditions,
+				},
+			}
+			action := NewIngressAction()
+			g.Expect(tt.expected).To(Equal(action.CanHandle(ctx, &instance)))
+		})
+	}
+}

--- a/internal/controller/ctlog/actions/monitor/statefulset.go
+++ b/internal/controller/ctlog/actions/monitor/statefulset.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	rhtasv1 "github.com/securesign/operator/api/v1"
-	ctlogutils "github.com/securesign/operator/internal/controller/ctlog/utils"
 	tlsensure "github.com/securesign/operator/internal/utils/tls/ensure"
 )
 
@@ -68,7 +67,13 @@ func (i statefulSetAction) Handle(ctx context.Context, instance *rhtasv1.CTlog) 
 			ObservedGeneration: instance.Generation,
 		})
 	}
-	ctlogServerHost, err := serviceresolver.Resolve(instance)
+
+	// Deliberately not serviceresolver.Resolve/ResolveExternalServiceUrl like Rekor's monitor:
+	// unlike Rekor (which validates a signed checkpoint), this monitor compares the log URL
+	// byte-for-byte against the URL stored in TUF metadata, so it must dial the exact external
+	// URL once ingress is enabled. ResolveExternalServiceUrl requires CTlog.Ready, but this
+	// action runs before Ready (server and monitor share one CR), which would deadlock.
+	ctlogServerHost, err := actions.ResolveUrl(ctx, i.Client, instance)
 	if err != nil {
 		return i.Error(ctx, err, instance)
 	}
@@ -85,10 +90,9 @@ func (i statefulSetAction) Handle(ctx context.Context, instance *rhtasv1.CTlog) 
 		i.ensureInitContainer(ctlogServerHost, tufServerHost),
 		ensure.ControllerReference[*v1.StatefulSet](instance, i.Client),
 		ensure.Labels[*v1.StatefulSet](slices.Collect(maps.Keys(labels)), labels),
-		ensure.Optional(
-			ctlogutils.TlsEnabled(instance),
-			i.ensureTLS(instance.Status.TLS, actions.MonitorStatefulSetName),
-		),
+		func(object *v1.StatefulSet) error {
+			return tlsensure.TrustedCA(instance.GetTrustedCA(), actions.MonitorStatefulSetName)(&object.Spec.Template)
+		},
 		func(object *v1.StatefulSet) error {
 			return ensure.PodSecurityContext(&object.Spec.Template.Spec)
 		},
@@ -118,18 +122,6 @@ func (i statefulSetAction) Handle(ctx context.Context, instance *rhtasv1.CTlog) 
 		}
 	}
 	return i.Continue()
-}
-
-func (i statefulSetAction) ensureTLS(tlsConfig rhtasv1.TLS, name string) func(sts *v1.StatefulSet) error {
-	return func(sts *v1.StatefulSet) error {
-		if err := tlsensure.TLS(tlsConfig, name)(&sts.Spec.Template); err != nil {
-			return err
-		}
-		container := kubernetes.FindContainerByNameOrCreate(&sts.Spec.Template.Spec, name)
-		sslEnv := kubernetes.FindEnvByNameOrCreate(container, "SSL_CERT_DIR")
-		sslEnv.Value = constants.SecretMountPath
-		return nil
-	}
 }
 
 func (i statefulSetAction) ensureMonitorStatefulSet(instance *rhtasv1.CTlog, sa string, labels map[string]string, ctlogServerHost string, tufServerHost string) func(*v1.StatefulSet) error {

--- a/internal/controller/ctlog/actions/status_url.go
+++ b/internal/controller/ctlog/actions/status_url.go
@@ -3,11 +3,16 @@ package actions
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/securesign/operator/internal/action"
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/serviceresolver"
 	"github.com/securesign/operator/internal/state"
+	"github.com/securesign/operator/internal/utils"
+	v2 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rhtasv1 "github.com/securesign/operator/api/v1"
 )
@@ -29,10 +34,32 @@ func (i statusUrlAction) CanHandle(_ context.Context, instance *rhtasv1.CTlog) b
 }
 
 func (i statusUrlAction) Handle(ctx context.Context, instance *rhtasv1.CTlog) *action.Result {
-	internalUrl, err := serviceresolver.Resolve(instance)
+	resolvedUrl, err := ResolveUrl(ctx, i.Client, instance)
 	if err != nil {
-		return i.Error(ctx, fmt.Errorf("error resolving internal URL: %w", err), instance)
+		return i.Error(ctx, fmt.Errorf("error resolving URL: %w", err), instance)
 	}
-	instance.Status.Url = internalUrl
+	if resolvedUrl == instance.Status.Url {
+		return i.Continue()
+	}
+	instance.Status.Url = resolvedUrl
 	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+}
+
+// ResolveUrl returns CTlog's externally reachable URL when ingress is
+// enabled, otherwise its internal cluster-DNS URL. Used for both
+// Status.Url and the ctlog-monitor's own dial target, which must match
+// exactly or the monitor can't find itself in the trusted root.
+func ResolveUrl(ctx context.Context, cli client.Client, instance *rhtasv1.CTlog) (string, error) {
+	if utils.IsEnabled(instance.Spec.Ingress.Enabled) {
+		scheme := "http"
+		ingress := &v2.Ingress{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: DeploymentName, Namespace: instance.Namespace}, ingress); err != nil {
+			return "", err
+		}
+		if len(ingress.Spec.TLS) > 0 {
+			scheme = "https"
+		}
+		return (&url.URL{Scheme: scheme, Host: ingress.Spec.Rules[0].Host, Path: instance.Spec.Prefix}).String(), nil
+	}
+	return serviceresolver.Resolve(instance)
 }

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/securesign/operator/internal/controller/ctlog/actions"
 	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	v12 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -122,6 +123,8 @@ func (r *ctlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		actions.NewRBACAction(),
 		actions.NewDeployAction(),
 		actions.NewServiceAction(),
+		actions.NewIngressAction(),
+		actions.NewStatusUrlAction(),
 		actions.NewCreateMonitorAction(),
 
 		monitor.NewRBACAction(),
@@ -129,7 +132,6 @@ func (r *ctlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		monitor.NewCreateServiceAction(),
 		monitor.NewCreateMonitorAction(),
 
-		actions.NewStatusUrlAction(),
 		transitions.NewToInitializePhaseAction[*rhtasv1.CTlog](),
 
 		actions.NewRolloutCheckAction(),
@@ -168,6 +170,7 @@ func (r *ctlogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&rhtasv1.CTlog{}, builder.WithPredicates(tasPredicate.ConfigurationChangedOnFailurePredicate[*rhtasv1.CTlog]())).
 		Owns(&v1.Deployment{}).
 		Owns(&v12.Service{}).
+		Owns(&networkingv1.Ingress{}).
 		// receive update on Fulcio root cert change (pulled from status.certificateChain)
 		Watches(&rhtasv1.Fulcio{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 			list := &rhtasv1.CTlogList{}

--- a/internal/utils/kubernetes/ingress.go
+++ b/internal/utils/kubernetes/ingress.go
@@ -51,12 +51,18 @@ func EnsureIngressSpec(ctx context.Context, cli client.Client, svc v12.Service, 
 
 // EnsureIngressTLS set flags for Openshift cluster to auto-create TLS termination
 func EnsureIngressTLS() func(ingress *networkingv1.Ingress) error {
+	return EnsureIngressTermination("edge")
+}
+
+// EnsureIngressTermination sets the given OpenShift Route termination mode
+// (e.g. "edge", "reencrypt") for the auto-generated Ingress-to-Route conversion.
+func EnsureIngressTermination(termination string) func(ingress *networkingv1.Ingress) error {
 	return func(ingress *networkingv1.Ingress) error {
 
 		if ingress.Annotations == nil {
 			ingress.Annotations = map[string]string{}
 		}
-		ingress.Annotations["route.openshift.io/termination"] = "edge"
+		ingress.Annotations["route.openshift.io/termination"] = termination
 
 		if ingress.Spec.TLS == nil {
 			// ocp is able to autogenerate TLS

--- a/internal/utils/kubernetes/ingress_test.go
+++ b/internal/utils/kubernetes/ingress_test.go
@@ -128,3 +128,13 @@ func TestEnsureIngressSpec(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureIngressTermination(t *testing.T) {
+	t.Parallel()
+	g := gomega.NewWithT(t)
+
+	ingress := &networkingv1.Ingress{}
+	g.Expect(EnsureIngressTermination("reencrypt")(ingress)).To(gomega.Succeed())
+	g.Expect(ingress.Annotations["route.openshift.io/termination"]).To(gomega.Equal("reencrypt"))
+	g.Expect(ingress.Spec.TLS).To(gomega.HaveLen(1))
+}

--- a/test/e2e/monitoring/ctlog_monitor_test.go
+++ b/test/e2e/monitoring/ctlog_monitor_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/securesign/operator/internal/controller/ctlog/actions"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/test/e2e/support"
-	testSupportKubernetes "github.com/securesign/operator/test/e2e/support/kubernetes"
 	"github.com/securesign/operator/test/e2e/support/postgresql"
 	"github.com/securesign/operator/test/e2e/support/steps"
 	"github.com/securesign/operator/test/e2e/support/tas"
@@ -149,11 +148,6 @@ var _ = Describe("Ctlog Monitor", Ordered, func() {
 			var ctlogServerUrl string
 			var found bool
 
-			protocol := "http"
-			if testSupportKubernetes.IsRemoteClusterOpenshift() {
-				protocol = "https"
-			}
-
 			for _, cmd := range ctlogMonitorContainer.Command {
 				if matches := urlRegex.FindStringSubmatch(cmd); len(matches) == 2 {
 					ctlogServerUrl = matches[1]
@@ -164,10 +158,12 @@ var _ = Describe("Ctlog Monitor", Ordered, func() {
 			Expect(found).To(BeTrue(), "Expected --url parameter to be present in container command")
 			Expect(ctlogServerUrl).ToNot(BeEmpty(), "Expected URL to not be empty")
 
-			// Verify the URL matches exactly what the ctlog service provides
-			expectedCtlogServerUrl := fmt.Sprintf("%s://ctlog.%s.svc/trusted-artifact-signer", protocol, namespace.Name)
-			Expect(ctlogServerUrl).To(Equal(expectedCtlogServerUrl),
-				fmt.Sprintf("Expected URL to be %s, but got %s", expectedCtlogServerUrl, ctlogServerUrl))
+			// Must match Status.Url exactly: the monitor looks itself up in
+			// the trusted root by exact base_url match.
+			ctlogInstance := &rhtasv1.CTlog{}
+			Expect(cli.Get(ctx, ctrl.ObjectKey{Namespace: namespace.Name, Name: s.Name}, ctlogInstance)).To(Succeed())
+			Expect(ctlogServerUrl).To(Equal(ctlogInstance.Status.Url),
+				fmt.Sprintf("Expected URL to be %s, but got %s", ctlogInstance.Status.Url, ctlogServerUrl))
 		})
 	})
 })

--- a/test/e2e/support/tas/securesign/securesign.go
+++ b/test/e2e/support/tas/securesign/securesign.go
@@ -89,6 +89,7 @@ func WithIngress() Opts {
 		s.Spec.Rekor.Ingress.Enabled = ptr.To(true)
 		s.Spec.Tuf.Ingress.Enabled = ptr.To(true)
 		s.Spec.Fulcio.Ingress.Enabled = ptr.To(true)
+		s.Spec.Ctlog.Ingress.Enabled = ptr.To(true)
 		if s.Spec.TimestampAuthority != nil {
 			s.Spec.TimestampAuthority.Ingress.Enabled = ptr.To(true)
 		}


### PR DESCRIPTION
## Why

CTlog is the only signing-path component without optional Ingress support, unlike Fulcio, Rekor, TUF, and TSA. CTlog is also the first component whose backend pod can terminate real TLS itself, so exposing it externally needs OpenShift Route `reencrypt` termination instead of the `edge` termination the other components use — edge would decrypt to plaintext at the router and break an HTTPS-only backend.

## What

- Add an optional `Ingress` field to `CTlogSpec`, with defaults/deepcopy/conversion/CRDs regenerated.
- Add an ingress reconcile action for CTlog, registered in the reconciler and watched via `Owns(&networkingv1.Ingress{})`.
- Select Route `reencrypt` termination instead of `edge` when CTlog's own TLS is enabled.
- Refactor `EnsureIngressTLS` into a thin wrapper around a new exported `EnsureIngressTermination(termination string)`, reused for the edge/reencrypt selection without changing behavior for existing callers.
- Port the ingress-aware URL branch into CTlog's status-url action so `Status.Url` reflects the external ingress URL when ingress is enabled.
- Restore the `Ingress` field during `v1alpha1<->v1` round-trip conversion for both `CTlog` and `Securesign`.
- Add CTlog to the e2e `WithIngress()` helper.