### PR TITLE
feat: gate component rollout on cluster TLS profile adherence

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,7 @@ import (
 	consolev1 "github.com/openshift/api/console/v1"
 	v1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -197,6 +198,12 @@ func main() {
 		setupLog.Error(resolveErr, "unable to resolve cluster TLS security profile")
 		os.Exit(1)
 	}
+
+	// The cluster-wide TLS adherence policy is a floor for every managed component:
+	// a per-resource tlsAdherence annotation may match or tighten it but never relax
+	// it. Snapshot it once at startup; the SecurityProfileWatcher restarts the operator
+	// when it changes.
+	appconfig.ClusterTLSAdherenceStrict = clusterEnforcesStrictTLS(tlsAdherence)
 
 	tlsConfigFn, unsupportedCiphers := ostls.NewTLSConfigFromProfile(tlsProfileSpec)
 	if len(unsupportedCiphers) > 0 {
@@ -441,6 +448,23 @@ func resolveClusterTLSProfile(ctx context.Context, cli client.Client, openshift,
 
 	log.Info("cluster TLS security profile resolved")
 	return tlsProfileSpec, tlsAdherence, nil
+}
+
+// clusterEnforcesStrictTLS reports whether the cluster-wide TLS adherence policy
+// mandates that every component honour the cluster TLS security profile.
+//
+// StrictAllComponents is strict. NoOpinion and LegacyAdheringComponentsOnly are
+// not (this covers the common case where the field is absent or the TLSAdherence
+// feature gate is off, which FetchAPIServerTLSAdherencePolicy maps to NoOpinion).
+// Any other, unrecognised value of a present field is treated as strict, matching
+// the fail-secure guidance in openshift/api.
+func clusterEnforcesStrictTLS(policy configv1.TLSAdherencePolicy) bool {
+	switch policy {
+	case configv1.TLSAdherencePolicyNoOpinion, configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly:
+		return false
+	default:
+		return true
+	}
 }
 
 func setupController(name string, constructor controller.Constructor, manager ctrl.Manager) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -193,3 +193,26 @@ func TestResolveClusterTLSProfile_NotFoundClassification(t *testing.T) {
 
 	g.Expect(apierrors.IsNotFound(err)).To(gomega.BeTrue())
 }
+
+// clusterEnforcesStrictTLS: StrictAllComponents (and any unrecognised value) is strict;
+// NoOpinion and LegacyAdheringComponentsOnly are not.
+func TestClusterEnforcesStrictTLS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		policy configv1.TLSAdherencePolicy
+		want   bool
+	}{
+		{"StrictAllComponents is strict", configv1.TLSAdherencePolicyStrictAllComponents, true},
+		{"NoOpinion is not strict", configv1.TLSAdherencePolicyNoOpinion, false},
+		{"LegacyAdheringComponentsOnly is not strict", configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly, false},
+		{"unrecognised value is treated as strict (fail-secure)", configv1.TLSAdherencePolicy("SomethingNew"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			g.Expect(clusterEnforcesStrictTLS(tt.policy)).To(gomega.Equal(tt.want))
+		})
+	}
+}

