### PR TITLE
test(e2e): KMS signer coverage for Rekor, Fulcio, TSA via OpenBao

### DIFF
--- a/test/e2e/install/kms_test.go
+++ b/test/e2e/install/kms_test.go
@@ -1,0 +1,292 @@
+//go:build integration
+
+package install
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rhtasv1 "github.com/securesign/operator/api/v1"
+	fulcioactions "github.com/securesign/operator/internal/controller/fulcio/actions"
+	rekoractions "github.com/securesign/operator/internal/controller/rekor/actions"
+	tsaactions "github.com/securesign/operator/internal/controller/tsa/actions"
+	"github.com/securesign/operator/test/e2e/support"
+	"github.com/securesign/operator/test/e2e/support/postgresql"
+	"github.com/securesign/operator/test/e2e/support/steps"
+	"github.com/securesign/operator/test/e2e/support/tas"
+	"github.com/securesign/operator/test/e2e/support/tas/openbao"
+	"github.com/securesign/operator/test/e2e/support/tas/securesign"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// parseECDSAPublicKeyPEM decodes a PEM-encoded PKIX public key and asserts it's ECDSA.
+func parseECDSAPublicKeyPEM(pemBytes []byte) (*ecdsa.PublicKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	Expect(block).NotTo(BeNil(), "failed to PEM-decode public key: %s", pemBytes)
+
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	ecdsaPub, ok := pub.(*ecdsa.PublicKey)
+	Expect(ok).To(BeTrue(), "expected ECDSA public key, got %T", pub)
+	return ecdsaPub, nil
+}
+
+// parseECDSACertPublicKeyPEM decodes a PEM-encoded certificate and returns its ECDSA public key.
+func parseECDSACertPublicKeyPEM(pemBytes []byte) (*ecdsa.PublicKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	Expect(block).NotTo(BeNil(), "failed to PEM-decode certificate: %s", pemBytes)
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	ecdsaPub, ok := cert.PublicKey.(*ecdsa.PublicKey)
+	Expect(ok).To(BeTrue(), "expected ECDSA public key, got %T", cert.PublicKey)
+	return ecdsaPub, nil
+}
+
+// findContainer returns the container with the given name from a Deployment, failing the spec if absent.
+func findContainer(dep *appsv1.Deployment, name string) *v1.Container {
+	for i := range dep.Spec.Template.Spec.Containers {
+		if dep.Spec.Template.Spec.Containers[i].Name == name {
+			return &dep.Spec.Template.Spec.Containers[i]
+		}
+	}
+	return nil
+}
+
+var _ = Describe("Securesign install with KMS (OpenBao) signer", Ordered, func() {
+	cli, _ := support.CreateClient()
+
+	var targetImageName string
+	var namespace *v1.Namespace
+	var s *rhtasv1.Securesign
+	var fipsEnabled bool
+
+	BeforeAll(steps.DetectAndConfigureFIPS(cli, func(enabled bool) {
+		fipsEnabled = enabled
+	}))
+
+	BeforeAll(steps.CreateNamespace(cli, func(new *v1.Namespace) {
+		namespace = new
+	}))
+
+	BeforeAll(func(ctx SpecContext) {
+		if fipsEnabled {
+			Expect(postgresql.CreateDB(ctx, cli, namespace.Name, postgresql.DefaultSecretName, "fips-password")).To(Succeed())
+			postgresql.WaitAndLoadSchema(ctx, cli, namespace.Name)
+		}
+	})
+
+	BeforeAll(func(ctx SpecContext) {
+		// Deploy an OpenBao dev server and configure the transit keys backing
+		// Rekor/Fulcio/TSA's KMS signers.
+		Expect(openbao.CreatePrerequisites(ctx, cli, namespace.Name)).To(Succeed())
+	})
+
+	BeforeAll(func(ctx SpecContext) {
+		// Fulcio and TSA (unlike Rekor) need a CA certificate chain whose public key
+		// matches their OpenBao transit key; generate and store those before creating
+		// the Securesign CR, since the reconciler requires the Secret to already exist.
+		Expect(openbao.CreateKMSCertificate(ctx, cli, namespace.Name, openbao.FulcioKeyName)).To(Succeed())
+		Expect(openbao.CreateKMSTimestampCertificate(ctx, cli, namespace.Name, openbao.TsaKeyName)).To(Succeed())
+	})
+
+	BeforeAll(func(ctx SpecContext) {
+		s = securesign.Create(namespace.Name, "test",
+			securesign.ChooseDefaults(fipsEnabled, namespace.Name),
+			securesign.WithKMSOpenBaoSigner(namespace.Name),
+			securesign.WithKMSOpenBaoFulcioSigner(namespace.Name),
+			securesign.WithKMSOpenBaoTSASigner(namespace.Name),
+		)
+		Expect(cli.Create(ctx, s)).To(Succeed())
+	})
+
+	BeforeAll(func(ctx SpecContext) {
+		targetImageName = support.PrepareImage(ctx)
+	})
+
+	Describe("KMS (OpenBao) install", func() {
+		It("all components reach Ready", func(ctx SpecContext) {
+			tas.VerifyAllComponents(ctx, cli, s, !fipsEnabled, true)
+		})
+
+		It("Rekor server runs with the OpenBao KMS signer", func(ctx SpecContext) {
+			dep := &appsv1.Deployment{}
+			Expect(cli.Get(ctx, types.NamespacedName{
+				Namespace: namespace.Name,
+				Name:      rekoractions.ServerDeploymentName,
+			}, dep)).To(Succeed())
+
+			container := findContainer(dep, rekoractions.ServerDeploymentName)
+			Expect(container).NotTo(BeNil())
+
+			signerFlagIdx := -1
+			for i, arg := range container.Args {
+				if arg == "--rekor_server.signer" {
+					signerFlagIdx = i
+					break
+				}
+			}
+			Expect(signerFlagIdx).To(BeNumerically(">=", 0), "container args: %v", container.Args)
+			Expect(container.Args[signerFlagIdx+1]).To(Equal("openbao://" + openbao.RekorKeyName))
+
+			Expect(container.Env).To(ContainElements(
+				v1.EnvVar{Name: "VAULT_ADDR", Value: openbao.Addr(namespace.Name)},
+				v1.EnvVar{Name: "VAULT_TOKEN", Value: openbao.RootToken},
+			))
+		})
+
+		It("Fulcio server runs with the OpenBao KMS signer", func(ctx SpecContext) {
+			dep := &appsv1.Deployment{}
+			Expect(cli.Get(ctx, types.NamespacedName{
+				Namespace: namespace.Name,
+				Name:      fulcioactions.DeploymentName,
+			}, dep)).To(Succeed())
+
+			container := findContainer(dep, fulcioactions.DeploymentName)
+			Expect(container).NotTo(BeNil())
+
+			Expect(container.Args).To(ContainElement("--ca=kmsca"))
+
+			kmsResourceIdx := -1
+			certChainPathIdx := -1
+			for i, arg := range container.Args {
+				switch arg {
+				case "--kms-resource":
+					kmsResourceIdx = i
+				case "--kms-cert-chain-path":
+					certChainPathIdx = i
+				}
+			}
+			Expect(kmsResourceIdx).To(BeNumerically(">=", 0), "container args: %v", container.Args)
+			Expect(container.Args[kmsResourceIdx+1]).To(Equal("openbao://" + openbao.FulcioKeyName))
+			Expect(certChainPathIdx).To(BeNumerically(">=", 0), "container args: %v", container.Args)
+			Expect(container.Args[certChainPathIdx+1]).To(Equal("/var/run/fulcio-secrets/cert.pem"))
+
+			Expect(container.Env).To(ContainElements(
+				v1.EnvVar{Name: "VAULT_ADDR", Value: openbao.Addr(namespace.Name)},
+				v1.EnvVar{Name: "VAULT_TOKEN", Value: openbao.RootToken},
+			))
+		})
+
+		It("TSA server runs with the OpenBao KMS signer", func(ctx SpecContext) {
+			dep := &appsv1.Deployment{}
+			Expect(cli.Get(ctx, types.NamespacedName{
+				Namespace: namespace.Name,
+				Name:      tsaactions.DeploymentName,
+			}, dep)).To(Succeed())
+
+			container := findContainer(dep, tsaactions.DeploymentName)
+			Expect(container).NotTo(BeNil())
+
+			Expect(container.Command).To(ContainElements(
+				"--timestamp-signer=kms",
+				"--kms-key-resource=openbao://"+openbao.TsaKeyName,
+			))
+
+			Expect(container.Env).To(ContainElements(
+				v1.EnvVar{Name: "VAULT_ADDR", Value: openbao.Addr(namespace.Name)},
+				v1.EnvVar{Name: "VAULT_TOKEN", Value: openbao.RootToken},
+			))
+		})
+
+		It("Rekor's active signing key matches the OpenBao transit key", func(ctx SpecContext) {
+			s = securesign.Get(ctx, cli, namespace.Name, s.Name)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.Status.RekorStatus.Url+"/api/v1/log/publicKey", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			rekorPEM, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			vaultPEM, err := openbao.TransitPublicKeyPEM(ctx, namespace.Name, openbao.RekorKeyName)
+			Expect(err).NotTo(HaveOccurred())
+
+			rekorKey, err := parseECDSAPublicKeyPEM(rekorPEM)
+			Expect(err).NotTo(HaveOccurred())
+			vaultKey, err := parseECDSAPublicKeyPEM([]byte(vaultPEM))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rekorKey.Equal(vaultKey)).To(BeTrue(),
+				"Rekor's active signing key does not match OpenBao transit key %q", openbao.RekorKeyName)
+		})
+
+		It("Fulcio's root certificate matches the OpenBao transit key", func(ctx SpecContext) {
+			s = securesign.Get(ctx, cli, namespace.Name, s.Name)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.Status.FulcioStatus.Url+"/api/v1/rootCert", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			fulcioPEM, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			vaultPEM, err := openbao.TransitPublicKeyPEM(ctx, namespace.Name, openbao.FulcioKeyName)
+			Expect(err).NotTo(HaveOccurred())
+
+			fulcioKey, err := parseECDSACertPublicKeyPEM(fulcioPEM)
+			Expect(err).NotTo(HaveOccurred())
+			vaultKey, err := parseECDSAPublicKeyPEM([]byte(vaultPEM))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fulcioKey.Equal(vaultKey)).To(BeTrue(),
+				"Fulcio's root certificate does not match OpenBao transit key %q", openbao.FulcioKeyName)
+		})
+
+		It("TSA's leaf certificate matches the OpenBao transit key", func(ctx SpecContext) {
+			s = securesign.Get(ctx, cli, namespace.Name, s.Name)
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.Status.TSAStatus.Url+"/certchain", nil)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			tsaChainPEM, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			vaultPEM, err := openbao.TransitPublicKeyPEM(ctx, namespace.Name, openbao.TsaKeyName)
+			Expect(err).NotTo(HaveOccurred())
+
+			// The chain is leaf-first (see CreateKMSTimestampCertificate), and
+			// parseECDSACertPublicKeyPEM only decodes the first PEM block, so this
+			// reads the leaf's public key, not the throwaway local root's.
+			tsaLeafKey, err := parseECDSACertPublicKeyPEM(tsaChainPEM)
+			Expect(err).NotTo(HaveOccurred())
+			vaultKey, err := parseECDSAPublicKeyPEM([]byte(vaultPEM))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(tsaLeafKey.Equal(vaultKey)).To(BeTrue(),
+				"TSA's leaf certificate does not match OpenBao transit key %q", openbao.TsaKeyName)
+		})
+
+		It("SecureSign CR reaches Ready state", func(ctx SpecContext) {
+			securesign.Verify(ctx, cli, namespace.Name, s.Name)
+		})
+
+		It("cosign sign and verify", func(ctx SpecContext) {
+			s = securesign.Get(ctx, cli, namespace.Name, s.Name)
+			tas.VerifyByCosign(ctx, targetImageName,
+				s.Status.TufStatus.Url,
+				s.Status.FulcioStatus.Url,
+				s.Status.RekorStatus.Url,
+				s.Status.TSAStatus.Url,
+			)
+		})
+	})
+})

