### PR TITLE
feat: re-reconcile managed controllers on cluster TLS profile change

### DIFF
--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -163,7 +163,7 @@ func (r *ctlogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(pause).
 		For(&rhtasv1.CTlog{}, builder.WithPredicates(tasPredicate.ConfigurationChangedOnFailurePredicate[*rhtasv1.CTlog]())).
 		Owns(&v1.Deployment{}).
@@ -202,6 +202,11 @@ func (r *ctlogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			ctrlutil.ServiceRefWatch(mgr.GetClient(), &rhtasv1.CTlogList{}, func(o client.Object) rhtasv1.ServiceReference {
 				return o.(*rhtasv1.CTlog).Spec.Monitoring.Tuf
 			}),
-		), builder.WithPredicates(crpredicate.GenerationChangedPredicate{})).
-		Complete(r)
+		), builder.WithPredicates(crpredicate.GenerationChangedPredicate{}))
+
+	// Re-reconcile all CTlog instances when the cluster-wide TLS security profile
+	// (config.openshift.io APIServer/cluster) changes. OpenShift-only; no-op on vanilla k8s.
+	ctrlutil.WatchAPIServer(b, mgr.GetClient(), &rhtasv1.CTlogList{})
+
+	return b.Complete(r)
 }

--- a/internal/controller/fulcio/fulcio_controller.go
+++ b/internal/controller/fulcio/fulcio_controller.go
@@ -147,7 +147,7 @@ func (r *fulcioReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(pause).
 		For(&rhtasv1.Fulcio{}, builder.WithPredicates(predicate.ConfigurationChangedOnFailurePredicate[*rhtasv1.Fulcio]())).
 		Owns(&v1.Deployment{}).
@@ -160,6 +160,11 @@ func (r *fulcioReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		), builder.WithPredicates(crpredicate.Or(
 			crpredicate.GenerationChangedPredicate{},
 			predicate.ConditionChangedPredicate[*rhtasv1.CTlog](ctlogActions.TLSCondition),
-		))).
-		Complete(r)
+		)))
+
+	// Re-reconcile all Fulcio instances when the cluster-wide TLS security profile
+	// (config.openshift.io APIServer/cluster) changes. OpenShift-only; no-op on vanilla k8s.
+	ctrlutil.WatchAPIServer(b, mgr.GetClient(), &rhtasv1.FulcioList{})
+
+	return b.Complete(r)
 }

--- a/internal/controller/rekor/rekor_controller.go
+++ b/internal/controller/rekor/rekor_controller.go
@@ -183,7 +183,7 @@ func (r *rekorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(pause).
 		For(&rhtasv1.Rekor{}, builder.WithPredicates(predicate.ConfigurationChangedOnFailurePredicate[*rhtasv1.Rekor]())).
 		Owns(&v12.Deployment{}).
@@ -200,6 +200,11 @@ func (r *rekorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			ctrlutil.ServiceRefWatch(mgr.GetClient(), &rhtasv1.RekorList{}, func(o client.Object) rhtasv1.ServiceReference {
 				return o.(*rhtasv1.Rekor).Spec.Monitoring.Tuf
 			}),
-		), builder.WithPredicates(crpredicate.GenerationChangedPredicate{})).
-		Complete(r)
+		), builder.WithPredicates(crpredicate.GenerationChangedPredicate{}))
+
+	// Re-reconcile all Rekor instances when the cluster-wide TLS security profile
+	// (config.openshift.io APIServer/cluster) changes. OpenShift-only; no-op on vanilla k8s.
+	ctrlutil.WatchAPIServer(b, mgr.GetClient(), &rhtasv1.RekorList{})
+
+	return b.Complete(r)
 }