--- a/internal/action/tlsadherence/action.go
+++ b/internal/action/tlsadherence/action.go
@@ -1,0 +1,98 @@
+package tlsadherence
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/apis"
+	"github.com/securesign/operator/internal/config"
+	"github.com/securesign/operator/internal/state"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewAction returns a generic action that gates a component's rollout on its
+// ability to honour the cluster TLS security profile.
+//
+// canHonourProfile is the per-component TLS-capability check. When it reports
+// true (the compliant case) the action is a no-op. When it reports false the
+// effective enforcement mode decides the outcome:
+//   - strict blocks the rollout with a terminal error condition;
+//   - legacy surfaces a Warning condition and lets the rollout continue.
+//
+// The effective mode is the cluster-wide TLS adherence policy combined with the
+// per-resource rhtas.redhat.com/tlsAdherence annotation. The cluster policy is a
+// floor: the annotation may match or tighten it, never relax it. A legacy
+// annotation on a strict cluster is a configuration conflict and is blocked.
+//
+// The action only takes effect when cluster TLS profile resolution is enforced
+// (see [github.com/securesign/operator/internal/config.ClusterTLSProfileEnforced]).
+// On vanilla Kubernetes or when resolution is disabled it is a no-op: no
+// condition is set and the rollout is never blocked.
+func NewAction[T apis.ConditionsAwareObject](component string, canHonourProfile func(T) bool) action.Action[T] {
+	return &adherenceAction[T]{component: component, canHonourProfile: canHonourProfile}
+}
+
+type adherenceAction[T apis.ConditionsAwareObject] struct {
+	action.BaseAction
+	component        string
+	canHonourProfile func(T) bool
+}
+
+func (i adherenceAction[T]) Name() string {
+	return fmt.Sprintf("check %s TLS profile adherence", i.component)
+}
+
+// CanHandle fires only when cluster TLS profile resolution is enforced and the
+// component cannot honour the profile. Compliant components, and any component on
+// a cluster where resolution is disabled (vanilla Kubernetes or
+// DisableClusterTLSProfile), are a no-op.
+func (i adherenceAction[T]) CanHandle(_ context.Context, instance T) bool {
+	if !config.ClusterTLSProfileEnforced() {
+		return false
+	}
+	return !i.canHonourProfile(instance)
+}
+
+func (i adherenceAction[T]) Handle(ctx context.Context, instance T) *action.Result {
+	// Only reached for a non-compliant component on a cluster that enforces the
+	// TLS profile. Combine the cluster-wide adherence policy (a floor) with the
+	// per-resource annotation to decide the effective enforcement mode.
+	effective, conflict := resolveMode(config.ClusterTLSAdherenceStrict, intentFromAnnotations(instance.GetAnnotations()))
+
+	msg := fmt.Sprintf("component %s cannot honour the cluster TLS security profile", i.component)
+
+	// A legacy annotation on a strict cluster tries to relax below the cluster
+	// mandate: surface it as a configuration error rather than silently upgrading.
+	if conflict {
+		err := reconcile.TerminalError(fmt.Errorf("%s: tlsAdherence=legacy conflicts with the cluster TLS adherence policy (StrictAllComponents); the annotation may not relax below the cluster mandate", msg))
+		return i.Error(ctx, err, instance, metav1.Condition{
+			Type:               TLSProfileAdherenceCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             ReasonInvalidConfiguration,
+			Message:            err.Error(),
+			ObservedGeneration: instance.GetGeneration(),
+		})
+	}
+
+	if effective == ModeStrict {
+		err := reconcile.TerminalError(fmt.Errorf("%s: rollout blocked because the effective TLS adherence mode is strict", msg))
+		return i.Error(ctx, err, instance, metav1.Condition{
+			Type:               TLSProfileAdherenceCondition,
+			Status:             metav1.ConditionFalse,
+			Reason:             state.Failure.String(),
+			Message:            err.Error(),
+			ObservedGeneration: instance.GetGeneration(),
+		})
+	}
+
+	instance.SetCondition(metav1.Condition{
+		Type:               TLSProfileAdherenceCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             ReasonWarning,
+		Message:            fmt.Sprintf("%s; deploying anyway (effective TLS adherence mode is legacy)", msg),
+		ObservedGeneration: instance.GetGeneration(),
+	})
+	return i.ReturnOnChange(i.PersistStatus)(ctx, instance)
+}

