### PR TITLE
fix: disable cluster-wide caching of Secret and ConfigMap data (backport to release-1.4)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -235,6 +235,18 @@ func main() {
 			RecoverPanic: ptr.To(true),
 		},
 		Cache: cacheOpts,
+		// Secret/ConfigMap are excluded from cacheOpts.ByObject: a label/field selector on
+		// these types would return a permanent NotFound for any object outside the selector
+		// (no live fallback), breaking user-provided (BYO) secret/configmap refs. DisableFor
+		// keeps reads live instead, avoiding an unfiltered, cluster-wide cache.
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.Secret{},
+					&corev1.ConfigMap{},
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/internal/controller/ctlog/actions/handle_keys.go
+++ b/internal/controller/ctlog/actions/handle_keys.go
@@ -236,7 +236,7 @@ func (g handleKeys) generateAndUploadSecret(ctx context.Context, instance *v1alp
 			Namespace:    instance.Namespace,
 		},
 	}
-	if _, err = kubernetes.CreateOrUpdate(ctx, g.Client,
+	if err = kubernetes.Create(ctx, g.Client,
 		secret,
 		ensure.ControllerReference[*v1.Secret](instance, g.Client),
 		ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(componentLabels)), componentLabels),

--- a/internal/controller/ctlog/actions/handle_keys_test.go
+++ b/internal/controller/ctlog/actions/handle_keys_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/securesign/operator/internal/utils/kubernetes"
 	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	. "github.com/onsi/gomega"
 	"github.com/securesign/operator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -565,4 +567,41 @@ func TestKeys_Handle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKeys_Handle_UncachedClientRejectsEmptyNameGet(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	instance := &v1alpha1.CTlog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instance",
+			Namespace: "default",
+		},
+	}
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:   constants.ReadyCondition,
+		Reason: state.Creating.String(),
+	})
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, wrapped client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v1.Secret); ok && key.Name == "" {
+					return k8sErrors.NewBadRequest("resource name may not be empty")
+				}
+				return wrapped.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testAction.PrepareAction(c, NewHandleKeysAction())
+	g.Expect(a.Handle(ctx, instance)).To(Equal(testAction.StatusUpdate()))
+
+	found := &v1alpha1.CTlog{}
+	g.Expect(c.Get(ctx, client.ObjectKeyFromObject(instance), found)).To(Succeed())
+	g.Expect(found.Status.PrivateKeyRef).To(Not(BeNil()))
+	g.Expect(found.Status.PublicKeyRef).To(Not(BeNil()))
 }

--- a/internal/controller/ctlog/actions/server_config.go
+++ b/internal/controller/ctlog/actions/server_config.go
@@ -205,7 +205,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.CTlog)
 
 	configAnnotations := i.configMatchingAnnotations(instance, trillianUrl)
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		newConfig,
 		ensure.ControllerReference[*corev1.Secret](instance, i.Client),
 		ensure.Labels[*corev1.Secret](slices.Collect(maps.Keys(configLabels)), configLabels),

--- a/internal/controller/ctlog/actions/server_config_test.go
+++ b/internal/controller/ctlog/actions/server_config_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/onsi/gomega/gstruct"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"k8s.io/utils/ptr"
 
