### PR TITLE
fix: recover from failed createtree Job instead of failing terminally

### DIFF
--- a/internal/action/tree/action.go
+++ b/internal/action/tree/action.go
@@ -12,6 +12,7 @@ import (
 
 	rhtasv1 "github.com/securesign/operator/api/v1"
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/annotations"
 	"github.com/securesign/operator/internal/images"
 	"github.com/securesign/operator/internal/labels"
 	"github.com/securesign/operator/internal/serviceresolver"
@@ -33,6 +34,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// createTreeRetryBaseDelay is the base retry delay; attempt N waits base*N.
+const createTreeRetryBaseDelay = 20 * time.Second
+
+// createTreeMaxAttempts bounds failed-Job retries before the failure is terminal.
+const createTreeMaxAttempts = 3
 
 func NewResolveTreeAction[T tlsAwareObject](component string, wrapper func(T) *wrapper[T]) action.Action[T] {
 	return &resolveTree[T]{
@@ -215,6 +222,17 @@ func (i resolveTree[T]) handleJob(ctx context.Context, instance T) *action.Resul
 		}
 	}
 
+	// Wait out the retry backoff before recreating a failed Job. A generation
+	// change (spec edit) resets attempts and skips the gate.
+	if readAttempts(configMap, instance.GetGeneration()) > 0 {
+		if nextRetry, ok := readNextRetry(configMap); ok {
+			if remaining := time.Until(nextRetry); remaining > 0 {
+				i.Logger.V(1).Info("waiting before recreating failed createtree job", "remaining", remaining.String())
+				return i.RequeueAfter(remaining)
+			}
+		}
+	}
+
 	trillianService := wrapped.GetTrillianService()
 
 	trillHost, trillPort, err := serviceresolver.ResolveInternalGrpcService(ctx, i.Client, *trillianService, instance.GetNamespace(), &rhtasv1.Trillian{})
@@ -332,16 +350,160 @@ func (i resolveTree[T]) handleJobFinished(ctx context.Context, instance T) *acti
 	}
 
 	if job.IsFailed(*j) {
+		// Tree was already created and written: adopt it instead of orphaning it.
+		if result, ok := configMap.Data[configMapResultField]; ok && result != "" {
+			i.Logger.V(1).Info("createtree job failed but result is present; adopting existing tree")
+			return i.Continue()
+		}
+
+		attempts := readAttempts(configMap, instance.GetGeneration()) + 1
+
+		if attempts >= createTreeMaxAttempts {
+			// Keep the failed Job for debugging and go terminal so alerting fires.
+			if err = i.recordAttempts(ctx, configMap, instance.GetGeneration(), attempts); err != nil {
+				return i.Error(ctx, fmt.Errorf("could not record createtree attempts: %w", err), instance)
+			}
+			i.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "CreateTreeJobFailed", "GaveUp",
+				"createtree job %s failed %d times; giving up. Fix the underlying cause and edit the resource to retry", j.GetName(), attempts)
+			return i.Error(ctx, reconcile.TerminalError(ErrJobFailed), instance, metav1.Condition{
+				Type:    JobCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  state.Failure.String(),
+				Message: ErrJobFailed.Error(),
+			})
+		}
+
+		// Delete the failed Job, drop its owner reference so handleJob recreates
+		// it, and requeue with linear backoff.
+		backoff := createTreeRetryBaseDelay * time.Duration(attempts)
+		nextRetry := time.Now().Add(backoff)
+		if err = i.cleanupFailedJob(ctx, j, configMap, instance.GetGeneration(), attempts, nextRetry); err != nil {
+			return i.Error(ctx, fmt.Errorf("could not clean up failed createtree job: %w", err), instance)
+		}
+
+		i.Recorder.Eventf(instance, nil, corev1.EventTypeWarning, "CreateTreeJobFailed", "Retrying",
+			"createtree job %s failed; retrying tree initialization (attempt %d/%d)", j.GetName(), attempts, createTreeMaxAttempts)
+
 		instance.SetCondition(metav1.Condition{
 			Type:    JobCondition,
 			Status:  metav1.ConditionFalse,
-			Reason:  state.Failure.String(),
-			Message: ErrJobFailed.Error(),
+			Reason:  state.Creating.String(),
+			Message: fmt.Sprintf("createtree job failed; retrying tree initialization (attempt %d/%d)", attempts, createTreeMaxAttempts),
 		})