--- a/internal/controller/securesign/securesign_controller.go
+++ b/internal/controller/securesign/securesign_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/operator-framework/operator-lib/predicate"
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/controller/securesign/actions"
+	ctrlutil "github.com/securesign/operator/internal/utils/controller"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -129,7 +130,7 @@ func (r *securesignReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(pause).
 		For(&rhtasv1.Securesign{}).
 		Owns(&rhtasv1.Fulcio{}).
@@ -137,6 +138,11 @@ func (r *securesignReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rhtasv1.Tuf{}).
 		Owns(&rhtasv1.Trillian{}).
 		Owns(&rhtasv1.CTlog{}).
-		Owns(&rhtasv1.TimestampAuthority{}).
-		Complete(r)
+		Owns(&rhtasv1.TimestampAuthority{})
+
+	// Re-reconcile all Securesign instances when the cluster-wide TLS security profile
+	// (config.openshift.io APIServer/cluster) changes. OpenShift-only; no-op on vanilla k8s.
+	ctrlutil.WatchAPIServer(b, mgr.GetClient(), &rhtasv1.SecuresignList{})
+
+	return b.Complete(r)
 }

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -44,6 +44,7 @@ import (
 
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	tasPredicate "github.com/securesign/operator/internal/controller/predicate"
+	ctrlutil "github.com/securesign/operator/internal/utils/controller"
 
 	// Register the service resolver for the trillian controller
 	_ "github.com/securesign/operator/internal/controller/trillian/serviceresolver"
@@ -165,10 +166,15 @@ func (r *trillianReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(pause).
 		For(&rhtasv1.Trillian{}, builder.WithPredicates(tasPredicate.ConfigurationChangedOnFailurePredicate[*rhtasv1.Trillian]())).
 		Owns(&v1.Deployment{}).
-		Owns(&v12.Service{}).
-		Complete(r)
+		Owns(&v12.Service{})
+
+	// Re-reconcile all Trillian instances when the cluster-wide TLS security profile
+	// (config.openshift.io APIServer/cluster) changes. OpenShift-only; no-op on vanilla k8s.
+	ctrlutil.WatchAPIServer(b, mgr.GetClient(), &rhtasv1.TrillianList{})
+
+	return b.Complete(r)
 }

--- a/internal/controller/tsa/timestampauthority_controller.go
+++ b/internal/controller/tsa/timestampauthority_controller.go
@@ -39,6 +39,7 @@ import (
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/controller/tsa/actions"
 	_ "github.com/securesign/operator/internal/controller/tsa/serviceresolver"
+	ctrlutil "github.com/securesign/operator/internal/utils/controller"
 	v1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
 	v13 "k8s.io/api/networking/v1"
@@ -146,11 +147,16 @@ func (r *timestampAuthorityReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(pause).
 		For(&rhtasv1.TimestampAuthority{}, builder.WithPredicates(predicate.ConfigurationChangedOnFailurePredicate[*rhtasv1.TimestampAuthority]())).
 		Owns(&v1.Deployment{}).
 		Owns(&v12.Service{}).
-		Owns(&v13.Ingress{}).
-		Complete(r)
+		Owns(&v13.Ingress{})
+
+	// Re-reconcile all TimestampAuthority instances when the cluster-wide TLS security
+	// profile (config.openshift.io APIServer/cluster) changes. OpenShift-only; no-op on vanilla k8s.
+	ctrlutil.WatchAPIServer(b, mgr.GetClient(), &rhtasv1.TimestampAuthorityList{})
+
+	return b.Complete(r)
 }

--- a/internal/controller/tuf/tuf_controller.go
+++ b/internal/controller/tuf/tuf_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/securesign/operator/internal/controller/tuf/actions"
 	"github.com/securesign/operator/internal/controller/tuf/constants"
 	_ "github.com/securesign/operator/internal/controller/tuf/serviceresolver"
+	ctrlutil "github.com/securesign/operator/internal/utils/controller"
 	fipsutil "github.com/securesign/operator/internal/utils/fips"
 	v1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
@@ -158,11 +159,16 @@ func (r *tufReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		WithEventFilter(pause).
 		For(&rhtasv1.Tuf{}, builder.WithPredicates(predicate.ConfigurationChangedOnFailurePredicate[*rhtasv1.Tuf]())).
 		Owns(&v1.Deployment{}).
 		Owns(&v12.Service{}).
-		Owns(&v13.Ingress{}).
-		Complete(r)
+		Owns(&v13.Ingress{})
+
+	// Re-reconcile all Tuf instances when the cluster-wide TLS security profile
+	// (config.openshift.io APIServer/cluster) changes. OpenShift-only; no-op on vanilla k8s.
+	ctrlutil.WatchAPIServer(b, mgr.GetClient(), &rhtasv1.TufList{})
+
+	return b.Complete(r)
 }

--- a/internal/utils/controller/apiserver_watch.go
+++ b/internal/utils/controller/apiserver_watch.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	crpredicate "sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// watchesRegistrar is the subset of builder.Builder used to register a watch.
+// *builder.Builder satisfies it, and it allows the guard in WatchAPIServer to be
+// unit-tested with a spy without standing up a manager.
+type watchesRegistrar interface {
+	Watches(object client.Object, eventHandler handler.EventHandler, opts ...builder.WatchesOption) *builder.Builder
+}
+
+// EnqueueAllOnClusterConfigChange returns a handler.MapFunc that enqueues a
+// reconcile request for every object contained in listObj.
+//
+// It is used to fan out a change on a cluster-scoped singleton (for example the
+// config.openshift.io APIServer/cluster object that carries the cluster-wide TLS
+// security profile) to all instances of a namespaced CR kind, so each instance
+// re-reconciles and re-reads the cluster-wide configuration. The triggering
+// object itself is ignored; the full list of CRs is always enqueued.
+func EnqueueAllOnClusterConfigChange(cl client.Client, listObj client.ObjectList) handler.MapFunc {
+	return func(ctx context.Context, obj client.Object) []reconcile.Request {
+		log := logf.FromContext(ctx).WithName("APIServerWatch")
+		list := listObj.DeepCopyObject().(client.ObjectList)
+		if err := cl.List(ctx, list); err != nil {
+			log.V(1).Info("failed to list CRs for cluster config change, skipping enqueue", "error", err)
+			return nil
+		}
+		items, err := meta.ExtractList(list)
+		if err != nil {
+			log.V(1).Info("failed to extract CR list for cluster config change, skipping enqueue", "error", err)
+			return nil
+		}
+		var requests []reconcile.Request
+		for _, raw := range items {
+			item, ok := raw.(client.Object)
+			if !ok {
+				continue
+			}
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: item.GetNamespace(), Name: item.GetName()},
+			})
+		}
+		if len(requests) > 0 {
+			log.V(1).Info("cluster TLS security profile changed, enqueuing reconcile for all CRs",
+				"trigger", obj.GetName(), "count", len(requests))
+		}
+		return requests
+	}
+}
+
+// WatchAPIServer registers a watch on the cluster-wide config.openshift.io
+// APIServer singleton that re-reconciles every CR in listObj when it changes,
+// so TLS-sensitive outputs converge on the new cluster TLS security profile.
+//
+// The watch is only registered on OpenShift: the APIServer CRD does not exist on
+// vanilla Kubernetes and watching a missing CRD makes the manager fail at
+// startup. ResourceVersionChangedPredicate suppresses no-op cache resyncs so
+// unrelated cache events do not trigger a reconcile storm.
+func WatchAPIServer(b watchesRegistrar, cl client.Client, listObj client.ObjectList) {
+	if !kubernetes.IsOpenShift() {
+		return
+	}
+	b.Watches(&configv1.APIServer{}, handler.EnqueueRequestsFromMapFunc(
+		EnqueueAllOnClusterConfigChange(cl, listObj),
+	), builder.WithPredicates(crpredicate.ResourceVersionChangedPredicate{}))
+}