@@ -163,9 +164,10 @@ func TestServerConfig_Handle(t *testing.T) {
 	labels := labels.ForResource(ComponentName, DeploymentName, "ctlog", serverConfigResourceName)
 
 	type env struct {
-		spec    rhtasv1alpha1.CTlogSpec
-		status  rhtasv1alpha1.CTlogStatus
-		objects []client.Object
+		spec      rhtasv1alpha1.CTlogSpec
+		status    rhtasv1alpha1.CTlogStatus
+		objects   []client.Object
+		intercept interceptor.Funcs
 	}
 	type want struct {
 		result *action.Result
@@ -237,6 +239,52 @@ func TestServerConfig_Handle(t *testing.T) {
 			},
 			want: want{
 				result: testAction.StatusUpdate(),
+				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
+					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
+					g.Expect(instance.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
+				},
+			},
+		},
+		{
+			name: "create a new config with an uncached client rejecting empty-name Get",
+			env: env{
+				spec: rhtasv1alpha1.CTlogSpec{
+					ServerConfigRef: nil,
+					Trillian:        rhtasv1alpha1.TrillianService{Port: ptr.To(int32(80))},
+				},
+				status: rhtasv1alpha1.CTlogStatus{
+					ServerConfigRef: nil,
+					TreeID:          ptr.To(int64(123456)),
+					RootCertificates: []rhtasv1alpha1.SecretKeySelector{
+						{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "cert"},
+					},
+					PrivateKeyRef: &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "private"},
+					PublicKeyRef:  &rhtasv1alpha1.SecretKeySelector{LocalObjectReference: rhtasv1alpha1.LocalObjectReference{Name: "secret"}, Key: "public"},
+				},
+				objects: []client.Object{
+					&v1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "secret",
+							Namespace: "default",
+						},
+						Data: map[string][]byte{
+							"cert":    cert,
+							"private": privateKey,
+							"public":  publicKey,
+						},
+					},
+				},
+				intercept: interceptor.Funcs{
+					Get: func(ctx context.Context, wrapped client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if _, ok := obj.(*v1.Secret); ok && key.Name == "" {
+							return k8sErrors.NewBadRequest("resource name may not be empty")
+						}
+						return wrapped.Get(ctx, key, obj, opts...)
+					},
+				},
+			},
+			want: want{
+				result: testAction.Return(),
 				verify: func(g Gomega, instance *rhtasv1alpha1.CTlog, cli client.WithWatch) {
 					g.Expect(instance.Status.ServerConfigRef).ShouldNot(BeNil())
 					g.Expect(instance.Status.ServerConfigRef.Name).Should(ContainSubstring("ctlog-config-"))
@@ -496,6 +544,7 @@ func TestServerConfig_Handle(t *testing.T) {
 				WithObjects(instance).
 				WithStatusSubresource(instance).
 				WithObjects(tt.env.objects...).
+				WithInterceptorFuncs(tt.env.intercept).
 				Build()
 
 			a := testAction.PrepareAction(c, NewServerConfigAction())

--- a/internal/controller/fulcio/actions/generate_cert.go
+++ b/internal/controller/fulcio/actions/generate_cert.go
@@ -164,7 +164,7 @@ func (g handleCert) Handle(ctx context.Context, instance *v1alpha1.Fulcio) *acti
 			Namespace:    instance.Namespace,
 		},
 	}
-	if _, err = kubernetes.CreateOrUpdate(ctx, g.Client,
+	if err = kubernetes.Create(ctx, g.Client,
 		newCert,
 		ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(componentLabels)), componentLabels),
 		ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(keyLabels)), keyLabels),

--- a/internal/controller/fulcio/actions/generate_cert_test.go
+++ b/internal/controller/fulcio/actions/generate_cert_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 )
@@ -447,4 +448,43 @@ func TestGenerateCert_Handle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateCert_Handle_UncachedClientRejectsEmptyNameGet(t *testing.T) {
+	ctx := context.TODO()
+	g := NewWithT(t)
+
+	instance := &rhtasv1alpha1.Fulcio{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "instance",
+			Namespace: "default",
+		},
+		Spec: rhtasv1alpha1.FulcioSpec{
+			Certificate: rhtasv1alpha1.FulcioCert{
+				OrganizationName:  "RH",
+				OrganizationEmail: "jdoe@redhat.com",
+			},
+		},
+	}
+	instance.SetCondition(metav1.Condition{
+		Type:   constants.ReadyCondition,
+		Reason: state.Pending.String(),
+	})
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, wrapped client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v1.Secret); ok && key.Name == "" {
+					return errors.NewBadRequest("resource name may not be empty")
+				}
+				return wrapped.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testAction.PrepareAction(c, NewHandleCertAction())
+	g.Expect(a.Handle(ctx, instance)).To(Equal(testAction.StatusUpdate()))
+	g.Expect(meta.IsStatusConditionPresentAndEqual(instance.Status.Conditions, CertCondition, metav1.ConditionTrue)).To(BeTrue())
 }