--- a/internal/action/tlsadherence/action_test.go
+++ b/internal/action/tlsadherence/action_test.go
@@ -1,0 +1,233 @@
+package tlsadherence
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/annotations"
+	"github.com/securesign/operator/internal/config"
+	"github.com/securesign/operator/internal/constants"
+	"github.com/securesign/operator/internal/state"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testComponent    = "test-component"
+	testInstanceName = "test-instance"
+	testNamespace    = "default"
+)
+
+func testInstance(adherence string) *rhtasv1.Fulcio {
+	instance := &rhtasv1.Fulcio{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testInstanceName,
+			Namespace:  testNamespace,
+			Generation: 1,
+		},
+	}
+	if adherence != "" {
+		instance.Annotations = map[string]string{annotations.TLSAdherence: adherence}
+	}
+	meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+		Type: constants.ReadyCondition, Status: metav1.ConditionFalse, Reason: state.Creating.String(),
+	})
+	return instance
+}
+
+func compliant(_ *rhtasv1.Fulcio) bool    { return true }
+func nonCompliant(_ *rhtasv1.Fulcio) bool { return false }
+
+// withClusterTLSProfile sets whether the operator resolves the cluster TLS
+// security profile for the duration of a test, restoring the globals afterwards.
+// The adherence gate only fires when resolution is active.
+func withClusterTLSProfile(t *testing.T, active bool) {
+	t.Helper()
+	prevOpenshift, prevDisabled := config.Openshift, config.DisableClusterTLSProfile
+	config.Openshift, config.DisableClusterTLSProfile = active, !active
+	t.Cleanup(func() {
+		config.Openshift, config.DisableClusterTLSProfile = prevOpenshift, prevDisabled
+	})
+}
+
+// withClusterAdherenceStrict sets the cluster-wide TLS adherence floor for the
+// duration of a test, restoring it afterwards.
+func withClusterAdherenceStrict(t *testing.T, strict bool) {
+	t.Helper()
+	prev := config.ClusterTLSAdherenceStrict
+	config.ClusterTLSAdherenceStrict = strict
+	t.Cleanup(func() { config.ClusterTLSAdherenceStrict = prev })
+}
+
+func TestIntentFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want annotationIntent
+	}{
+		{"nil is absent", nil, annotationAbsent},
+		{"empty value is absent", map[string]string{annotations.TLSAdherence: ""}, annotationAbsent},
+		{"unrecognised value is absent", map[string]string{annotations.TLSAdherence: "bogus"}, annotationAbsent},
+		{"legacy is legacy", map[string]string{annotations.TLSAdherence: "legacy"}, annotationLegacy},
+		{"strict is strict", map[string]string{annotations.TLSAdherence: "strict"}, annotationStrict},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(intentFromAnnotations(tt.in)).To(Equal(tt.want))
+		})
+	}
+}
+
+func TestResolveMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterStrict bool
+		intent        annotationIntent
+		wantMode      Mode
+		wantConflict  bool
+	}{
+		{"cluster strict + absent inherits strict", true, annotationAbsent, ModeStrict, false},
+		{"cluster strict + strict affirms strict", true, annotationStrict, ModeStrict, false},
+		{"cluster strict + legacy is a conflict", true, annotationLegacy, ModeStrict, true},
+		{"cluster not strict + absent is legacy", false, annotationAbsent, ModeLegacy, false},
+		{"cluster not strict + legacy is legacy", false, annotationLegacy, ModeLegacy, false},
+		{"cluster not strict + strict tightens", false, annotationStrict, ModeStrict, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			mode, conflict := resolveMode(tt.clusterStrict, tt.intent)
+			g.Expect(mode).To(Equal(tt.wantMode))
+			g.Expect(conflict).To(Equal(tt.wantConflict))
+		})
+	}
+}
+
+func TestCanHonourClusterTLSProfile_StubIsCompliant(t *testing.T) {
+	g := NewWithT(t)
+	// TODO(STORY-994): stub currently reports every component as compliant.
+	g.Expect(CanHonourClusterTLSProfile(testInstance(""))).To(BeTrue())
+}
+
+func TestCanHandle(t *testing.T) {
+	t.Run("enforced: compliant component is a no-op (CanHandle false)", func(t *testing.T) {
+		g := NewWithT(t)
+		withClusterTLSProfile(t, true)
+		cli := testAction.FakeClientBuilder().Build()
+		a := testAction.PrepareAction(cli, NewAction[*rhtasv1.Fulcio](testComponent, compliant))
+		g.Expect(a.CanHandle(t.Context(), testInstance(""))).To(BeFalse())
+	})
+
+	t.Run("enforced: non-compliant component is handled (CanHandle true)", func(t *testing.T) {
+		g := NewWithT(t)
+		withClusterTLSProfile(t, true)
+		cli := testAction.FakeClientBuilder().Build()
+		a := testAction.PrepareAction(cli, NewAction[*rhtasv1.Fulcio](testComponent, nonCompliant))
+		g.Expect(a.CanHandle(t.Context(), testInstance(""))).To(BeTrue())
+	})
+
+	t.Run("disabled: non-compliant is a no-op regardless of annotation (CanHandle false)", func(t *testing.T) {
+		g := NewWithT(t)
+		withClusterTLSProfile(t, false)
+		cli := testAction.FakeClientBuilder().Build()
+		a := testAction.PrepareAction(cli, NewAction[*rhtasv1.Fulcio](testComponent, nonCompliant))
+		g.Expect(a.CanHandle(t.Context(), testInstance("strict"))).To(BeFalse())
+		g.Expect(a.CanHandle(t.Context(), testInstance("legacy"))).To(BeFalse())
+		g.Expect(a.CanHandle(t.Context(), testInstance(""))).To(BeFalse())
+	})
+}
+
+func TestHandle_LegacyDeploysWithWarning(t *testing.T) {
+	g := NewWithT(t)
+	withClusterTLSProfile(t, true)
+	withClusterAdherenceStrict(t, false)
+	instance := testInstance("legacy")
+
+	cli := testAction.FakeClientBuilder().WithObjects(instance).WithStatusSubresource(instance).Build()
+	a := testAction.PrepareAction(cli, NewAction[*rhtasv1.Fulcio](testComponent, nonCompliant))
+
+	result := a.Handle(t.Context(), instance)
+
+	// Legacy mode must not block the rollout: no error is returned.
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).ToNot(HaveOccurred())
+
+	warn := meta.FindStatusCondition(instance.Status.Conditions, TLSProfileAdherenceCondition)
+	g.Expect(warn).ToNot(BeNil())
+	g.Expect(warn.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(warn.Reason).To(Equal(ReasonWarning))
+
+	// Ready must not be flipped to Failure in legacy mode.
+	ready := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+	g.Expect(ready.Reason).ToNot(Equal(state.Failure.String()))
+}
+
+func TestHandle_StrictBlocksRollout(t *testing.T) {
+	g := NewWithT(t)
+	withClusterTLSProfile(t, true)
+	withClusterAdherenceStrict(t, false)
+	instance := testInstance("strict")
+
+	cli := testAction.FakeClientBuilder().WithObjects(instance).WithStatusSubresource(instance).Build()
+	a := testAction.PrepareAction(cli, NewAction[*rhtasv1.Fulcio](testComponent, nonCompliant))
+
+	result := a.Handle(t.Context(), instance)
+
+	// Strict mode must block the rollout with a terminal error.
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).To(HaveOccurred())
+
+	blocked := meta.FindStatusCondition(instance.Status.Conditions, TLSProfileAdherenceCondition)
+	g.Expect(blocked).ToNot(BeNil())
+	g.Expect(blocked.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(blocked.Reason).To(Equal(state.Failure.String()))
+
+	// A terminal error also drives the component Ready condition to Failure.
+	ready := meta.FindStatusCondition(instance.Status.Conditions, constants.ReadyCondition)
+	g.Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(ready.Reason).To(Equal(state.Failure.String()))
+}
+
+func TestHandle_ClusterStrictInheritedWithoutAnnotation(t *testing.T) {
+	g := NewWithT(t)
+	withClusterTLSProfile(t, true)
+	withClusterAdherenceStrict(t, true)
+	instance := testInstance("") // no annotation: inherit the cluster mandate
+
+	cli := testAction.FakeClientBuilder().WithObjects(instance).WithStatusSubresource(instance).Build()
+	a := testAction.PrepareAction(cli, NewAction[*rhtasv1.Fulcio](testComponent, nonCompliant))
+
+	result := a.Handle(t.Context(), instance)
+
+	// Inheriting a strict cluster blocks, but it is not a configuration conflict.
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).To(HaveOccurred())
+
+	blocked := meta.FindStatusCondition(instance.Status.Conditions, TLSProfileAdherenceCondition)
+	g.Expect(blocked).ToNot(BeNil())
+	g.Expect(blocked.Reason).To(Equal(state.Failure.String()))
+}
+
+func TestHandle_ClusterStrictWithLegacyAnnotationIsConflict(t *testing.T) {
+	g := NewWithT(t)
+	withClusterTLSProfile(t, true)
+	withClusterAdherenceStrict(t, true)
+	instance := testInstance("legacy") // tries to relax below the cluster floor
+
+	cli := testAction.FakeClientBuilder().WithObjects(instance).WithStatusSubresource(instance).Build()
+	a := testAction.PrepareAction(cli, NewAction[*rhtasv1.Fulcio](testComponent, nonCompliant))
+
+	result := a.Handle(t.Context(), instance)
+
+	// Relaxing below the cluster floor is a terminal configuration error.
+	g.Expect(result).ToNot(BeNil())
+	g.Expect(result.Err).To(HaveOccurred())
+
+	cond := meta.FindStatusCondition(instance.Status.Conditions, TLSProfileAdherenceCondition)
+	g.Expect(cond).ToNot(BeNil())
+	g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).To(Equal(ReasonInvalidConfiguration))
+}