--- a/internal/utils/controller/apiserver_watch_test.go
+++ b/internal/utils/controller/apiserver_watch_test.go
@@ -1,0 +1,119 @@
+package controller
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/config"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+func TestEnqueueAllOnClusterConfigChange(t *testing.T) {
+	// The triggering object is the cluster APIServer singleton; it is ignored and
+	// every instance of the watched CR kind must be enqueued regardless of namespace.
+	apiServer := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
+
+	tests := []struct {
+		name     string
+		fulcios  []client.Object
+		expected []types.NamespacedName
+	}{
+		{
+			name:     "no instances enqueues nothing",
+			fulcios:  nil,
+			expected: nil,
+		},
+		{
+			name: "single instance enqueued",
+			fulcios: []client.Object{
+				&rhtasv1.Fulcio{ObjectMeta: metav1.ObjectMeta{Name: "f1", Namespace: "ns1"}},
+			},
+			expected: []types.NamespacedName{{Name: "f1", Namespace: "ns1"}},
+		},
+		{
+			name: "instances across namespaces are all enqueued",
+			fulcios: []client.Object{
+				&rhtasv1.Fulcio{ObjectMeta: metav1.ObjectMeta{Name: "f1", Namespace: "ns1"}},
+				&rhtasv1.Fulcio{ObjectMeta: metav1.ObjectMeta{Name: "f2", Namespace: "ns2"}},
+			},
+			expected: []types.NamespacedName{
+				{Name: "f1", Namespace: "ns1"},
+				{Name: "f2", Namespace: "ns2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := testAction.FakeClientBuilder().WithObjects(tt.fulcios...).Build()
+
+			mapFn := EnqueueAllOnClusterConfigChange(c, &rhtasv1.FulcioList{})
+			got := mapFn(t.Context(), apiServer)
+
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %d requests, got %d: %v", len(tt.expected), len(got), got)
+			}
+			set := make(map[types.NamespacedName]bool, len(got))
+			for _, r := range got {
+				set[r.NamespacedName] = true
+			}
+			for _, want := range tt.expected {
+				if !set[want] {
+					t.Errorf("expected request %v not found in %v", want, got)
+				}
+			}
+		})
+	}
+}
+
+// spyRegistrar records Watches invocations so the OpenShift guard in
+// WatchAPIServer can be asserted without standing up a manager.
+type spyRegistrar struct {
+	calls   int
+	watched client.Object
+}
+
+func (s *spyRegistrar) Watches(object client.Object, _ handler.EventHandler, _ ...builder.WatchesOption) *builder.Builder {
+	s.calls++
+	s.watched = object
+	return nil
+}
+
+func TestWatchAPIServer_OpenShiftGuard(t *testing.T) {
+	c := testAction.FakeClientBuilder().Build()
+
+	t.Run("not registered on vanilla kubernetes", func(t *testing.T) {
+		orig := config.Openshift
+		config.Openshift = false
+		defer func() { config.Openshift = orig }()
+
+		spy := &spyRegistrar{}
+		WatchAPIServer(spy, c, &rhtasv1.FulcioList{})
+
+		if spy.calls != 0 {
+			t.Fatalf("expected no APIServer watch on vanilla k8s, got %d", spy.calls)
+		}
+	})
+
+	t.Run("registered on OpenShift", func(t *testing.T) {
+		orig := config.Openshift
+		config.Openshift = true
+		defer func() { config.Openshift = orig }()
+
+		spy := &spyRegistrar{}
+		WatchAPIServer(spy, c, &rhtasv1.FulcioList{})
+
+		if spy.calls != 1 {
+			t.Fatalf("expected exactly one APIServer watch on OpenShift, got %d", spy.calls)
+		}
+		if _, ok := spy.watched.(*configv1.APIServer); !ok {
+			t.Fatalf("expected watch on *configv1.APIServer, got %T", spy.watched)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

When a cluster admin changes `spec.tlsSecurityProfile` on the OpenShift
`config.openshift.io` `APIServer/cluster` singleton, every managed controller now
**re-reconciles** so all TLS-sensitive outputs — Route annotations, the `redis.conf`
ConfigMap, and operand `GODEBUG` env vars — converge on the new cluster TLS security
profile within one reconcile cycle.

This PR adds **only the trigger** (the Watch). It does not change any reconcile
business logic. The reconcile bodies already resolve the cluster profile
(SECURESIGN-4993) and are idempotent via `kubernetes.CreateOrUpdate` + the `ensure.*`
helpers, so re-enqueuing is sufficient for convergence.

Jira: **SECURESIGN-4996**
Builds on **SECURESIGN-4993** (cluster TLS profile resolver) and **#2040** (RBAC + cache scaffolding).

## What changed

**1. `Watch` on `configv1.APIServer` in all 7 controllers**
`ctlog`, `fulcio`, `rekor`, `trillian`, `tsa`, `tuf`, `securesign` each register a watch
on the cluster APIServer singleton via a new shared helper. The handler maps the
singleton change → enqueues **every instance** of that controller's own CR kind; the
APIServer object itself is never reconciled. All existing `For` / `Owns` / `Watches`
entries are left intact.

**2. Shared helper — `internal/utils/controller/apiserver_watch.go`**
- `WatchAPIServer(...)` — registers the watch, guarded by `kubernetes.IsOpenShift()`,
  with `predicate.ResourceVersionChangedPredicate{}`.
- `EnqueueAllOnClusterConfigChange(...)` — lists the controller's CR kind and enqueues
  one request per instance.

## OpenShift-only guard

`configv1.APIServer` does not exist on vanilla Kubernetes, and watching a missing CRD
makes the manager fail at startup. Registration is therefore wrapped in
`kubernetes.IsOpenShift()` (the same pattern already used across the codebase). On
vanilla k8s the watch is simply never added and the operator starts normally.

## Storm prevention

- `ResourceVersionChangedPredicate` drops no-op cache resyncs, so periodic informer
  resyncs of the singleton never trigger a reconcile.
- The watch only fires on real APIServer changes — unrelated changes to a Securesign (or
  any operand) CR do **not** cause an APIServer re-read.
- Reconcile bodies remain idempotent (`CreateOrUpdate` + `ensure.*`), so a redundant
  enqueue is a cheap no-op when nothing changed.

## Cache singleton restriction (already present, verified)

The APIServer informer cache is pinned to `metadata.name=cluster` in
`cmd/main.go` (inside the existing `IsOpenShift()` block, alongside `configv1.Ingress`).
The operator's ClusterRole is scoped to `resourceName=cluster`, so a cluster-wide list
would be forbidden — the singleton restriction keeps the cache legal.

## RBAC (already present, verified)

The `config.openshift.io` `apiservers` `get;list;watch` marker
(`internal/controller/types.go`) and the generated cluster-scoped ClusterRole rule
(`config/rbac/role.yaml`) already exist from #2040. `make manifests` produces **no diff**
to `role.yaml` in this PR.

## Tests

- New unit tests in `internal/utils/controller/apiserver_watch_test.go`:
  - `EnqueueAllOnClusterConfigChange` fans out to every CR instance across namespaces and
    ignores the triggering object.
  - `WatchAPIServer` registers the watch **only** when `IsOpenShift()` is true
    (0 registrations on vanilla k8s, exactly 1 on OpenShift, on `*configv1.APIServer`).
- All 7 controller envtest suites pass.

```
make manifests generate fmt vet   # clean; git diff config/rbac/role.yaml is empty
go build ./...                    # ok
go test ./internal/controller/... ./cmd/...   # pass
```

## Non-goals

- No changes to reconcile business logic, Route annotation writing, `redis.conf`
  generation, or `GODEBUG` injection (separate stories).
- No process-restart watcher — this is re-reconcile, not restart.
- All new behavior is OpenShift-guarded; vanilla Kubernetes startup is unaffected.