--- a/internal/controller/fulcio/actions/server_config.go
+++ b/internal/controller/fulcio/actions/server_config.go
@@ -117,7 +117,7 @@ func (i serverConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.Fulcio
 		},
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		newConfig,
 		ensure.ControllerReference[*v1.ConfigMap](instance, i.Client),
 		ensure.Labels[*v1.ConfigMap](slices.Collect(maps.Keys(configLabel)), configLabel),

--- a/internal/controller/rekor/actions/searchIndex/redis/actions/generate_password.go
+++ b/internal/controller/rekor/actions/searchIndex/redis/actions/generate_password.go
@@ -52,7 +52,7 @@ func (i generatePasswordAction) Handle(ctx context.Context, instance *rhtasv1alp
 			GenerateName: fmt.Sprintf("redis-password-%s", instance.Name),
 		},
 	}
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client, obj,
+	if err = kubernetes.Create(ctx, i.Client, obj,
 		ensure.ControllerReference[*core.Secret](instance, i.Client),
 		ensure.Labels[*core.Secret](slices.Collect(maps.Keys(labels)), labels),
 		kubernetes.EnsureSecretData(true, map[string][]byte{"password": utils.GeneratePassword(8)}),

--- a/internal/controller/rekor/actions/server/generate_signer.go
+++ b/internal/controller/rekor/actions/server/generate_signer.go
@@ -152,7 +152,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Rekor) *a
 				},
 			}
 
-			if _, err = kubernetes.CreateOrUpdate(ctx, g.Client,
+			if err = kubernetes.Create(ctx, g.Client,
 				secret,
 				ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(componentLabels)), componentLabels),
 				ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(signerLabels)), signerLabels),

--- a/internal/controller/rekor/actions/server/generate_signer_test.go
+++ b/internal/controller/rekor/actions/server/generate_signer_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/securesign/operator/internal/constants"
 	"github.com/securesign/operator/internal/state"
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 
 	. "github.com/onsi/gomega"
 	"github.com/securesign/operator/internal/controller/rekor/actions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
 	testAction "github.com/securesign/operator/internal/testing/action"
@@ -459,6 +461,46 @@ func TestGenerateSigner_Handle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGenerateSigner_Handle_UncachedClientRejectsEmptyNameGet(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	instance := &rhtasv1alpha1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rekor",
+			Namespace: "default",
+		},
+	}
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:   constants.ReadyCondition,
+		Reason: state.Pending.String(),
+	})
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type:   actions.SignerCondition,
+		Status: metav1.ConditionFalse,
+		Reason: state.Pending.String(),
+	})
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, wrapped client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v1.Secret); ok && key.Name == "" {
+					return k8sErrors.NewBadRequest("resource name may not be empty")
+				}
+				return wrapped.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	a := testAction.PrepareAction(c, NewGenerateSignerAction())
+	g.Expect(a.Handle(ctx, instance)).To(Equal(testAction.StatusUpdate()))
+	g.Expect(instance.Status.Signer.KeyRef).ShouldNot(BeNil())
+	g.Expect(instance.Status.Signer.KeyRef.Name).Should(ContainSubstring("rekor-signer-rekor-"))
+	g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, actions.SignerCondition)).Should(BeTrue())
 }
 
 func TestGenerateSigner_SECURESIGN_1455(t *testing.T) {

--- a/internal/controller/rekor/actions/server/resolve_pub_key.go
+++ b/internal/controller/rekor/actions/server/resolve_pub_key.go
@@ -105,7 +105,7 @@ func (i resolvePubKeyAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 		},
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		newConfig,
 		ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(componentLabels)), componentLabels),
 		ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(keyLabels)), keyLabels),