--- a/internal/action/tlsadherence/adherence.go
+++ b/internal/action/tlsadherence/adherence.go
@@ -1,0 +1,88 @@
+package tlsadherence
+
+import (
+	"github.com/securesign/operator/internal/annotations"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Mode selects how the operator reacts when a managed component cannot honour
+// the cluster TLS security profile.
+type Mode string
+
+const (
+	// ModeLegacy deploys a non-compliant component and surfaces a Warning
+	// condition without blocking the rollout.
+	ModeLegacy Mode = "legacy"
+
+	// ModeStrict blocks the rollout of a non-compliant component and surfaces
+	// an error condition instead.
+	ModeStrict Mode = "strict"
+)
+
+// TLSProfileAdherenceCondition is the status condition type used to report a
+// component's adherence to the cluster TLS security profile.
+const TLSProfileAdherenceCondition = "TLSProfileAdherence"
+
+// ReasonWarning is the condition reason used when a non-compliant component is
+// deployed anyway under legacy mode (with cluster TLS profile resolution enforced).
+const ReasonWarning = "Warning"
+
+// ReasonInvalidConfiguration is the condition reason used when the tlsAdherence
+// annotation tries to relax below the cluster-wide TLS adherence policy, which is
+// a floor that a per-resource annotation may match or tighten but never relax.
+const ReasonInvalidConfiguration = "InvalidConfiguration"
+
+// annotationIntent captures the three meaningful states of the tlsAdherence
+// annotation. Absent is distinct from an explicit "legacy": on a strict cluster
+// an absent annotation inherits the cluster mandate, whereas an explicit "legacy"
+// tries to relax below it and is a configuration conflict.
+type annotationIntent int
+
+const (
+	annotationAbsent annotationIntent = iota
+	annotationLegacy
+	annotationStrict
+)
+
+// intentFromAnnotations classifies the tlsAdherence annotation. An unrecognised
+// value is treated as absent so a typo defaults to the cluster's own policy
+// rather than being read as an explicit relax request.
+func intentFromAnnotations(a map[string]string) annotationIntent {
+	switch a[annotations.TLSAdherence] {
+	case string(ModeStrict):
+		return annotationStrict
+	case string(ModeLegacy):
+		return annotationLegacy
+	default:
+		return annotationAbsent
+	}
+}
+
+// resolveMode combines the cluster-wide TLS adherence policy (a floor) with the
+// per-resource tlsAdherence annotation to produce the effective enforcement mode.
+//
+// The cluster policy is a floor: the annotation may match or tighten it, never
+// relax it. On a strict cluster an explicit "legacy" annotation is a
+// configuration conflict (conflict is true, effective mode is strict); an absent
+// or "strict" annotation inherits/affirms strict. On a non-strict cluster the
+// operator is in full control: "strict" tightens, everything else is legacy.
+func resolveMode(clusterStrict bool, intent annotationIntent) (effective Mode, conflict bool) {
+	if clusterStrict {
+		return ModeStrict, intent == annotationLegacy
+	}
+	if intent == annotationStrict {
+		return ModeStrict, false
+	}
+	return ModeLegacy, false
+}
+
+// CanHonourClusterTLSProfile reports whether the component's upstream binary can
+// honour the cluster TLS security profile.
+//
+// TODO(STORY-994): replace this stub with a real per-component TLS-capability
+// signal. Until the upstream binaries expose whether they honour the cluster
+// profile, every component is assumed compliant, so the tlsAdherence annotation
+// is a no-op in production and only exercised in unit tests.
+func CanHonourClusterTLSProfile[T client.Object](_ T) bool {
+	return true
+}

--- a/internal/action/tlsadherence/doc.go
+++ b/internal/action/tlsadherence/doc.go
@@ -1,0 +1,57 @@
+// Package tlsadherence provides a generic action that gates a component's
+// rollout on its ability to honour the cluster TLS security profile.
+//
+// # Effective mode
+//
+// The outcome is driven by the effective enforcement mode, which combines two
+// inputs:
+//
+//   - the cluster-wide TLS adherence policy (OpenShift APIServer
+//     spec.tlsAdherence), snapshotted at startup into
+//     [github.com/securesign/operator/internal/config.ClusterTLSAdherenceStrict];
+//   - the per-resource rhtas.redhat.com/tlsAdherence annotation
+//     (see [github.com/securesign/operator/internal/annotations.TLSAdherence]).
+//
+// The cluster policy is a floor: the annotation may match or tighten it, never
+// relax it. Given cluster policy P and annotation A:
+//
+//	P strict     + A absent  -> strict   (inherit the cluster mandate)
+//	P strict     + A strict   -> strict
+//	P strict     + A legacy   -> configuration error (relaxing below the floor)
+//	P not-strict + A absent   -> legacy   (operator default)
+//	P not-strict + A legacy   -> legacy
+//	P not-strict + A strict   -> strict   (operator opts in tighter)
+//
+// StrictAllComponents (or any unrecognised value of a present field) is strict;
+// NoOpinion and LegacyAdheringComponentsOnly are not. On most clusters the field
+// is absent or the TLSAdherence feature gate is off, which resolves to NoOpinion
+// (not strict), so the annotation is the operative control there.
+//
+// # Outcomes (for a component that cannot honour the profile)
+//
+//   - strict: blocked with a terminal error condition; not rolled out.
+//   - legacy: deployed anyway with a Warning condition; rollout is not blocked.
+//   - configuration error: the annotation relaxes below the cluster floor;
+//     blocked with a terminal error condition (reason InvalidConfiguration).
+//
+// A component that can honour the profile is a no-op regardless of mode.
+//
+// # Disabled resolution
+//
+// The action only takes effect when the operator resolves and enforces the
+// cluster TLS security profile (OpenShift with resolution enabled; see
+// [github.com/securesign/operator/internal/config.ClusterTLSProfileEnforced]). On
+// vanilla Kubernetes, or when DisableClusterTLSProfile is set, the action is a
+// no-op: no condition is set and the rollout is never blocked.
+//
+// # Capability check
+//
+// Whether a component can honour the profile is decided by the per-component
+// TLS-capability check passed to [NewAction]. Until the upstream binaries
+// expose that signal, [CanHonourClusterTLSProfile] is a stub that always
+// reports compliant (see STORY-994), so the action is a no-op in production
+// and only exercised in unit tests.
+//
+// This is an interim control; once all upstream binaries honour the cluster
+// profile it will be deprecated and removed.
+package tlsadherence

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -125,6 +125,52 @@
 //	  name: example
 //	  annotations:
 //	    rhtas.redhat.com/log-type: "dev"
+//
+// # Annotation: rhtas.redhat.com/tlsAdherence
+//
+// [TLSAdherence] controls whether the operator blocks or only warns when a
+// managed component cannot yet honour the cluster TLS security profile.
+//
+// This is an interim control. Once all upstream binaries honour the cluster
+// profile it will be deprecated and removed (see STORY-994).
+//
+// Supported values:
+//   - "legacy": deploy a non-compliant component and surface a Warning condition;
+//     do not block the rollout. This is the operator default when the cluster
+//     policy is not strict and the annotation is absent or empty.
+//   - "strict": block deployment of any component that cannot honour the cluster
+//     TLS profile, surfacing an error condition instead of rolling out.
+//
+// A component that can honour the profile is a no-op in either mode.
+//
+// This annotation only takes effect on clusters where the operator resolves and
+// enforces the cluster TLS security profile (OpenShift with resolution enabled).
+// On vanilla Kubernetes, or when cluster TLS profile resolution is disabled, the
+// annotation has no effect for any value: neither strict nor legacy sets a
+// condition or blocks, and the operator deploys exactly as it does today.
+//
+// Relationship to the cluster policy: the cluster-wide TLS adherence policy
+// (OpenShift APIServer spec.tlsAdherence) is a floor. This annotation may match
+// or tighten it but never relax it. When the cluster mandates StrictAllComponents,
+// setting this annotation to "legacy" is a configuration error and blocks the
+// rollout; an absent annotation inherits the cluster mandate (strict). When the
+// cluster policy is not strict (the common case, including clusters without the
+// TLSAdherence feature gate), this annotation is the operative control.
+//
+// Precedence: if set on the Securesign resource, this annotation is automatically
+// propagated to child resources and overwrites any value set directly on them.
+// Per-component overrides via this annotation are only effective on standalone
+// child CRs that are not managed by a Securesign parent.
+// ([github.com/securesign/operator/api/rhtasv1.Securesign])
+//
+// Example usage:
+//
+//	apiVersion: rhtas.redhat.com/v1alpha1
+//	kind: Securesign
+//	metadata:
+//	  name: example
+//	  annotations:
+//	    rhtas.redhat.com/tlsAdherence: "strict"
 package annotations
 
 const (
@@ -147,9 +193,14 @@ const (
 	// trust material change and accept the newly observed value.
 	RefreshTrustMaterial = "rhtas.redhat.com/refresh-trust-material"
 
+	// TLSAdherence defines the annotation key controlling whether the operator blocks
+	// ("strict") or only warns ("legacy", the default) when a component cannot yet
+	// honour the cluster TLS security profile.
+	TLSAdherence = "rhtas.redhat.com/tlsAdherence"
+
 	TLS = "service.beta.openshift.io/serving-cert-secret-name"
 )
 
 var InheritableAnnotations = []string{
-	TrustedCA, LogType, Godebug,
+	TrustedCA, LogType, Godebug, TLSAdherence,
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,4 +9,21 @@ var (
 	APIServerTimeout         time.Duration
 	IngressHostTemplate      = "%[1]s.local"
 	DisableClusterTLSProfile bool
+
+	// ClusterTLSAdherenceStrict reports whether the cluster-wide TLS adherence
+	// policy mandates that all components honour the cluster TLS security profile
+	// (OpenShift APIServer spec.tlsAdherence = StrictAllComponents, or any unknown
+	// value, which is treated as strict per openshift/api). It is resolved once at
+	// startup and acts as a floor: a per-resource tlsAdherence annotation may match
+	// or tighten it but never relax it.
+	ClusterTLSAdherenceStrict bool
 )
+
+// ClusterTLSProfileEnforced reports whether the operator resolves and enforces
+// the cluster-wide TLS security profile. It is only true on OpenShift and when
+// resolution has not been disabled via DisableClusterTLSProfile. On vanilla
+// Kubernetes or when disabled, callers must treat the cluster TLS profile as
+// unavailable and behave exactly as they did before it existed.
+func ClusterTLSProfileEnforced() bool {
+	return Openshift && !DisableClusterTLSProfile
+}

--- a/internal/controller/console/console_controller.go
+++ b/internal/controller/console/console_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/tlsadherence"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/constants"
@@ -82,6 +83,7 @@ func (r *consoleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		consoleapi.NewTlsAction(),
 
 		transitions.NewToCreatePhaseAction[*rhtasv1.Console](),
+		tlsadherence.NewAction[*rhtasv1.Console]("console", tlsadherence.CanHonourClusterTLSProfile[*rhtasv1.Console]),
 		consoleapi.NewRBACAction(),
 		ui.NewRBACAction(),
 

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -21,6 +21,7 @@ import (
 
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/tlsadherence"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/action/trustmaterial"
 	"github.com/securesign/operator/internal/annotations"
@@ -113,6 +114,7 @@ func (r *ctlogReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		actions.NewTlsAction(),
 
 		transitions.NewToCreatePhaseAction[*rhtasv1.CTlog](),
+		tlsadherence.NewAction[*rhtasv1.CTlog]("ctlog", tlsadherence.CanHonourClusterTLSProfile[*rhtasv1.CTlog]),
 
 		actions.NewHandleFulcioCertAction(),
 		actions.NewFIPSValidationAction(),

--- a/internal/controller/fulcio/fulcio_controller.go
+++ b/internal/controller/fulcio/fulcio_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/tlsadherence"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/action/trustmaterial"
 	"github.com/securesign/operator/internal/annotations"
@@ -110,6 +111,7 @@ func (r *fulcioReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		actions.NewFIPSValidationAction(),
 		actions.NewGenerateSignerAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1.Fulcio](),
+		tlsadherence.NewAction[*rhtasv1.Fulcio]("fulcio", tlsadherence.CanHonourClusterTLSProfile[*rhtasv1.Fulcio]),
 		actions.NewRBACAction(),
 		actions.NewServerConfigAction(),
 		actions.NewDeployAction(),

--- a/internal/controller/rekor/rekor_controller.go
+++ b/internal/controller/rekor/rekor_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/tlsadherence"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/action/trustmaterial"
 	"github.com/securesign/operator/internal/annotations"
@@ -126,6 +127,7 @@ func (r *rekorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		server.NewGenerateSignerAction(),
 
 		transitions.NewToCreatePhaseAction[*rhtasv1.Rekor](),
+		tlsadherence.NewAction[*rhtasv1.Rekor]("rekor", tlsadherence.CanHonourClusterTLSProfile[*rhtasv1.Rekor]),
 
 		server.NewRBACAction(),
 		redis.NewRBACAction(),

--- a/internal/controller/securesign/actions/ensure_tls_adherence_test.go
+++ b/internal/controller/securesign/actions/ensure_tls_adherence_test.go
@@ -1,0 +1,72 @@
+package actions
+
+import (
+	"context"
+	"testing"
+
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/annotations"
+	testAction "github.com/securesign/operator/internal/testing/action"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// parentWithTLSAdherence returns a Securesign carrying the tlsAdherence
+// annotation together with the minimal spec required for every ensure action to
+// create its child (TimestampAuthority must be non-nil to be reconciled).
+func parentWithTLSAdherence(value string) *rhtasv1.Securesign {
+	return &rhtasv1.Securesign{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.TLSAdherence: value,
+			},
+		},
+		Spec: rhtasv1.SecuresignSpec{
+			TimestampAuthority: &rhtasv1.TimestampAuthoritySpec{},
+		},
+	}
+}
+
+func childAnnotations(t *testing.T, newAction func() action.Action[*rhtasv1.Securesign], child client.Object) map[string]string {
+	t.Helper()
+	parent := parentWithTLSAdherence("strict")
+	c := testAction.FakeClientBuilder().WithObjects(parent).WithStatusSubresource(parent).Build()
+	a := testAction.PrepareAction(c, newAction())
+
+	a.Handle(context.Background(), parent)
+
+	if err := c.Get(context.Background(), types.NamespacedName{Name: "test", Namespace: "default"}, child); err != nil {
+		t.Fatalf("expected child resource to be created: %v", err)
+	}
+	return child.GetAnnotations()
+}
+
+// TestTLSAdherencePropagation asserts the tlsAdherence annotation is propagated
+// from the Securesign umbrella to each of the components it manages.
+func TestTLSAdherencePropagation(t *testing.T) {
+	tests := []struct {
+		name      string
+		newAction func() action.Action[*rhtasv1.Securesign]
+		child     client.Object
+	}{
+		{"fulcio", NewFulcioAction, &rhtasv1.Fulcio{}},
+		{"rekor", NewRekorAction, &rhtasv1.Rekor{}},
+		{"ctlog", NewCtlogAction, &rhtasv1.CTlog{}},
+		{"trillian", NewTrillianAction, &rhtasv1.Trillian{}},
+		{"tuf", NewTufAction, &rhtasv1.Tuf{}},
+		{"tsa", NewTsaAction, &rhtasv1.TimestampAuthority{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := childAnnotations(t, tt.newAction, tt.child)
+			if got[annotations.TLSAdherence] != "strict" {
+				t.Fatalf("expected %s=strict on %s child, got %q",
+					annotations.TLSAdherence, tt.name, got[annotations.TLSAdherence])
+			}
+		})
+	}
+}

--- a/internal/controller/trillian/trillian_controller.go
+++ b/internal/controller/trillian/trillian_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/tlsadherence"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
@@ -115,6 +116,7 @@ func (r *trillianReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		actions.NewFIPSValidationAction(),
 
 		transitions.NewToCreatePhaseAction[*rhtasv1.Trillian](),
+		tlsadherence.NewAction[*rhtasv1.Trillian]("trillian", tlsadherence.CanHonourClusterTLSProfile[*rhtasv1.Trillian]),
 		logserver.NewRBACAction(),
 		logsigner.NewRBACAction(),
 		db.NewRBACAction(),

--- a/internal/controller/tsa/timestampauthority_controller.go
+++ b/internal/controller/tsa/timestampauthority_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/tlsadherence"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/action/trustmaterial"
 	"github.com/securesign/operator/internal/annotations"
@@ -106,6 +107,7 @@ func (r *timestampAuthorityReconciler) Reconcile(ctx context.Context, req ctrl.R
 		actions.NewGenerateSignerAction(),
 		actions.NewResolveKMSTinkSignerAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1.TimestampAuthority](),
+		tlsadherence.NewAction[*rhtasv1.TimestampAuthority]("timestamp-authority", tlsadherence.CanHonourClusterTLSProfile[*rhtasv1.TimestampAuthority]),
 		actions.NewRBACAction(),
 		actions.NewNtpMonitoringAction(),
 		actions.NewDeployAction(),

--- a/internal/controller/tuf/tuf_controller.go
+++ b/internal/controller/tuf/tuf_controller.go
@@ -22,6 +22,7 @@ import (
 	olpredicate "github.com/operator-framework/operator-lib/predicate"
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/action/tlsadherence"
 	"github.com/securesign/operator/internal/action/transitions"
 	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/controller"
@@ -113,6 +114,7 @@ func (r *tufReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		actions.NewResolveKeysAction(),
 		actions.NewFIPSValidationAction(),
 		transitions.NewToCreatePhaseAction[*rhtasv1.Tuf](),
+		tlsadherence.NewAction[*rhtasv1.Tuf]("tuf", tlsadherence.CanHonourClusterTLSProfile[*rhtasv1.Tuf]),
 		actions.NewRBACInitJobAction(),
 		actions.NewRBACAction(),
 		actions.NewCreatePvcAction(),


### PR DESCRIPTION
## Summary

Adds a per-component gate that decides what happens when a managed component cannot honour the cluster TLS security profile. The effective mode is derived from the cluster-wide TLS adherence policy combined with an optional `rhtas.redhat.com/tlsAdherence` annotation.

The cluster policy is treated as a **floor** — the annotation may match or tighten it, never relax it:

- **strict** → block the rollout with a terminal error condition
- **legacy** → deploy with a `Warning` condition
- **legacy annotation on a strict cluster** → configuration error

On vanilla Kubernetes, or when profile resolution is disabled, the gate is a no-op. The per-component capability check is currently stubbed (`TODO STORY-994`) until upstream binaries expose the signal.

## Changes

- New inheritable `rhtas.redhat.com/tlsAdherence` annotation (propagates Securesign → all components).
- Snapshot the OpenShift `APIServer` TLS adherence policy at startup; gate runs only when the cluster profile is actually resolved.
- New `internal/action/tlsadherence` gate, wired into all seven component controllers.
- Tests for intent/mode resolution, policy mapping, annotation propagation, and every legacy/strict/conflict/disabled outcome.

No CRD schema change. This is an interim control, to be deprecated once all upstream binaries honour the cluster profile.
