### PR TITLE
fix(e2e): actually verify RFC3161 timestamps in cosign sign/verify helper

### DIFF
--- a/test/e2e/support/tas/cosign/cosign_local.go
+++ b/test/e2e/support/tas/cosign/cosign_local.go
@@ -58,6 +58,7 @@ func (c *LocalCosign) Sign(ctx context.Context, targetImageName string) error {
 func (c *LocalCosign) Verify(ctx context.Context, targetImageName string) error {
 	ensureCosignConfig()
 	verifyArgs := []string{"verify",
+		"--use-signed-timestamps=true",
 		"--certificate-identity-regexp", ".*@redhat",
 		"--certificate-oidc-issuer-regexp", ".*keycloak.*",
 		targetImageName}


### PR DESCRIPTION
## What changed
`test/e2e/support/tas/cosign/cosign_local.go`'s `Verify()` now passes `--use-signed-timestamps=true` to `cosign verify`.

## Why
`cosign verify` defaults `--use-signed-timestamps` to `false`. Every e2e install test that goes through the shared `VerifyByCosign` helper (pkcs11, default install, provided-certs, etc.) calls `cosign sign` with a TSA in the loop, but `Verify()` never checked the resulting RFC3161 timestamp's signature — only that `cosign sign` had embedded one. A TSA that signs with a corrupted or wrong key would still pass every existing e2e test.

The flag is safe to always pass: cosign's own `VerifyRFC3161Timestamp` returns `(nil, nil)` — not an error — when no timestamp is present in the bundle at all, so tests without TSA are unaffected. It only produces a real failure when a timestamp exists but doesn't cryptographically validate.

## Before → after
- **Before**: `cosign sign and verify` passing proved a timestamp was present in the signature bundle, nothing about whether it was valid.
- **After**: the same step now cryptographically verifies the RFC3161 timestamp against the TSA's certificate chain, and fails loudly (`unable to verify RFC3161 timestamp bundle: ...`) if it doesn't check out.

## Test plan
- [x] `go build -tags integration ./test/...`
- [x] `go vet -tags integration ./test/e2e/...`
- [ ] full e2e run against a live cluster