--- a/internal/controller/rekor/actions/server/resolve_pub_key_test.go
+++ b/internal/controller/rekor/actions/server/resolve_pub_key_test.go
@@ -19,7 +19,9 @@ import (
 	testAction "github.com/securesign/operator/internal/testing/action"
 	httpmock "github.com/securesign/operator/internal/testing/http"
 	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/securesign/operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -270,4 +272,59 @@ func TestResolvePubKey_Handle(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolvePubKey_Handle_UncachedClientRejectsEmptyNameGet(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.TODO()
+
+	instance := &v1alpha1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rekor",
+			Namespace: "default",
+		},
+		Status: v1alpha1.RekorStatus{
+			TreeID:       ptr.To(int64(123456789)),
+			PublicKeyRef: nil,
+			Conditions: []metav1.Condition{
+				{
+					Type:   actions.ServerCondition,
+					Reason: state.Initialize.String(),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance).
+		WithStatusSubresource(instance).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, wrapped client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*v1.Secret); ok && key.Name == "" {
+					return k8sErrors.NewBadRequest("resource name may not be empty")
+				}
+				return wrapped.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	httpmock.SetMockTransport(http.DefaultClient, map[string]httpmock.RoundTripFunc{
+		"http://rekor-server.default.svc/api/v1/log/publicKey": func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(testPublicKey)),
+				Header:     make(http.Header),
+			}
+		},
+	})
+	defer httpmock.RestoreDefaultTransport(http.DefaultClient)
+
+	a := testAction.PrepareAction(c, NewResolvePubKeyAction())
+	g.Expect(a.Handle(ctx, instance)).To(Equal(testAction.StatusUpdate()))
+
+	secrets := v1.SecretList{}
+	g.Expect(kubernetes.FindByLabelSelector(ctx, c, &secrets, instance.Namespace, RekorPubLabel)).To(Succeed())
+	g.Expect(secrets.Items).Should(HaveLen(1))
+	g.Expect(secrets.Items[0].Data).Should(HaveKeyWithValue("public", testPublicKey))
 }

--- a/internal/controller/rekor/actions/server/sharding_config.go
+++ b/internal/controller/rekor/actions/server/sharding_config.go
@@ -83,7 +83,7 @@ func (i shardingConfig) Handle(ctx context.Context, instance *rhtasv1alpha1.Reko
 		},
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		newConfig,
 		ensure.ControllerReference[*v1.ConfigMap](instance, i.Client),
 		ensure.Labels[*v1.ConfigMap](slices.Collect(maps.Keys(labels)), labels),

--- a/internal/controller/trillian/actions/db/handle_secret.go
+++ b/internal/controller/trillian/actions/db/handle_secret.go
@@ -136,7 +136,7 @@ func (i handleSecretAction) Handle(ctx context.Context, instance *rhtasv1alpha1.
 			Namespace:    instance.Namespace,
 		},
 	}
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		dbSecret,
 		ensure.Labels[*corev1.Secret](slices.Collect(maps.Keys(dbLabels)), dbLabels),
 		ensure.Annotations[*corev1.Secret](managedAnnotations, i.secretAnnotations()),

--- a/internal/controller/tsa/actions/generate_signer.go
+++ b/internal/controller/tsa/actions/generate_signer.go
@@ -189,7 +189,7 @@ func (g generateSigner) Handle(ctx context.Context, instance *v1alpha1.Timestamp
 		},
 	}
 
-	if _, err = kubernetes.CreateOrUpdate(ctx, g.Client,
+	if err = kubernetes.Create(ctx, g.Client,
 		certificateChain,
 		ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(componentLabels)), componentLabels),
 		ensure.Labels[*v1.Secret](slices.Collect(maps.Keys(certLabels)), certLabels),