--- a/test/e2e/support/tas/openbao/certificate.go
+++ b/test/e2e/support/tas/openbao/certificate.go
@@ -1,0 +1,174 @@
+package openbao
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// oidExtKeyUsageTimeStamping is the id-kp-timeStamping OID (1.3.6.1.5.5.7.3.8).
+// RFC 3161 requires a timestamping signer's certificate to carry this as a
+// critical extended key usage extension.
+var oidExtKeyUsageTimeStamping = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8}
+
+// CertChainSecretName returns the name of the Secret CreateKMSCertificate /
+// CreateKMSTimestampCertificate store the resulting cert chain under, for a
+// given transit key name.
+func CertChainSecretName(keyName string) string {
+	return keyName + "-cert-chain"
+}
+
+func newSerialNumber() (*big.Int, error) {
+	return rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+}
+
+func storeCertChainSecret(ctx context.Context, cli client.Client, namespace, keyName string, chainPEM []byte) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      CertChainSecretName(keyName),
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"cert": chainPEM,
+		},
+	}
+	if err := cli.Create(ctx, secret); err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating secret %s: %w", secret.Name, err)
+	}
+	return nil
+}
+
+// CreateKMSCertificate builds a self-signed CA certificate whose public key is the
+// given OpenBao transit key (signed by OpenBao itself via Signer), and stores it as
+// a Secret named CertChainSecretName(keyName) under the "cert" data key, ready to be
+// referenced by a component's signer.certificateChain.certificateChainRef.
+//
+// Fulcio's kmsca accepts a chain of a single certificate (fulcio/pkg/ca/common.go
+// only requires "at least one certificate"), so this single self-signed shape is
+// sufficient for Fulcio. It is NOT sufficient for TSA — see CreateKMSTimestampCertificate.
+func CreateKMSCertificate(ctx context.Context, cli client.Client, namespace, keyName string) error {
+	signer, err := NewSigner(ctx, namespace, keyName)
+	if err != nil {
+		return fmt.Errorf("creating signer for transit key %s: %w", keyName, err)
+	}
+
+	serialNumber, err := newSerialNumber()
+	if err != nil {
+		return fmt.Errorf("generating serial number: %w", err)
+	}
+
+	notBefore := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{CommonName: keyName, Organization: []string{"RHTAS"}},
+		SignatureAlgorithm:    x509.ECDSAWithSHA256,
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(10 * 365 * 24 * time.Hour),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, signer.Public(), signer)
+	if err != nil {
+		return fmt.Errorf("creating certificate for transit key %s: %w", keyName, err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	return storeCertChainSecret(ctx, cli, namespace, keyName, certPEM)
+}
+
+// CreateKMSTimestampCertificate builds a two-certificate chain (root + leaf) for a
+// timestamping signer: a throwaway local root CA (not backed by any KMS key) issues
+// a leaf certificate whose public key is the given OpenBao transit key. TSA signs
+// timestamp responses directly with the transit key at runtime, so only the leaf's
+// public key needs to match it — the root's private key is used purely to make this
+// a real chain and is discarded once the certs are created.
+//
+// A bare self-signed cert (as CreateKMSCertificate produces for Fulcio) is NOT
+// sufficient here: timestamp-authority panics at startup with "certificate chain
+// must contain at least two certificates" if given only one. The leaf also carries
+// a critical id-kp-timeStamping EKU, which RFC 3161 requires for a TSA responder cert.
+func CreateKMSTimestampCertificate(ctx context.Context, cli client.Client, namespace, keyName string) error {
+	pemStr, err := TransitPublicKeyPEM(ctx, namespace, keyName)
+	if err != nil {
+		return fmt.Errorf("fetching public key for transit key %s: %w", keyName, err)
+	}
+	leafPub, err := parseECDSAPublicKey([]byte(pemStr))
+	if err != nil {
+		return fmt.Errorf("parsing public key for transit key %s: %w", keyName, err)
+	}
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generating throwaway root key: %w", err)
+	}
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(10 * 365 * 24 * time.Hour)
+
+	rootSerial, err := newSerialNumber()
+	if err != nil {
+		return fmt.Errorf("generating root serial number: %w", err)
+	}
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          rootSerial,
+		Subject:               pkix.Name{CommonName: keyName + "-root", Organization: []string{"RHTAS"}},
+		SignatureAlgorithm:    x509.ECDSAWithSHA256,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		return fmt.Errorf("creating root certificate: %w", err)
+	}
+	rootPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootDER})
+
+	leafSerial, err := newSerialNumber()
+	if err != nil {
+		return fmt.Errorf("generating leaf serial number: %w", err)
+	}
+	ekuValue, err := asn1.Marshal([]asn1.ObjectIdentifier{oidExtKeyUsageTimeStamping})
+	if err != nil {
+		return fmt.Errorf("encoding timestamping EKU: %w", err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber:       leafSerial,
+		Subject:            pkix.Name{CommonName: keyName, Organization: []string{"RHTAS"}},
+		SignatureAlgorithm: x509.ECDSAWithSHA256,
+		NotBefore:          notBefore,
+		NotAfter:           notAfter,
+		KeyUsage:           x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:        []x509.ExtKeyUsage{x509.ExtKeyUsageTimeStamping},
+		ExtraExtensions: []pkix.Extension{{
+			Id:       asn1.ObjectIdentifier{2, 5, 29, 37}, // id-ce-extKeyUsage
+			Critical: true,
+			Value:    ekuValue,
+		}},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, rootTemplate, leafPub, rootKey)
+	if err != nil {
+		return fmt.Errorf("creating leaf certificate: %w", err)
+	}
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER})
+
+	chainPEM := append(append([]byte{}, leafPEM...), rootPEM...)
+
+	return storeCertChainSecret(ctx, cli, namespace, keyName, chainPEM)
+}

