### PR TITLE
docs: add KMS signer guides for Rekor and TSA

### DIFF
--- a/docs/fulcio-kms.md
+++ b/docs/fulcio-kms.md
@@ -96,7 +96,22 @@ cosign initialize --mirror "$TUF_URL" --root "$TUF_URL/root.json"
 cosign sign --oidc-client-id trusted-artifact-signer <image>
 ```
 
+Inspect the certificate chain the running service is serving, which the operator resolves into the status for TUF and other components:
+```bash
+oc get fulcio <name> -n <namespace> -o jsonpath='{.status.certificateChain}'
+```
+
+## Rotating the KMS Key
+
+The operator fetches the trust bundle from the running service at `/api/v2/trustBundle` on every reconcile and caches it in `.status.certificateChain`. If the fetched chain ever differs from the cached one — for example after rotating the key in the KMS — the operator does **not** accept it automatically, because certificates issued under the old chain would no longer verify. Complete the [Fulcio certificate rotation procedure](fulcio-key-rotation.md), then acknowledge the new chain:
+
+```bash
+oc annotate fulcio <name> rhtas.redhat.com/refresh-trust-material=true --overwrite -n <namespace>
+```
+
 ## Related
 
+- [Rekor KMS Signer](rekor-kms.md) — KMS signer for the Rekor transparency log
+- [Timestamp Authority KMS Signer](tsa-kms.md) — KMS signer for the Timestamp Authority
 - [Fulcio Certificate Rotation](fulcio-key-rotation.md) — rotating KMS keys and certificate chains
 - [FIPS](fips.md) — KMS key FIPS compliance is the user's responsibility

--- a/docs/rekor-kms.md
+++ b/docs/rekor-kms.md
@@ -1,0 +1,91 @@
+# Configuring Rekor with a KMS Signer Backend
+
+By default, Rekor signs log entries with a key stored in a Kubernetes Secret — the operator generates one automatically if you do not provide it. KMS mode delegates signing to an external key management service, so the private key never resides in the cluster.
+
+Unlike Fulcio and the Timestamp Authority, Rekor signs with a raw key pair rather than a certificate, so **no certificate chain is required**.
+
+## Supported KMS Providers
+
+| Provider | URI Format | Auth Variables |
+|----------|-----------|----------------|
+| AWS KMS | `awskms:///KEY_ID` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
+| GCP KMS | `gcpkms://projects/P/locations/L/keyRings/R/cryptoKeys/K/cryptoKeyVersions/V` | `GOOGLE_APPLICATION_CREDENTIALS` |
+| Azure Key Vault | `azurekms://VAULT_NAME.vault.azure.net/KEY` | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` |
+| HashiCorp Vault | `hashivault://keyname` | `VAULT_ADDR`, `VAULT_TOKEN` |
+| OpenBao | `openbao://keyname` | `VAULT_ADDR` or `BAO_ADDR`, `VAULT_TOKEN` or `BAO_TOKEN` |
+
+For Vault/OpenBao, the Transit secrets engine must be enabled. The KMS library checks `VAULT_ADDR` first, then falls back to `BAO_ADDR` (same for token). For non-default mount paths, set `TRANSIT_SECRET_ENGINE_PATH`.
+
+## Example Securesign CR
+
+```yaml
+apiVersion: rhtas.redhat.com/v1
+kind: Securesign
+metadata:
+  name: securesign-sample
+spec:
+  rekor:
+    signer:
+      type: kms
+      kms:
+        keyResource: "awskms:///1234abcd-12ab-34cd-56ef-1234567890ab"
+    auth:
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws-credentials
+              key: access-key-id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws-credentials
+              key: secret-access-key
+        - name: AWS_REGION
+          value: "us-east-1"
+  # ... other components (fulcio, ctlog, tuf, etc.)
+```
+
+`type` defaults to `secret` — you must explicitly set `type: kms`.
+
+`signer.keyRef` must not be set when `type` is `kms`; the resource is rejected on admission.
+
+For GCP, mount the service account JSON via `spec.rekor.auth.secretMount` and set `GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/tas/auth/<key>`, where `<key>` is the `key` field from the `SecretKeySelector`.
+
+## Public Key Discovery
+
+You do not configure Rekor's public key. The operator fetches it from the running service at `/api/v1/log/publicKey` on every reconcile and caches it in `.status.publicKey`, where TUF and other components pick it up.
+
+If the fetched key ever differs from the cached one — for example after rotating the key in the KMS — the operator does **not** accept it automatically, because artifacts signed with the old key would no longer verify. Complete the [Rekor signer key rotation procedure](rekor-key-rotation.md), which includes freezing the current log tree, then acknowledge the new key:
+
+```bash
+oc annotate rekor <name> rhtas.redhat.com/refresh-trust-material=true --overwrite -n <namespace>
+```
+
+The same applies when switching an existing Rekor instance from `secret` to `kms`.
+
+## Verification
+
+Check that the Rekor resource is `Ready`:
+```bash
+oc get rekor <name> -n <namespace> -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+```
+
+Verify pod args:
+```bash
+oc get deployment rekor-server -n <namespace> -o jsonpath='{.spec.template.spec.containers[0].args}'
+```
+Look for `--rekor_server.signer <KMS_KEY_URI>`.
+
+Confirm the served public key matches your KMS key:
+```bash
+export REKOR_URL=$(oc get rekor <name> -n <namespace> -o jsonpath='{.status.url}')
+curl -s "$REKOR_URL/api/v1/log/publicKey"
+```
+
+## Related
+
+- [Fulcio KMS Signer](fulcio-kms.md) — KMS signer for the Fulcio CA
+- [Timestamp Authority KMS Signer](tsa-kms.md) — KMS signer for the Timestamp Authority
+- [Rekor Signer Key Rotation](rekor-key-rotation.md) — rotating the log signing key
+- [FIPS](fips.md) — the operator does not validate the signer key in KMS mode; KMS key FIPS compliance is the user's responsibility