--- a/internal/controller/tsa/actions/generate_signer_test.go
+++ b/internal/controller/tsa/actions/generate_signer_test.go
@@ -14,10 +14,13 @@ import (
 
 	. "github.com/onsi/gomega"
 	rhtasv1alpha1 "github.com/securesign/operator/api/v1alpha1"
+	testAction "github.com/securesign/operator/internal/testing/action"
 	common "github.com/securesign/operator/internal/testing/common/tsa"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func Test_NewGenerateSignerAction(t *testing.T) {
@@ -124,6 +127,37 @@ func Test_SignerHandle(t *testing.T) {
 				g.Expect(secret.Name).To(Equal(instance.Status.Signer.CertificateChain.CertificateChainRef.Name), "Secret name mismatch for CertificateChainRef")
 				g.Expect(secret.Name).To(Equal(instance.Status.Signer.File.PrivateKeyRef.Name), "Secret name mismatch for PrivateKeyRef")
 				g.Expect(secret.Annotations).To(Equal(generateSecretAnnotations(instance.Spec.Signer)), "Secret annotation mismatch")
+
+				g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, TSASignerCondition)).To(BeTrue())
+
+				return true
+			},
+		},
+		{
+			name: "generate all resources with uncached client rejecting empty-name Get",
+			setup: func(instance *rhtasv1alpha1.TimestampAuthority) (client.WithWatch, action.Action[*rhtasv1alpha1.TimestampAuthority]) {
+				instance.Status.Conditions[0].Reason = state.Pending.String()
+				cli := testAction.FakeClientBuilder().
+					WithObjects(instance).
+					WithStatusSubresource(instance).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(ctx context.Context, wrapped client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+							if _, ok := obj.(*v1.Secret); ok && key.Name == "" {
+								return k8sErrors.NewBadRequest("resource name may not be empty")
+							}
+							return wrapped.Get(ctx, key, obj, opts...)
+						},
+					}).
+					Build()
+				return common.TsaTestSetup(instance, t, cli, NewGenerateSignerAction())
+			},
+			testCase: func(g Gomega, _ action.Action[*rhtasv1alpha1.TimestampAuthority], client client.WithWatch, instance *rhtasv1alpha1.TimestampAuthority) bool {
+
+				secret, err := kubernetes.FindSecret(context.TODO(), client, instance.Namespace, TSACertCALabel)
+				g.Expect(err).NotTo(HaveOccurred(), "Unable to find secret")
+
+				g.Expect(instance.Status.Signer).NotTo(BeNil(), "Status Signer should not be nil")
+				g.Expect(secret.Name).To(Equal(instance.Status.Signer.CertificateChain.CertificateChainRef.Name), "Secret name mismatch for CertificateChainRef")
 
 				g.Expect(meta.IsStatusConditionTrue(instance.Status.Conditions, TSASignerCondition)).To(BeTrue())
 

--- a/internal/controller/tsa/actions/ntpMonitoring.go
+++ b/internal/controller/tsa/actions/ntpMonitoring.go
@@ -159,7 +159,7 @@ func (i ntpMonitoringAction) Handle(ctx context.Context, instance *rhtasv1alpha1
 			Namespace:    instance.Namespace,
 		},
 	}