--- a/test/e2e/support/tas/openbao/prerequisites.go
+++ b/test/e2e/support/tas/openbao/prerequisites.go
@@ -1,0 +1,237 @@
+package openbao
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/securesign/operator/internal/utils/kubernetes"
+	k8sSupport "github.com/securesign/operator/test/e2e/support/kubernetes"
+)
+
+const (
+	// Image is the OpenBao dev-mode server image.
+	Image = "quay.io/openbao/openbao:2.1.0"
+
+	// PodName/ServiceName of the in-cluster OpenBao dev server.
+	PodName     = "openbao"
+	ServiceName = "openbao"
+	appLabel    = "openbao"
+	port        = 8200
+
+	containerName = "openbao"
+
+	// RootToken is the dev-mode root token (VAULT_TOKEN).
+	RootToken = "root"
+
+	// RekorKeyName is the transit key backing the Rekor KMS signer.
+	RekorKeyName = "rekor-kms"
+	// FulcioKeyName is the transit key backing the Fulcio KMS signer.
+	FulcioKeyName = "fulcio-kms"
+	// TsaKeyName is the transit key backing the TSA KMS signer.
+	TsaKeyName = "tsa-kms"
+)
+
+// transitKeyNames lists every transit key CreatePrerequisites provisions.
+var transitKeyNames = []string{RekorKeyName, FulcioKeyName, TsaKeyName}
+
+// Addr returns the in-cluster VAULT_ADDR pointing at the OpenBao service.
+func Addr(namespace string) string {
+	return fmt.Sprintf("http://%s.%s.svc:%d", ServiceName, namespace, port)
+}
+
+// CreatePrerequisites deploys an OpenBao dev-mode server in the given namespace,
+// waits for it to become ready, and enables the transit secrets engine with the
+// rekor-kms, fulcio-kms and tsa-kms signing keys used by WithKMSOpenBaoSigner.
+func CreatePrerequisites(ctx context.Context, cli client.Client, namespace string) error {
+	resources := []client.Object{
+		service(namespace),
+		pod(namespace),
+	}
+	for _, r := range resources {
+		if err := cli.Create(ctx, r); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				return fmt.Errorf("creating %T %s: %w", r, r.GetName(), err)
+			}
+		}
+	}
+
+	if err := waitForPodReady(ctx, cli, namespace, PodName); err != nil {
+		return fmt.Errorf("waiting for openbao pod: %w", err)
+	}
+
+	var keyWrites strings.Builder
+	for _, keyName := range transitKeyNames {
+		fmt.Fprintf(&keyWrites, "bao write transit/keys/%s type=ecdsa-p256\n", keyName)
+	}
+
+	script := fmt.Sprintf(`
+export VAULT_ADDR=http://127.0.0.1:%d
+export VAULT_TOKEN=%s
+bao secrets enable transit
+%s`, port, RootToken, keyWrites.String())
+
+	if err := k8sSupport.ExecInPod(ctx, PodName, containerName, namespace, "/bin/sh", "-c", script); err != nil {
+		return fmt.Errorf("configuring openbao transit engine: %w", err)
+	}
+
+	return nil
+}
+
+func service(namespace string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ServiceName,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": appLabel},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       port,
+					TargetPort: intstr.FromInt32(port),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+}
+
+func podSecurityContext() *corev1.PodSecurityContext {
+	sc := &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+	if !kubernetes.IsOpenShift() {
+		sc.RunAsUser = ptr.To(int64(100))
+		sc.RunAsGroup = ptr.To(int64(1000))
+		sc.FSGroup = ptr.To(int64(1000))
+	}
+	return sc
+}
+
+func pod(namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PodName,
+			Namespace: namespace,
+			Labels:    map[string]string{"app": appLabel},
+		},
+		Spec: corev1.PodSpec{
+			SecurityContext: podSecurityContext(),
+			Containers: []corev1.Container{
+				{
+					Name:            containerName,
+					Image:           Image,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"bao"},
+					Args: []string{
+						"server", "-dev",
+						"-dev-root-token-id=" + RootToken,
+						fmt.Sprintf("-dev-listen-address=0.0.0.0:%d", port),
+					},
+					Env: []corev1.EnvVar{
+						// Dev mode writes a convenience CLI token file to $HOME/.vault-token.
+						// Without HOME set, it defaults to "/", which the non-root user can't
+						// write to; that failure makes OpenBao revoke the just-generated root
+						// token as a safety measure, breaking VAULT_TOKEN=root auth.
+						{Name: "HOME", Value: "/tmp"},
+					},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: port},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path: "/v1/sys/health",
+								Port: intstr.FromInt32(port),
+							},
+						},
+						InitialDelaySeconds: 2,
+						PeriodSeconds:       3,
+					},
+				},
+			},
+		},
+	}
+}
+
+// transitKeyResponse models the subset of `bao read -format=json transit/keys/<name>`
+// needed to extract the active version's public key.
+type transitKeyResponse struct {
+	Data struct {
+		LatestVersion int `json:"latest_version"`
+		Keys          map[string]struct {
+			PublicKey string `json:"public_key"`
+		} `json:"keys"`
+	} `json:"data"`
+}
+
+// TransitPublicKeyPEM reads the PEM-encoded public key of the given transit key's
+// active version directly from OpenBao, for cross-checking against the public key
+// a KMS-backed signer (e.g. Rekor) reports using the same key resource.
+func TransitPublicKeyPEM(ctx context.Context, namespace, keyName string) (string, error) {
+	out, err := k8sSupport.ExecInPodWithOutput(ctx, PodName, containerName, namespace, "/bin/sh", "-c",
+		fmt.Sprintf(`export VAULT_ADDR=http://127.0.0.1:%d VAULT_TOKEN=%s; bao read -format=json transit/keys/%s`, port, RootToken, keyName))
+	if err != nil {
+		return "", fmt.Errorf("reading transit key %s: %w", keyName, err)
+	}
+
+	var resp transitKeyResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return "", fmt.Errorf("parsing transit key %s response: %w", keyName, err)
+	}
+
+	key, ok := resp.Data.Keys[fmt.Sprintf("%d", resp.Data.LatestVersion)]
+	if !ok {
+		return "", fmt.Errorf("transit key %s: no data for latest version %d", keyName, resp.Data.LatestVersion)
+	}
+	return key.PublicKey, nil
+}
+
+// waitForPodReady polls the Pod until its Ready condition is true.
+func waitForPodReady(ctx context.Context, cli client.Client, namespace, name string) error {
+	deadline := time.After(5 * time.Minute)
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			return fmt.Errorf("timeout waiting for pod %s to become ready", name)
+		case <-ticker.C:
+			p := &corev1.Pod{}
+			if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, p); err != nil {
+				if errors.IsNotFound(err) {
+					continue
+				}
+				return fmt.Errorf("getting pod %s: %w", name, err)
+			}
+			for _, cond := range p.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					return nil
+				}
+			}
+		}
+	}
+}