-		return i.Error(ctx, reconcile.TerminalError(ErrJobFailed), instance)
+		if _, err = i.PersistStatus(ctx, instance); err != nil {
+			return i.Error(ctx, err, instance)
+		}
+		return i.RequeueAfter(backoff)
 	}
 
 	return i.Continue()
+}
+
+// readAttempts returns the failed-attempt count recorded for the given generation.
+func readAttempts(configMap *corev1.ConfigMap, generation int64) int {
+	anns := configMap.GetAnnotations()
+	if anns == nil {
+		return 0
+	}
+	if anns[annotations.CreateTreeAttemptsGeneration] != strconv.FormatInt(generation, 10) {
+		return 0
+	}
+	attempts, err := strconv.Atoi(anns[annotations.CreateTreeAttempts])
+	if err != nil {
+		return 0
+	}
+	return attempts
+}
+
+// readNextRetry returns the scheduled next-retry time recorded on the ConfigMap.
+func readNextRetry(configMap *corev1.ConfigMap) (time.Time, bool) {
+	anns := configMap.GetAnnotations()
+	if anns == nil {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, anns[annotations.CreateTreeNextRetry])
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// recordAttempts persists the attempt count and generation on the ConfigMap.
+func (i resolveTree[T]) recordAttempts(ctx context.Context, configMap *corev1.ConfigMap, generation int64, attempts int) error {
+	if _, err := kubernetes.CreateOrUpdate(ctx, i.Client, configMap,
+		setAttemptsAnnotations(generation, attempts),
+	); err != nil {
+		return fmt.Errorf("could not update %s ConfigMap: %w", configMap.GetName(), err)
+	}
+	return nil
+}
+
+// setAttemptsAnnotations records the attempt count and generation annotations.
+func setAttemptsAnnotations(generation int64, attempts int) func(*corev1.ConfigMap) error {
+	return func(object *corev1.ConfigMap) error {
+		anns := object.GetAnnotations()
+		if anns == nil {
+			anns = map[string]string{}
+		}
+		anns[annotations.CreateTreeAttempts] = strconv.Itoa(attempts)
+		anns[annotations.CreateTreeAttemptsGeneration] = strconv.FormatInt(generation, 10)
+		object.SetAnnotations(anns)
+		return nil
+	}
+}
+
+// setNextRetryAnnotation records the earliest time the Job may be recreated.
+func setNextRetryAnnotation(nextRetry time.Time) func(*corev1.ConfigMap) error {
+	return func(object *corev1.ConfigMap) error {
+		anns := object.GetAnnotations()
+		if anns == nil {
+			anns = map[string]string{}
+		}
+		anns[annotations.CreateTreeNextRetry] = nextRetry.UTC().Format(time.RFC3339)
+		object.SetAnnotations(anns)
+		return nil
+	}
+}
+
+// clearRetryAnnotations removes the retry bookkeeping annotations.
+func clearRetryAnnotations(object *corev1.ConfigMap) error {
+	anns := object.GetAnnotations()
+	if anns == nil {
+		return nil
+	}
+	delete(anns, annotations.CreateTreeAttempts)
+	delete(anns, annotations.CreateTreeAttemptsGeneration)
+	delete(anns, annotations.CreateTreeNextRetry)
+	object.SetAnnotations(anns)
+	return nil
+}
+
+// cleanupFailedJob drops the Job owner reference (so handleJob recreates the
+// Job), records the attempt count and next-retry time, and deletes the Job.
+func (i resolveTree[T]) cleanupFailedJob(ctx context.Context, j *batchv1.Job, configMap *corev1.ConfigMap, generation int64, attempts int, nextRetry time.Time) error {
+	if _, err := kubernetes.CreateOrUpdate(ctx, i.Client, configMap,
+		func(object *corev1.ConfigMap) error {
+			refs := object.GetOwnerReferences()
+			filtered := make([]metav1.OwnerReference, 0, len(refs))
+			for _, ref := range refs {
+				if ref.Kind != "Job" { //nolint:goconst
+					filtered = append(filtered, ref)
+				}
+			}
+			object.SetOwnerReferences(filtered)
+			return nil
+		},
+		setAttemptsAnnotations(generation, attempts),
+		setNextRetryAnnotation(nextRetry),
+	); err != nil {
+		return fmt.Errorf("could not remove Job owner reference from %s ConfigMap: %w", configMap.GetName(), err)
+	}
+
+	propagation := metav1.DeletePropagationBackground
+	if err := i.Client.Delete(ctx, j, &client.DeleteOptions{PropagationPolicy: &propagation}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("could not delete failed Job %s: %w", j.GetName(), err)
+	}
+	return nil
 }
 
 func (i resolveTree[T]) handleExtractJobResult(ctx context.Context, instance T) *action.Result {
@@ -360,6 +522,11 @@ func (i resolveTree[T]) handleExtractJobResult(ctx context.Context, instance T) 
 		treeID, err := strconv.ParseInt(result, 10, 64)
 		if err != nil {
 			return i.Error(ctx, reconcile.TerminalError(err), instance)
+		}
+
+		// Tree resolved: clear any retry bookkeeping left by earlier failures.
+		if _, err := kubernetes.CreateOrUpdate(ctx, i.Client, configMap, clearRetryAnnotations); err != nil {
+			return i.Error(ctx, fmt.Errorf("could not clear retry annotations on %s ConfigMap: %w", configMap.GetName(), err), instance)
 		}
 
 		wrapped.SetStatusTreeID(&treeID)

--- a/internal/action/tree/action_test.go
+++ b/internal/action/tree/action_test.go
@@ -12,10 +12,13 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	"github.com/securesign/operator/internal/action"
+	"github.com/securesign/operator/internal/annotations"
+	"github.com/securesign/operator/internal/state"
 	testAction "github.com/securesign/operator/internal/testing/action"
 	v1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -316,6 +319,84 @@ func testCreateJob(t *testing.T) {
 	}
 }
 
+// TestResolveTree_BackoffGate: a future next-retry requeues without recreating the Job.
+func TestResolveTree_BackoffGate(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	instance := &rhtasv1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{Name: nnObject.Name, Namespace: nnObject.Namespace},
+		Spec:       rhtasv1.RekorSpec{Trillian: rhtasv1.ServiceReference{}},
+	}
+	generation := strconv.FormatInt(instance.GetGeneration(), 10)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nnResult.Name,
+			Namespace: nnResult.Namespace,
+			Annotations: map[string]string{
+				annotations.CreateTreeAttempts:           "1",
+				annotations.CreateTreeAttemptsGeneration: generation,
+				annotations.CreateTreeNextRetry:          time.Now().Add(time.Hour).UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance, cm).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewResolveTreeAction("test", defaultWrapper))
+	ra := a.(*resolveTree[*rhtasv1.Rekor])
+
+	got := ra.handleJob(ctx, instance)
+	g.Expect(got).ToNot(BeNil())
+	g.Expect(got.Result.RequeueAfter).To(BeNumerically(">", 0))
+
+	jobs := &v1.JobList{}
+	g.Expect(c.List(ctx, jobs, client.InNamespace(nnObject.Namespace))).To(Succeed())
+	g.Expect(jobs.Items).To(BeEmpty())
+}
+
+// TestResolveTree_BackoffGateElapsed: a past next-retry recreates the Job.
+func TestResolveTree_BackoffGateElapsed(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	instance := &rhtasv1.Rekor{
+		ObjectMeta: metav1.ObjectMeta{Name: nnObject.Name, Namespace: nnObject.Namespace},
+		Spec:       rhtasv1.RekorSpec{Trillian: rhtasv1.ServiceReference{}},
+	}
+	generation := strconv.FormatInt(instance.GetGeneration(), 10)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nnResult.Name,
+			Namespace: nnResult.Namespace,
+			Annotations: map[string]string{
+				annotations.CreateTreeAttempts:           "1",
+				annotations.CreateTreeAttemptsGeneration: generation,
+				annotations.CreateTreeNextRetry:          time.Now().Add(-time.Minute).UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	c := testAction.FakeClientBuilder().
+		WithObjects(instance, cm).
+		WithStatusSubresource(instance).
+		Build()
+
+	a := testAction.PrepareAction(c, NewResolveTreeAction("test", defaultWrapper))
+	ra := a.(*resolveTree[*rhtasv1.Rekor])
+
+	g.Expect(ra.handleJob(ctx, instance)).To(Equal(testAction.Return()))
+
+	jobs := &v1.JobList{}
+	g.Expect(c.List(ctx, jobs, client.InNamespace(nnObject.Namespace))).To(Succeed())
+	g.Expect(jobs.Items).To(HaveLen(1))
+}
+
 func testMonitorJob(t *testing.T) {
 	for _, tc := range []struct {
 		desc string
@@ -428,7 +509,129 @@ func testMonitorJob(t *testing.T) {
 				},
 			},
 			want: want{
+				// first failure -> attempt 1, linear backoff base*1
+				result: testAction.RequeueAfter(createTreeRetryBaseDelay),
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch) {
+					// failed Job is deleted so it can be recreated
+					job := &v1.Job{}
+					g.Expect(apierrors.IsNotFound(
+						c.Get(ctx, types.NamespacedName{Name: "job", Namespace: nnResult.Namespace}, job),
+					)).To(BeTrue())
+
+					// Job owner reference is removed from the result ConfigMap so
+					// handleJob recreates the Job on the next reconcile
+					cm := &corev1.ConfigMap{}
+					g.Expect(c.Get(ctx, nnResult, cm)).To(Succeed())
+					for _, ref := range cm.GetOwnerReferences() {
+						g.Expect(ref.Kind).ToNot(Equal("Job"))
+					}
+
+					// attempt count is recorded on the ConfigMap
+					g.Expect(cm.GetAnnotations()).To(HaveKeyWithValue(annotations.CreateTreeAttempts, "1"))
+
+					// the resource is not frozen into a terminal Failure state
+					r := rhtasv1.Rekor{}
+					g.Expect(c.Get(ctx, nnObject, &r)).To(Succeed())
+					cond := meta.FindStatusCondition(r.GetConditions(), JobCondition)
+					g.Expect(cond).ToNot(BeNil())
+					g.Expect(cond.Reason).ToNot(Equal(state.Failure.String()))
+				},
+			},
+		},
+		{
+			desc: "job failed at max attempts is terminal and keeps the failed job",
+			pre: pre{
+				before: func(ctx context.Context, g Gomega, c client.WithWatch) {
+					r := rhtasv1.Rekor{}
+					g.Expect(c.Get(ctx, nnObject, &r)).To(Succeed())
+
+					cm := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nnResult.Name,
+							Namespace: nnResult.Namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								{Kind: "Job", Name: "job"},
+							},
+							Annotations: map[string]string{
+								// one below the cap, recorded for the current generation
+								annotations.CreateTreeAttempts:           strconv.Itoa(createTreeMaxAttempts - 1),
+								annotations.CreateTreeAttemptsGeneration: strconv.FormatInt(r.GetGeneration(), 10),
+							},
+						},
+					}
+					g.Expect(c.Create(ctx, cm)).To(Succeed())
+
+					job := v1.Job{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "job",
+							Namespace: nnResult.Namespace,
+						},
+						Status: v1.JobStatus{
+							Conditions: []v1.JobCondition{
+								{Status: corev1.ConditionTrue, Type: v1.JobComplete},
+								{Status: corev1.ConditionTrue, Type: v1.JobFailed},
+							},
+						},
+					}
+					g.Expect(c.Create(ctx, &job)).To(Succeed())
+				},
+			},
+			want: want{
 				result: testAction.Error(reconcile.TerminalError(ErrJobFailed)),
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch) {
+					// the failed Job is kept for debugging
+					job := &v1.Job{}
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: "job", Namespace: nnResult.Namespace}, job)).To(Succeed())
+
+					// Tree condition is terminal Failure
+					r := rhtasv1.Rekor{}
+					g.Expect(c.Get(ctx, nnObject, &r)).To(Succeed())
+					cond := meta.FindStatusCondition(r.GetConditions(), JobCondition)
+					g.Expect(cond).ToNot(BeNil())
+					g.Expect(cond.Reason).To(Equal(state.Failure.String()))
+				},
+			},
+		},
+		{
+			desc: "job failed but result present adopts existing tree",
+			pre: pre{
+				before: func(ctx context.Context, g Gomega, c client.WithWatch) {
+					cm := &corev1.ConfigMap{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      nnResult.Name,
+							Namespace: nnResult.Namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								{Kind: "Job", Name: "job"},
+							},
+						},
+						Data: map[string]string{
+							"tree_id": "123456789",
+						},
+					}
+					g.Expect(c.Create(ctx, cm)).To(Succeed())
+
+					job := v1.Job{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "job",
+							Namespace: nnResult.Namespace,
+						},
+						Status: v1.JobStatus{
+							Conditions: []v1.JobCondition{
+								{Status: corev1.ConditionTrue, Type: v1.JobComplete},
+								{Status: corev1.ConditionTrue, Type: v1.JobFailed},
+							},
+						},
+					}
+					g.Expect(c.Create(ctx, &job)).To(Succeed())
+				},
+			},
+			want: want{
+				result: testAction.Continue(),
+				verify: func(ctx context.Context, g Gomega, c client.WithWatch) {
+					// the Job is left intact for handleExtractJobResult to consume
+					job := &v1.Job{}
+					g.Expect(c.Get(ctx, types.NamespacedName{Name: "job", Namespace: nnResult.Namespace}, job)).To(Succeed())
+				},
 			},
 		},
 		{

--- a/internal/annotations/annotations.go
+++ b/internal/annotations/annotations.go
@@ -184,6 +184,15 @@ const (
 	// for drift detection across reconcile cycles.
 	PKCS11SpecHash = "rhtas.redhat.com/pkcs11-spec-hash"
 
+	// CreateTreeAttempts counts consecutive failed createtree Jobs, to bound retries.
+	CreateTreeAttempts = "rhtas.redhat.com/createtree-attempts"
+
+	// CreateTreeAttemptsGeneration is the CR generation CreateTreeAttempts applies to.
+	CreateTreeAttemptsGeneration = "rhtas.redhat.com/createtree-attempts-generation"
+
+	// CreateTreeNextRetry is the earliest RFC3339 time the failed Job may be recreated.
+	CreateTreeNextRetry = "rhtas.redhat.com/createtree-next-retry"
+
 	// TLSAdherence defines the annotation key controlling whether the operator blocks
 	// ("strict") or only warns ("legacy", the default) when a component cannot yet
 	// honour the cluster TLS security profile.

--- a/internal/controller/ctlog/ctlog_controller.go
+++ b/internal/controller/ctlog/ctlog_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	v1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -177,6 +178,7 @@ func (r *ctlogReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&v1.Deployment{}).
 		Owns(&v12.Service{}).
 		Owns(&networkingv1.Ingress{}).
+		Owns(&batchv1.Job{}).
 		// receive update on Fulcio root cert change (pulled from status.certificateChain)
 		Watches(&rhtasv1.Fulcio{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 			list := &rhtasv1.CTlogList{}

--- a/internal/controller/rekor/rekor_controller.go
+++ b/internal/controller/rekor/rekor_controller.go
@@ -193,6 +193,7 @@ func (r *rekorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&v13.Service{}).
 		Owns(&v1.Ingress{}).
 		Owns(&batchv1.CronJob{}).
+		Owns(&batchv1.Job{}).
 		Watches(&rhtasv1.Trillian{}, handler.EnqueueRequestsFromMapFunc(
 			ctrlutil.ServiceRefWatch(mgr.GetClient(), &rhtasv1.RekorList{}, func(o client.Object) rhtasv1.ServiceReference {
 				return o.(*rhtasv1.Rekor).Spec.Trillian


### PR DESCRIPTION
Fixes #2274

## Problem

A failed `createtree` Job left Rekor/CTLog permanently `Ready=Failure`. The Job was never deleted or recreated, the result ConfigMap kept the Job owner reference (so `handleJob` short-circuited), and neither controller watched Jobs. Transient failures (Trillian briefly unavailable, image pull errors, scheduling failures) froze into an unrecoverable state that needed manual Job deletion and an operator restart.

## Change

Bound the failure to a retry budget instead of going terminal on the first failure:

- Adopt an already-created tree if the result is present (avoids orphaning a valid tree).
- Otherwise delete the failed Job, drop its ConfigMap owner reference so it is recreated, and requeue with a backoff gated on a next-retry timestamp.
- After `createTreeMaxAttempts` the failure is treated as terminal, so alerting still fires.
- The attempt counter is keyed to the CR generation, so a spec edit resets the budget.
- Both `rekor` and `ctlog` controllers now `Owns(&batchv1.Job{})` so Job status changes trigger reconciles.

## Testing

- `go build ./...`, `go vet`, and `go test ./internal/action/tree/...` pass.
- Unit tests added/updated: bounded retry, terminal-at-cap (keeps failed Job), adopt-existing-tree, and the backoff gate (waiting + elapsed).