-	if _, err = kubernetes.CreateOrUpdate(ctx, i.Client,
+	if err = kubernetes.Create(ctx, i.Client,
 		configMap,
 		ensure.ControllerReference[*v1.ConfigMap](instance, i.Client),
 		ensure.Labels[*v1.ConfigMap](slices.Collect(maps.Keys(l)), l),

--- a/internal/utils/kubernetes/common.go
+++ b/internal/utils/kubernetes/common.go
@@ -101,6 +101,17 @@ func FindByLabelSelector(ctx context.Context, c client.Client, list client.Objec
 	return c.List(ctx, list, client.InNamespace(namespace), listOptions)
 }
 
+func Create[T client.Object](ctx context.Context, cli client.Client, obj T, fn ...func(object T) error) error {
+	var err error
+	for _, f := range fn {
+		err = errors.Join(err, f(obj))
+	}
+	if err != nil {
+		return err
+	}
+	return cli.Create(ctx, obj)
+}
+
 func CreateOrUpdate[T client.Object](ctx context.Context, cli client.Client, obj T, fn ...func(object T) error) (result controllerutil.OperationResult, err error) {
 	err = retry.OnError(retry.DefaultRetry, func(err error) bool {
 		return apiErrors.IsConflict(err) || apiErrors.IsAlreadyExists(err)

--- a/internal/utils/kubernetes/common_test.go
+++ b/internal/utils/kubernetes/common_test.go
@@ -1,0 +1,86 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/onsi/gomega"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestCreate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		mutateErr error
+		intercept interceptor.Funcs
+		wantErr   bool
+	}{
+		{
+			name: "applies mutate fns and creates, without probing for an existing object",
+			intercept: interceptor.Funcs{
+				Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+					return fmt.Errorf("Get should never be called by Create")
+				},
+			},
+		},
+		{
+			name:      "mutate fn error is returned and Create is not called",
+			mutateErr: fmt.Errorf("mutate failed"),
+			intercept: interceptor.Funcs{
+				Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+					return fmt.Errorf("Create should not be called when a mutate fn fails")
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "client Create error is propagated",
+			intercept: interceptor.Funcs{
+				Create: func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.CreateOption) error {
+					return fmt.Errorf("api server unavailable")
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := gomega.NewWithT(t)
+			c := testAction.FakeClientBuilder().
+				WithInterceptorFuncs(tt.intercept).
+				Build()
+
+			obj := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "test-secret-",
+					Namespace:    "test-namespace",
+				},
+			}
+
+			err := Create(t.Context(), c, obj,
+				func(s *corev1.Secret) error {
+					if tt.mutateErr != nil {
+						return tt.mutateErr
+					}
+					s.Labels = map[string]string{"test-key": "test-value"}
+					return nil
+				},
+			)
+
+			if tt.wantErr {
+				g.Expect(err).To(gomega.HaveOccurred())
+				return
+			}
+			g.Expect(err).ToNot(gomega.HaveOccurred())
+			g.Expect(obj.Name).ToNot(gomega.BeEmpty())
+			g.Expect(obj.Labels).To(gomega.Equal(map[string]string{"test-key": "test-value"}))
+		})
+	}
+}


### PR DESCRIPTION
## What
Backport of the Secret/ConfigMap cache-disable fix from `main` (`5d047ed7`, `ffbdc504`) to `release-1.4`, plus a follow-up fix for additional call sites found during cluster testing.

- `cmd/main.go`: `Client.Cache.DisableFor` for `corev1.Secret`/`corev1.ConfigMap` — reads go straight to the API server instead of the shared informer cache.
- New `kubernetes.Create` helper (Create without the existence-check Get) used for the 6 `GenerateName` Secret/ConfigMap objects covered by upstream (trillian DB secret, ctlog/fulcio config, rekor sharding config, redis password, tsa NTP config).
- **Follow-up**: `release-1.4` still has 5 pre-generic-signer-action call sites (Fulcio cert, Rekor signer, Rekor pub key, CTlog keys, TSA signer) with the same `GenerateName` + `CreateOrUpdate` pattern. These weren't in the upstream commit since `main` had already replaced them via a later generic-signer refactor. Deploying this backport on a live cluster surfaced it immediately: Fulcio/Rekor/TSA/CTlog all failed reconciliation with `resource name may not be empty`. Fixed the same way (`Create` instead of `CreateOrUpdate`), with a regression test per call site.

## Why
Secret/ConfigMap have no `ByObject` label filter (unlike Deployment/Pod/Service), so any Get/List against them cached **every** Secret/ConfigMap in the cluster, including decrypted key material — flagged by a customer as a data-exposure issue. Label-filtering isn't an option here since CRDs allow unlabeled, user-provided secret/configmap refs (BYO keys/certs).

Disabling the cache means `CreateOrUpdate`'s probing `Get` on any `GenerateName` object (empty name) now hits the API server and gets `BadRequest` instead of a cache `NotFound`, breaking creation. `kubernetes.Create` skips that Get entirely for these always-new objects.

## Not included
1.5.0 also has `649b3bd2`/`1f7a7d0e` (metadata-only Secret reads) and the later generic-signer-action refactor — skipped, they depend on helpers/refactors not present on `release-1.4` and aren't needed for the customer fix.

## Test plan
- [x] `make test` — full suite green (envtest included), all 11 affected call sites covered
- [x] `go vet`, `gofmt`, `golangci-lint` clean
- [x] Deployed to a live OpenShift cluster: full `Securesign` CR (Trillian, CTlog, Fulcio, Rekor, TSA) reconciles cleanly, no `resource name may not be empty` errors
- [x] Live cluster memory test: 150 Secrets + 150 ConfigMaps, ~900KB payload each (~270MB total), fresh operator pod per run:
  - `v1.4.3` (unfixed): **OOMKilled**
  - This backport: **33.3 MiB**, no crash

REF: [SECURESIGN-5387](https://redhat.atlassian.net/browse/SECURESIGN-5387)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SECURESIGN-5387]: https://redhat.atlassian.net/browse/SECURESIGN-5387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