--- a/docs/tsa-key-rotation.md
+++ b/docs/tsa-key-rotation.md
@@ -134,6 +134,7 @@ If you have deployed the Timestamp Authority Service using a KMS provider follow
 4. Patch the securesign resource with updated references to the rotated keys and certificate chain:
     ```
     signer:
+      type: kms
       certificateChain:
         certificateChainRef:
           name: rotated-cert-chain
@@ -153,6 +154,7 @@ If you have deployed the Timestamp Authority Service using the Tink signer, foll
 5. Patch the securesign resource with updated references to the rotated keys and certificate chain:
     ```
     signer:
+      type: tink
       certificateChain:
         certificateChainRef:
           name: rotated-cert-chain

--- a/docs/tsa-kms.md
+++ b/docs/tsa-kms.md
@@ -1,0 +1,111 @@
+# Configuring the Timestamp Authority with a KMS Signer Backend
+
+By default, the Timestamp Authority (TSA) uses a file-based signer where the private key is stored in a Kubernetes Secret. KMS mode delegates private key operations to an external key management service.
+
+The TSA also supports a Tink signer, which is configured separately and uses a different URI format (`gcp-kms://`, `aws-kms://`, `hcvault://`). This document covers the `kms` signer only.
+
+## Supported KMS Providers
+
+| Provider | URI Format | Auth Variables |
+|----------|-----------|----------------|
+| AWS KMS | `awskms:///KEY_ID` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
+| GCP KMS | `gcpkms://projects/P/locations/L/keyRings/R/cryptoKeys/K/cryptoKeyVersions/V` | `GOOGLE_APPLICATION_CREDENTIALS` |
+| Azure Key Vault | `azurekms://VAULT_NAME.vault.azure.net/KEY` | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` |
+| HashiCorp Vault | `hashivault://keyname` | `VAULT_ADDR`, `VAULT_TOKEN` |
+| OpenBao | `openbao://keyname` | `VAULT_ADDR` or `BAO_ADDR`, `VAULT_TOKEN` or `BAO_TOKEN` |
+
+For Vault/OpenBao, the Transit secrets engine must be enabled. The KMS library checks `VAULT_ADDR` first, then falls back to `BAO_ADDR` (same for token). For non-default mount paths, set `TRANSIT_SECRET_ENGINE_PATH`.
+
+## Preparing the Certificate Chain
+
+KMS holds only the private key. You must create a certificate chain externally and provide it as a Secret.
+
+> **Important:** The leaf certificate's public key **must** match the KMS signing key. For Vault/OpenBao, do **not** mark the transit key `exportable` — issuing the leaf certificate only needs the public key and remote signing via the Transit `sign` endpoint, so the private key never has to leave the vault.
+
+Requirements for the chain:
+
+- Ordered **leaf first, root last**: leaf (timestamping) certificate, then any intermediate CAs, then the root CA.
+- The leaf certificate must carry the `timeStamping` extended key usage marked **critical**, and `digitalSignature` key usage.
+- The leaf's public key is the KMS key's public key; the leaf is signed by your intermediate or root CA.
+
+See the upstream [Timestamp Authority cloud KMS documentation](https://github.com/securesign/timestamp-authority?tab=readme-ov-file#cloud-kms) for details, and the `fetch-tsa-certs` binary from the command line tools for retrieving a chain from a KMS-backed deployment.
+
+Create the secret:
+```bash
+oc create secret generic tsa-kms-cert --from-file=cert=chain.pem -n <namespace>
+```
+
+## Example Securesign CR
+
+```yaml
+apiVersion: rhtas.redhat.com/v1
+kind: Securesign
+metadata:
+  name: securesign-sample
+spec:
+  tsa:
+    signer:
+      type: kms
+      kms:
+        keyResource: "awskms:///1234abcd-12ab-34cd-56ef-1234567890ab"
+      certificateChain:
+        certificateChainRef:
+          name: tsa-kms-cert
+          key: cert
+    auth:
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: aws-credentials
+              key: access-key-id
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: aws-credentials
+              key: secret-access-key
+        - name: AWS_REGION
+          value: "us-east-1"
+    ingress:
+      enabled: true
+  # ... other components (fulcio, rekor, ctlog, tuf, etc.)
+```
+
+`type` defaults to `file` — you must explicitly set `type: kms`.
+
+Both `kms.keyResource` and `certificateChain.certificateChainRef` are required for KMS mode. The `certificateChain.rootCA`, `intermediateCA`, and `leafCA` fields are for operator-generated chains only and must not be set alongside `certificateChainRef`.
+
+For GCP, mount the service account JSON via `spec.tsa.auth.secretMount` and set `GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/tas/auth/<key>`, where `<key>` is the `key` field from the `SecretKeySelector`.
+
+## Verification
+
+Check that the `TSASignerCondition` condition is `True`:
+```bash
+oc get timestampauthority <name> -n <namespace> -o jsonpath='{.status.conditions[?(@.type=="TSASignerCondition")].status}'
+```
+
+Verify the pod command. The TSA passes its flags via `command`, not `args`:
+```bash
+oc get deployment tsa-server -n <namespace> -o jsonpath='{.spec.template.spec.containers[0].command}'
+```
+Look for `--timestamp-signer=kms` and `--kms-key-resource=<KMS_KEY_URI>`.
+
+Inspect the certificate chain the running service is serving, which the operator resolves into the status for TUF and other components:
+```bash
+oc get timestampauthority <name> -n <namespace> -o jsonpath='{.status.certificateChain}'
+```
+
+## Rotating the KMS Key
+
+If the certificate chain served by the running service ever differs from the cached one — for example after rotating the key in the KMS — the operator does **not** accept it automatically, because artifacts timestamped with the old key would no longer verify. Complete the [Timestamp Authority key rotation procedure](tsa-key-rotation.md), then acknowledge the new chain:
+
+```bash
+oc annotate timestampauthority <name> rhtas.redhat.com/refresh-trust-material=true --overwrite -n <namespace>
+```
+
+## Related
+
+- [Fulcio KMS Signer](fulcio-kms.md) — KMS signer for the Fulcio CA
+- [Rekor KMS Signer](rekor-kms.md) — KMS signer for the Rekor transparency log
+- [Timestamp Authority Key Rotation](tsa-key-rotation.md) — rotating the certificate chain and signer keys
+- [FIPS](fips.md) — only the certificate chain is validated in KMS mode; KMS key FIPS compliance is the user's responsibility


### PR DESCRIPTION
## What changed

- **`docs/rekor-kms.md`** (new) — KMS signer guide for Rekor. No certificate chain section: Rekor signs with a raw key pair. Adds a Public Key Discovery section, since the operator fetches the key from `/api/v1/log/publicKey` rather than taking it from the CR.
- **`docs/tsa-kms.md`** (new) — KMS signer guide for the Timestamp Authority. Same shape as the Fulcio guide, with three differences: the chain is leaf-first, the leaf needs a critical `timeStamping` EKU, and verification reads the container's `command` rather than `args`.
- **`docs/fulcio-kms.md`** — added the trust-material refresh section. Fulcio uses the same rotation-detection mechanism as Rekor and TSA, but it was only documented for TSA.
- **`docs/tsa-key-rotation.md`** — added the missing `type` to the KMS and Tink snippets.

## Why

Rekor and TSA have supported KMS signers for a while but only Fulcio had a guide, so the CR shape and verification steps for the other two were undocumented.

The `tsa-key-rotation.md` fix is a correctness bug: the CEL rules `kms field is only allowed when type is kms` and `tink field is only allowed when type is tink` mean those snippets are rejected on admission as written.

## Verification

Commands and flags are taken from the code and from a live cluster, not composed by hand:

| Claim | Source |
|---|---|
| `--rekor_server.signer <URI>` | `rekor/actions/server/deployment.go:160` |
| `--timestamp-signer=kms`, `--kms-key-resource=<URI>` in `command` | `tsa/actions/deployment.go:176` |
| `Ready` is the right condition for Rekor (not `SignerAvailable`) | `generate_signer.go` `isEnabled()` only covers `secret`/`""` |
| `TSASignerCondition` | `tsa/actions/resolve_kms_tink_signer.go` |
| CR shape | e2e helpers `WithKMSOpenBaoSigner`, `WithKMSOpenBaoTSASigner` |
| leaf-first chain, critical timeStamping EKU | `tsa/utils/tsa_cert_chain.go:190`, `openbao.CreateKMSTimestampCertificate` |
| `refresh-trust-material` | `internal/annotations/annotations.go:73` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)