--- a/test/e2e/support/tas/openbao/signer.go
+++ b/test/e2e/support/tas/openbao/signer.go
@@ -1,0 +1,94 @@
+package openbao
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"strings"
+
+	k8sSupport "github.com/securesign/operator/test/e2e/support/kubernetes"
+)
+
+// Signer implements crypto.Signer backed by an OpenBao transit key. It is driven
+// entirely through ExecInPod + the "bao" CLI already installed in the OpenBao pod —
+// no Vault/OpenBao SDK dependency and no port-forwarding from the test process.
+type Signer struct {
+	ctx       context.Context
+	namespace string
+	keyName   string
+	pub       *ecdsa.PublicKey
+}
+
+// NewSigner returns a crypto.Signer for the given transit key. It fetches and caches
+// the key's public key immediately, so construction fails fast if the key is missing.
+func NewSigner(ctx context.Context, namespace, keyName string) (*Signer, error) {
+	pemStr, err := TransitPublicKeyPEM(ctx, namespace, keyName)
+	if err != nil {
+		return nil, fmt.Errorf("fetching public key for transit key %s: %w", keyName, err)
+	}
+	pub, err := parseECDSAPublicKey([]byte(pemStr))
+	if err != nil {
+		return nil, fmt.Errorf("parsing public key for transit key %s: %w", keyName, err)
+	}
+	return &Signer{ctx: ctx, namespace: namespace, keyName: keyName, pub: pub}, nil
+}
+
+func (s *Signer) Public() crypto.PublicKey {
+	return s.pub
+}
+
+// Sign signs an already-hashed digest via OpenBao's transit/sign endpoint, using
+// "prehashed" input so OpenBao signs the digest x509.CreateCertificate computed
+// rather than re-hashing it. The returned bytes are the raw ASN.1 DER ECDSA
+// signature, exactly what x509.CreateCertificate expects back from a Signer.
+func (s *Signer) Sign(_ io.Reader, digest []byte, _ crypto.SignerOpts) ([]byte, error) {
+	input := base64.StdEncoding.EncodeToString(digest)
+
+	script := fmt.Sprintf(
+		`export VAULT_ADDR=http://127.0.0.1:%d VAULT_TOKEN=%s; bao write -format=json transit/sign/%s input=%s prehashed=true hash_algorithm=sha2-256`,
+		port, RootToken, s.keyName, input)
+
+	out, err := k8sSupport.ExecInPodWithOutput(s.ctx, PodName, containerName, s.namespace, "/bin/sh", "-c", script)
+	if err != nil {
+		return nil, fmt.Errorf("signing with transit key %s: %w", s.keyName, err)
+	}
+
+	var resp struct {
+		Data struct {
+			Signature string `json:"signature"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(out, &resp); err != nil {
+		return nil, fmt.Errorf("parsing sign response for transit key %s: %w (raw: %s)", s.keyName, err, out)
+	}
+
+	// Signature format: "vault:v<version>:<base64 ASN.1 DER signature>".
+	parts := strings.SplitN(resp.Data.Signature, ":", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("unexpected signature format from transit key %s: %q", s.keyName, resp.Data.Signature)
+	}
+	return base64.StdEncoding.DecodeString(parts[2])
+}
+
+// parseECDSAPublicKey decodes a PEM-encoded PKIX public key and asserts it's ECDSA.
+func parseECDSAPublicKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("failed to PEM-decode public key: %s", pemBytes)
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	ecdsaPub, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("expected ECDSA public key, got %T", pub)
+	}
+	return ecdsaPub, nil
+}

--- a/test/e2e/support/tas/securesign/securesign.go
+++ b/test/e2e/support/tas/securesign/securesign.go
@@ -9,6 +9,7 @@ import (
 	"github.com/securesign/operator/test/e2e/support"
 	"github.com/securesign/operator/test/e2e/support/condition"
 	"github.com/securesign/operator/test/e2e/support/postgresql"
+	"github.com/securesign/operator/test/e2e/support/tas/openbao"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -491,6 +492,89 @@ func WithPKCS11Signer(namespace string) Opts {
 
 		// --- NTP Monitoring ---
 		WithNTPMonitoring()(s)
+	}
+}
+
+// openBaoAuthEnv returns the VAULT_ADDR/VAULT_TOKEN env vars shared by every
+// component authenticating against the in-cluster OpenBao dev server.
+func openBaoAuthEnv(namespace string) *rhtasv1.Auth {
+	return &rhtasv1.Auth{
+		Env: []core.EnvVar{
+			{
+				Name:  "VAULT_ADDR",
+				Value: openbao.Addr(namespace),
+			},
+			{
+				Name:  "VAULT_TOKEN",
+				Value: openbao.RootToken,
+			},
+		},
+	}
+}
+
+// WithKMSOpenBaoSigner configures Rekor to sign with an OpenBao-backed KMS key
+// (transit key "rekor-kms"), authenticating via VAULT_ADDR/VAULT_TOKEN env vars.
+func WithKMSOpenBaoSigner(namespace string) Opts {
+	return func(s *rhtasv1.Securesign) {
+		s.Spec.Rekor.Signer = rhtasv1.RekorSigner{
+			Type: rhtasv1.SignerTypeKMS,
+			Kms: &rhtasv1.KMS{
+				KeyResource: "openbao://" + openbao.RekorKeyName,
+			},
+		}
+		s.Spec.Rekor.Auth = openBaoAuthEnv(namespace)
+	}
+}
+
+// WithKMSOpenBaoFulcioSigner configures Fulcio to sign certificates with an
+// OpenBao-backed KMS key (transit key "fulcio-kms"). The CA certificate chain
+// referenced here must already exist (see openbao.CreateKMSCertificate) and its
+// public key must match the fulcio-kms transit key.
+func WithKMSOpenBaoFulcioSigner(namespace string) Opts {
+	return func(s *rhtasv1.Securesign) {
+		s.Spec.Fulcio.Signer = rhtasv1.FulcioSigner{
+			Type: rhtasv1.SignerTypeKMS,
+			Kms: &rhtasv1.KMS{
+				KeyResource: "openbao://" + openbao.FulcioKeyName,
+			},
+			CertificateChain: rhtasv1.FulcioCertificateChain{
+				CertificateChainRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{
+						Name: openbao.CertChainSecretName(openbao.FulcioKeyName),
+					},
+					Key: "cert",
+				},
+			},
+		}
+		s.Spec.Fulcio.Auth = openBaoAuthEnv(namespace)
+	}
+}
+
+// WithKMSOpenBaoTSASigner configures TSA to sign timestamp responses with an
+// OpenBao-backed KMS key (transit key "tsa-kms"). TSA's signer type is inferred
+// from which pointer is set (there is no explicit Type field), and CEL requires
+// certificateChain.certificateChainRef whenever kms/file/tink is configured. The
+// cert chain secret must already exist (see openbao.CreateKMSCertificate) with a
+// leaf cert usable for RFC 3161 timestamping and a public key matching tsa-kms.
+func WithKMSOpenBaoTSASigner(namespace string) Opts {
+	return func(s *rhtasv1.Securesign) {
+		if s.Spec.TimestampAuthority == nil {
+			WithTSA()(s)
+		}
+		s.Spec.TimestampAuthority.Signer = rhtasv1.TimestampAuthoritySigner{
+			CertificateChain: rhtasv1.CertificateChain{
+				CertificateChainRef: &rhtasv1.SecretKeySelector{
+					LocalObjectReference: rhtasv1.LocalObjectReference{
+						Name: openbao.CertChainSecretName(openbao.TsaKeyName),
+					},
+					Key: "cert",
+				},
+			},
+			Kms: &rhtasv1.KMS{
+				KeyResource: "openbao://" + openbao.TsaKeyName,
+			},
+		}
+		s.Spec.TimestampAuthority.Auth = openBaoAuthEnv(namespace)
 	}
 }
 


### PR DESCRIPTION
## What changed
Adds e2e integration coverage for the KMS signer path on Rekor, Fulcio, and TSA, using OpenBao as the KMS backend (natively supported by sigstore via the `openbao://` scheme, no plugin/InitContainer needed):

- `test/e2e/support/tas/openbao/` (new): deploys an in-cluster OpenBao dev server + transit engine with `rekor-kms`/`fulcio-kms`/`tsa-kms` keys; a `crypto.Signer` implementation driven entirely through `ExecInPod` + the `bao` CLI (no Vault/OpenBao SDK, no port-forwarding); certificate-chain builders for Fulcio (single self-signed cert) and TSA (root→leaf chain with a `id-kp-timeStamping` EKU on the leaf).
- `test/e2e/support/tas/securesign/securesign.go`: `WithKMSOpenBaoSigner`/`WithKMSOpenBaoFulcioSigner`/`WithKMSOpenBaoTSASigner` CR options.
- `test/e2e/install/kms_test.go` (new): full install flow — components reach Ready, deployment args/auth env asserted per component, live public key of Rekor and Fulcio cross-checked against their OpenBao transit key (not string/PEM comparison — actual `ecdsa.PublicKey.Equal()`), and a final `cosign sign+verify` exercising the whole KMS-backed chain.

## Why
KMS signer support already existed in the operator (Rekor/Fulcio/TSA), but had zero e2e coverage — regressions in the KMS wiring, CEL validation, or deployment-arg construction wouldn't be caught.

## Before → after
- **Before**: `openbao://`/`hashivault://` KMS signer paths were unexercised by any e2e test. Bugs like a missing `Rekor.Signer.Type: kms` (defaults to `secret`, silently ignoring KMS config) or TSA's `certificateChain.certificateChainRef` CEL requirement would only surface manually or in production.
- **After**: `go test ./test/e2e/install/... -tags=integration -timeout 30m -ginkgo.focus="KMS"` exercises all three components end-to-end against a real OpenBao instance, with cryptographic proof (not just "reached Ready") that each component is actually signing/issuing with the configured transit key.

## Scope notes
- Test-only changes — no `api/` or `internal/controller/` code touched.
- Fulcio and TSA cert-chain shapes differ (found empirically): Fulcio's `kmsca` accepts a single self-signed cert; `timestamp-authority` panics on startup (`certificate chain must contain at least two certificates`) unless given a real root→leaf chain, so TSA gets a throwaway local root signing a leaf whose public key is the transit key.

## Test plan
- [x] `go build -tags integration ./test/...`
- [x] `go vet -tags integration ./test/e2e/...`
- [x] `go test ./test/e2e/install/... -tags=integration -timeout 30m -ginkgo.focus="KMS"` — passing locally against a live cluster